### PR TITLE
ux: replace preview fade-out with explicit “More…” link and surface truncation flag

### DIFF
--- a/public/css/blocks-dashboard.css
+++ b/public/css/blocks-dashboard.css
@@ -39,17 +39,6 @@ ul {
   position: relative;
 }
 
-.content-preview::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 50px;
-  background: linear-gradient(transparent, #fff);
-  pointer-events: none;
-}
-
 .content-preview img, .featured-content-preview img {
   max-width: 100%;
   height: auto;
@@ -97,7 +86,7 @@ a.btn {
   background-color: #0056b3;
 }
 
-.user-profile-link {
+.user-profile-link, .more-link {
   color: #007bff;
   text-decoration: none;
   font-weight: bold;

--- a/server/utils/block.js
+++ b/server/utils/block.js
@@ -17,11 +17,11 @@ export function toBlockPreviewDTO(block, {
     ? (block.votes?.find(v => v.userId === userId)?.type || null)
     : null;
 
-  const contentHTML = renderMarkdownPreview(block.content, {
+  const { html, truncated } = renderMarkdownPreview(block.content, {
     maxChars: previewChars,
     includeWholeTables: true,
     allowImages,
-    ellipsis: '…'
+    ellipsis: ''
   });
 
   return {
@@ -31,6 +31,7 @@ export function toBlockPreviewDTO(block, {
     createdAt: block.createdAt,
     userVote,
     ...(includeTranslation && block.translation ? { translation: block.translation } : {}),
-    contentHTML
+    truncated,
+    contentHTML: html
   };
 }

--- a/server/utils/markdownHelper.js
+++ b/server/utils/markdownHelper.js
@@ -42,18 +42,22 @@ function wrapTables(html) {
  */
 function renderCore(content, { mode = 'full', previewOpts = {} } = {}) {
   const cleaned = content ? content.replace(/\u200B/g, '').trim() : '';
-  if (!cleaned) return '<p><em>(No content yet)</em></p>';
 
   if (mode === 'full') {
-    let html = md.render(cleaned);
+    const html = cleaned
+      ? md.render(cleaned)
+      : '<p><em>(No content yet)</em></p>';
     return wrapTables(html);
   }
 
+  // mode === 'preview' → siempre objeto:
+  if (!cleaned) return { html: '<p><em>(No content yet)</em></p>', truncated: false };
+
   // mode === 'preview'
   const tokens = md.parse(cleaned, {});
-  let html = renderPreviewFromTokens(tokens, previewOpts, md);
+  let { html, truncated } = renderPreviewFromTokens(tokens, previewOpts, md);
   html = wrapTables(html);
-  return html;
+  return { html, truncated };
 }
 
 /** ---------- Preview "token-aware" ---------- */
@@ -184,10 +188,10 @@ function renderPreviewFromTokens(tokens, opts, mdInstance) {
   }
 
   let html = mdInstance.renderer.render(slice, mdInstance.options, {});
-  if (truncated) {
+  if (truncated && ellipsis) {
     html += `<p class="preview-ellipsis">${ellipsis}</p>`;
   }
-  return html;
+  return { html, truncated };
 }
 
 /** ---------- API Pública ---------- */

--- a/views/rooms/blocks-dashboard.pug
+++ b/views/rooms/blocks-dashboard.pug
@@ -91,6 +91,11 @@ append content
                     |  on #{new Date(block.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
                   +translationAttribution(block)
                   div.content-preview!= block.contentHTML
+                  if block.truncated
+                    a.more-link(
+                      href=`/rooms/${room_id}/blocks/${block._id}`
+                      aria-label=`Read full block: ${block.title}`
+                    ) More...
         else
           p No locked blocks yet! Blocks auto-lock after 1 hour of inactivity.
 


### PR DESCRIPTION
- markdownHelper: preview returns {html, truncated}; full mode always returns string
- renderer: skip empty ellipsis element when ellipsis=""
- block DTO: include `truncated`, map {html} → contentHTML
- pug: show .more-link when truncated (with aria-label)
- css: remove gradient overlay; style .more-link