### PR TITLE
i18n(archive): localize month calendar (global & per-room)

### DIFF
--- a/i18n/en/archive.json
+++ b/i18n/en/archive.json
@@ -6,6 +6,19 @@
       "titleRoom": "Daily Page — Archive · {roomName}",
       "descriptionRoom": "Explore past writing in the {roomName} room—month by month. Jump to any date to see what others shared in this space over time."
     },
+    "nav": {
+      "prev": "Previous",
+      "next": "Next"
+    },
+    "calendar": {
+      "meta": {
+        "description": "View all creative blocks posted in {month} {year}—from quick thoughts to deep reflections. Click any date to explore what was shared.",
+        "descriptionRoom": "View the creative activity in {roomName} during {month} {year}. Pick a date to explore the blocks shared that day."
+      },
+      "title": "📆 Archive for {month} {year}",
+      "prevLabel": "Archive for {month} {year}",
+      "nextLabel": "Archive for {month} {year}"
+    },
     "title": "📚 Browse Archives",
     "titleRoom": "📚 {roomName} — Archives",
     "roomViewing": "Viewing archive for room {roomName}",

--- a/i18n/es/archive.json
+++ b/i18n/es/archive.json
@@ -6,6 +6,19 @@
       "titleRoom": "Daily Page — Archivo · {roomName}",
       "descriptionRoom": "Explora los escritos pasados en la sala {roomName}, mes a mes. Salta a cualquier fecha para ver lo que otros compartieron con el tiempo."
     },
+    "nav": {
+      "prev": "Anterior",
+      "next": "Siguiente"
+    },
+    "calendar": {
+      "meta": {
+        "description": "Mira todos los bloques creativos publicados en {month} de {year}—desde ideas rápidas hasta reflexiones profundas. Haz clic en cualquier fecha para explorar lo compartido.",
+        "descriptionRoom": "Observa la actividad creativa en {roomName} durante {month} de {year}. Elige una fecha para ver los bloques compartidos ese día."
+      },
+      "title": "📆 Archivo de {month} de {year}",
+      "prevLabel": "Archivo de {month} de {year}",
+      "nextLabel": "Archivo de {month} de {year}"
+    },
     "title": "📚 Explorar archivos",
     "titleRoom": "📚 {roomName} — Archivos",
     "roomViewing": "Viendo el archivo de la sala {roomName}",

--- a/lib/dateHelper.js
+++ b/lib/dateHelper.js
@@ -33,6 +33,23 @@ class DateHelper {
     return new Intl.DateTimeFormat(lang, { month: 'long' }).format(d);
   }
 
+  /**
+   * Devuelve ['Sun','Mon',...,'Sat'] pero localizados y en formato 'short'
+   * Siempre empezando en domingo para alinear con los calendarios del sitio.
+  */
+  static weekdayShortNames(lang = 'en') {
+    // Domingo conocido: 2020-02-02 fue domingo (UTC)
+    const start = new Date(Date.UTC(2020, 1, 2));
+    const fmt = new Intl.DateTimeFormat(lang, { weekday: 'short' });
+    const arr = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start);
+      d.setUTCDate(start.getUTCDate() + i);
+      arr.push(fmt.format(d));
+    }
+    return arr;
+  }
+
   static roundedDuration(durationMillis) {
     return duration(durationMillis, { round: true, units: ['m', 's'] });
   }

--- a/server/routes/archive.js
+++ b/server/routes/archive.js
@@ -119,25 +119,27 @@ router.get('/archive/best-of', optionalAuth, async (req, res) => {
 });
 
 // GET /archive/:year/:month - Muestra calendario del mes
-router.get('/archive/:year/:month', optionalAuth, async (req, res) => {
+router.get('/archive/:year/:month', optionalAuth, addI18n(['archive']), async (req, res) => {
   try {
     const { year, month } = req.params;
     const datesWithContent = await getBlockDatesByYearMonth(year, month);
 
-    const description = `View all creative blocks posted in ${DateHelper.monthName(month)} ${year}—from quick thoughts to deep reflections. ` +
-      `Click any date to explore what was shared.`;
+    const { t, lang } = res.locals;
+    const monthStr = DateHelper.monthName(Number(month), lang || 'en');
+    const description = t('archive.calendar.meta.description', { month: monthStr, year });
 
     const { prevMonth, nextMonth } = await getMonthNav(null, year, month, { getAllBlockYearMonthCombos });
 
     res.render('archive/calendar', {
-      title: `Archive for ${year}-${month}`,
+      title: t('archive.calendar.title', { month: monthStr, year }),
       description,
       year,
       month,
       prevMonth,
       nextMonth,
       datesWithContent,
-      monthName: DateHelper.monthName,
+      monthName: (m) => DateHelper.monthName(m, lang || 'en'),
+      weekdaysShort: DateHelper.weekdayShortNames(lang || 'en'),
       user: req.user || null,
     });
   } catch (error) {
@@ -286,26 +288,30 @@ router.get('/rooms/:roomId/archive', optionalAuth, addI18n(['archive']), async (
 });
 
 // Calendario del mes específico en una sala
-router.get('/rooms/:roomId/archive/:year/:month', optionalAuth, async (req, res) => {
+router.get('/rooms/:roomId/archive/:year/:month', optionalAuth, addI18n(['archive']), async (req, res) => {
   try {
     const { roomId, year, month } = req.params;
     const datesWithContent = await getBlockDatesByYearMonth(year, month, roomId);
     const roomMetadata = await getRoomMetadata(roomId);
 
-    const description = `View the creative activity in ${roomMetadata.name} during ${DateHelper.monthName(month)} ${year}. ` +
-      `Pick a date to explore the blocks shared that day.`;
+    const { t, lang } = res.locals;
+    const monthStr = DateHelper.monthName(Number(month), lang || 'en');
+    const description = t('archive.calendar.meta.descriptionRoom', {
+      roomName: roomMetadata.name, month: monthStr, year
+    })
 
     const { prevMonth, nextMonth } = await getMonthNav(roomId, year, month, { getAllBlockYearMonthCombos });
 
     res.render('archive/calendar', {
-      title: `Archive for ${year}-${month}`,
+      title: t('archive.calendar.title', { month: monthStr, year }),
       description,
       year,
       month,
       prevMonth,
       nextMonth,
       datesWithContent,
-      monthName: DateHelper.monthName,
+      monthName: (m) => DateHelper.monthName(m, lang || 'en'),
+      weekdaysShort: DateHelper.weekdayShortNames(lang || 'en'),
       roomId,
       roomName: roomMetadata.name,
       user: req.user || null,

--- a/views/archive/calendar.pug
+++ b/views/archive/calendar.pug
@@ -21,8 +21,9 @@ block content
   if roomId
     .archive-room-meta
       p 
-        | Viewing archive for room 
-        a(href=`/rooms/${roomId}`)= `${roomName}`
+        = t('archive.roomViewing', { roomName })
+        |  · 
+        a(href=`/rooms/${roomId}`)= t('archive.viewRoomLink')
   .calendar-container
     include ../partials/_archiveNav
     +archiveNav(
@@ -33,7 +34,7 @@ block content
           )
         : null,
       prevMonth 
-        ? `Archive for ${monthName(prevMonth.month)} ${prevMonth.year}` 
+        ? t('archive.calendar.prevLabel', { month: monthName(prevMonth.month), year: prevMonth.year })
         : '',
       nextMonth
         ? (roomId 
@@ -42,16 +43,17 @@ block content
           )
         : null,
       nextMonth 
-        ? `Archive for ${monthName(nextMonth.month)} ${nextMonth.year}` 
+        ? t('archive.calendar.nextLabel', { month: monthName(nextMonth.month), year: nextMonth.year })
         : '',
       'block-nav'
     )
-    h1 📆 Archive for #{monthName(month)} #{year}
+    h1= t('archive.calendar.title', { month: monthName(month), year })
 
     table.calendar
       thead
         tr
-          each day in ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+          // Nota: weekdaysShort viene ya localizado desde la ruta
+          each day in weekdaysShort
             th= day
       tbody
         - const firstDay = new Date(year, month - 1, 1).getDay()
@@ -74,4 +76,4 @@ block content
                 - dayCount++
   if roomId
     .back-to-room-link
-      a(href=`/rooms/${roomId}`) ← Back to Room Dashboard
+      a(href=`/rooms/${roomId}`)= t('archive.backToRoom')

--- a/views/partials/_archiveNav.pug
+++ b/views/partials/_archiveNav.pug
@@ -14,15 +14,23 @@ mixin archiveNav(prevUrl, prevLabel, nextUrl, nextLabel, cssClass = 'archive-nav
         rel="prev"
         href=prevUrl
         aria-label=prevLabel
-      ) ← #{prevLabel}
+      )
+        span(aria-hidden="true") ←
+        |  #{prevLabel}
     else
-      span.nav-link.disabled.prev ← Earlier
+      span.nav-link.disabled.prev(aria-disabled="true")
+        span(aria-hidden="true") ←
+        |  #{t('archive.nav.prev')}
 
     if nextUrl
       a.nav-link.next(
         rel="next"
         href=nextUrl
         aria-label=nextLabel
-      ) #{nextLabel} →
+      )
+        | #{nextLabel} 
+        span(aria-hidden="true") →
     else
-      span.nav-link.disabled.next Later →
+      span.nav-link.disabled.next(aria-disabled="true")
+        | #{t('archive.nav.next')} 
+        span(aria-hidden="true") →


### PR DESCRIPTION
Intl-based month/day names; a11y-friendly nav with localized fallbacks

- Add archive.nav and archive.calendar keys (en/es)
- Use addI18n(['archive']) in /archive/:year/:month and /rooms/:roomId/archive/:year/:month
- Derive month labels via Intl + pass weekdaysShort from DateHelper
- Localize headings and prev/next labels; localize disabled nav fallbacks
- aria-hidden arrows for better screen-reader output