### PR TITLE
feat(i18n): localize Privacy page meta + date; wire privacy namespace…

### DIFF
--- a/i18n/en/privacy.json
+++ b/i18n/en/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Privacy Policy",
+      "description": "How Daily Page collects, uses, and protects your data, in plain language."
+    },
+    "title": "Privacy Policy",
+    "lastUpdated": "Last updated: {date}",
+    "intro": {
+      "h2": "Introduction",
+      "p1": "Daily Page (\"us\", \"we\", or \"our\") operates the dailypage.org website (hereinafter referred to as the \"Service\").",
+      "p2": "This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service."
+    },
+    "collection": {
+      "h2": "Information Collection and Use",
+      "p": "We collect minimal personal data to improve and provide our Service. This includes email addresses for account management and content submitted voluntarily by users."
+    },
+    "usage": {
+      "h2": "Data Usage",
+      "p": "Data collected is used solely for account authentication, content moderation, and enhancing user experience."
+    },
+    "storage": {
+      "h2": "Data Storage & Security",
+      "p": "Your data is securely stored and never shared or sold to third parties without explicit consent, except as required by law."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "We use cookies solely for session management and improving user experience. You can disable cookies via your browser settings."
+    },
+    "rights": {
+      "h2": "Your Rights",
+      "p": "You may request deletion or modification of your personal data at any time by contacting us."
+    },
+    "changes": {
+      "h2": "Changes to This Privacy Policy",
+      "p": "We may update our Privacy Policy from time to time. Changes will be posted on this page."
+    },
+    "contact": {
+      "h2": "Contact Us",
+      "p": "For questions about this Privacy Policy, contact us at:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/es/privacy.json
+++ b/i18n/es/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Política de Privacidad",
+      "description": "Cómo Daily Page recopila, usa y protege tus datos, explicado sin rollo."
+    },
+    "title": "Política de Privacidad",
+    "lastUpdated": "Última actualización: {date}",
+    "intro": {
+      "h2": "Introducción",
+      "p1": "Daily Page (\"nosotros\") opera el sitio web dailypage.org (en adelante, el \"Servicio\").",
+      "p2": "Esta página informa sobre nuestras políticas respecto a la recopilación, uso y divulgación de datos personales cuando usas nuestro Servicio."
+    },
+    "collection": {
+      "h2": "Recopilación y Uso de Información",
+      "p": "Recopilamos datos personales mínimos para mejorar y brindar el Servicio. Esto incluye direcciones de correo para gestión de cuentas y contenido enviado voluntariamente por usuarios."
+    },
+    "usage": {
+      "h2": "Uso de Datos",
+      "p": "Los datos recopilados se utilizan únicamente para autenticación de cuentas, moderación de contenido y mejora de la experiencia de usuario."
+    },
+    "storage": {
+      "h2": "Almacenamiento y Seguridad de Datos",
+      "p": "Tus datos se almacenan de forma segura y nunca se comparten ni venden a terceros sin consentimiento explícito, salvo cuando lo requiera la ley."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "Usamos cookies solo para la gestión de sesión y mejora de la experiencia. Puedes deshabilitarlas en la configuración de tu navegador."
+    },
+    "rights": {
+      "h2": "Tus Derechos",
+      "p": "Puedes solicitar la eliminación o modificación de tus datos personales en cualquier momento contactándonos."
+    },
+    "changes": {
+      "h2": "Cambios a Esta Política de Privacidad",
+      "p": "Podemos actualizar esta Política periódicamente. Los cambios se publicarán en esta página."
+    },
+    "contact": {
+      "h2": "Contacto",
+      "p": "Para preguntas sobre esta Política de Privacidad, contáctanos en:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import { isAuthenticated } from '../middleware/auth.js';
+import { addI18n } from '../services/i18n.js';
 import { findUserById, findUserByUsername } from "../db/userService.js";
 import { getRecentActivityByUser } from '../db/blockService.js';
 import Block from '../db/models/Block.js';
@@ -36,11 +37,16 @@ router.get('/reset-password', (req, res) => {
   });
 });
 
-router.get('/privacy', (req, res) => {
+router.get('/privacy', addI18n(['privacy']), (req, res) => {
+  const { t, lang } = res.locals;
+  const lastUpdatedISO = '2025-08-30'; // ISO constante
+  const lastUpdated = new Intl.DateTimeFormat(lang || 'en', { dateStyle: 'long' })
+    .format(new Date(lastUpdatedISO));
+
   res.render('privacy', {
-    title: 'Privacy Policy',
-    description: 'Privacy Policy for Daily Page.',
-    lastUpdated: 'April 19, 2025'
+    title: t('privacy.meta.title'),
+    description: t('privacy.meta.description'),
+    lastUpdated
   });
 });
 

--- a/views/privacy.pug
+++ b/views/privacy.pug
@@ -8,32 +8,32 @@ block append head
 
 block content
   .privacy-container
-    h1 Privacy Policy
-    p Last updated: #{lastUpdated}
-    
-    h2 Introduction
-    p Daily Page ("us", "we", or "our") operates the dailypage.org website (hereinafter referred to as the "Service").
-    
-    p This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service.
+    h1= t('privacy.title')
+    p= t('privacy.lastUpdated', { date: lastUpdated })
 
-    h2 Information Collection and Use
-    p We collect minimal personal data to improve and provide our Service. This includes email addresses for account management and content submitted voluntarily by users.
+    h2= t('privacy.intro.h2')
+    p= t('privacy.intro.p1')
+    p= t('privacy.intro.p2')
 
-    h2 Data Usage
-    p Data collected is used solely for account authentication, content moderation, and enhancing user experience.
+    h2= t('privacy.collection.h2')
+    p= t('privacy.collection.p')
 
-    h2 Data Storage & Security
-    p Your data is securely stored and never shared or sold to third parties without explicit consent, except as required by law.
+    h2= t('privacy.usage.h2')
+    p= t('privacy.usage.p')
 
-    h2 Cookies
-    p We use cookies solely for session management and improving user experience. You can disable cookies via your browser settings.
+    h2= t('privacy.storage.h2')
+    p= t('privacy.storage.p')
 
-    h2 Your Rights
-    p You may request deletion or modification of your personal data at any time by contacting us.
+    h2= t('privacy.cookies.h2')
+    p= t('privacy.cookies.p')
 
-    h2 Changes to This Privacy Policy
-    p We may update our Privacy Policy from time to time. Changes will be posted on this page.
+    h2= t('privacy.rights.h2')
+    p= t('privacy.rights.p')
 
-    h2 Contact Us
-    p For questions about this Privacy Policy, contact us at: 
-      a(href="mailto:ask@dailypage.org") ask@dailypage.org
+    h2= t('privacy.changes.h2')
+    p= t('privacy.changes.p')
+
+    h2= t('privacy.contact.h2')
+    p
+      | #{t('privacy.contact.p')} 
+      a(href="mailto:ask@dailypage.org")= t('privacy.contact.emailLabel')


### PR DESCRIPTION
… and render with t()

- Add privacy.meta.{title,description} to i18n/en|es
- Use addI18n(['privacy']) and Intl.DateTimeFormat for locale-aware lastUpdated
- Render localized title/description in /privacy