### PR TITLE
Fix word breaks in the block previews on pages relying on 'block dash…

### DIFF
--- a/public/css/blocks-dashboard.css
+++ b/public/css/blocks-dashboard.css
@@ -35,6 +35,8 @@ ul {
 .content-preview {
   max-height: 200px;
   overflow: hidden;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .content-preview img, .featured-content-preview img {


### PR DESCRIPTION
…board' template/styling