### PR TITLE
feat(auth): handle 401 as normal state; add no-cache to /me; harden l…

### DIFF
--- a/server/api/v1/users.js
+++ b/server/api/v1/users.js
@@ -8,7 +8,7 @@ import {
   updateUserStreak
 } from '../../db/userService.js';
 import User from '../../db/models/User.js';
-import isAuthenticated from '../../middleware/auth.js'
+import { isAuthenticated } from '../../middleware/auth.js'
 import { uploadProfilePic } from '../../services/uploadProfilePic.js';
 import { makeUserJWT, refreshAuthToken } from '../../utils/jwtHelper.js';
 import { sendEmail } from '../../services/mailgunService.js';

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,6 +1,6 @@
 import { verifyJWT } from '../services/jwt.js'; // Adjust path as needed
 
-function isAuthenticated(req, res, next) {
+export function isAuthenticated(req, res, next) {
   const token = req.cookies.auth_token;
 
   if (!token) {
@@ -17,4 +17,10 @@ function isAuthenticated(req, res, next) {
   }
 }
 
-export default isAuthenticated;
+// Middleware to prevent caching of auth endpoints
+export function noCache(req, res, next) {
+  res.set('Cache-Control', 'no-store');
+  res.set('Vary', 'Cookie');
+  next();
+}
+

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import isAuthenticated from '../middleware/auth.js';
+import { isAuthenticated } from '../middleware/auth.js';
 import { findUserById, findUserByUsername } from "../db/userService.js";
 import { getRecentActivityByUser } from '../db/blockService.js';
 import Block from '../db/models/Block.js';


### PR DESCRIPTION
…ogout; switch auth middleware to named exports

- Frontend now handles 401 without throwing; logs soft warnings only
- Adds noCache middleware (Cache-Control: no-store, Vary: Cookie) to /me
- logout: clear HttpOnly cookie server-side and return 204; client uses credentials: 'include'
- middleware: switch to named exports (isAuthenticated, noCache)
- UI: prevent potential XSS by avoiding innerHTML for username link