### PR TITLE
Stop using 'text-decoration: none' for anchor tags by default on the …

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -83,7 +83,6 @@ ul, ol {
 }
 
 a {
-  text-decoration: none;
   color: black;
 }
 


### PR DESCRIPTION
…site