### PR TITLE
feat(i18n): localize room dashboard + shared JS modals; add tiny front-end i18n helper

### DIFF
--- a/i18n/en/blockList.json
+++ b/i18n/en/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "all time",
+      "days": "in the last {n} days",
+      "day": "in the last 24 hours"
+    },
+    "createdBy": "Created by:",
+    "on": "on"
+  }
+}

--- a/i18n/en/modals.json
+++ b/i18n/en/modals.json
@@ -1,0 +1,17 @@
+{
+  "modals": {
+    "login": {
+      "title": "Please Log In",
+      "message": "You need to be logged in to continue.",
+      "messageWithAction": "You need to be logged in to {action}.",
+      "cta": "Log In"
+    },
+    "actions": {
+      "voteOnBlock": "vote on a block",
+      "starRoom": "star this room"
+    },
+    "errors": {
+      "starToggleFail": "Failed to update star status. Please try again."
+    }
+  }
+}

--- a/i18n/en/readMore.json
+++ b/i18n/en/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "More...",
+    "aria": "Read full block: {title}"
+  }
+}

--- a/i18n/en/roomDashboard.json
+++ b/i18n/en/roomDashboard.json
@@ -1,0 +1,32 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Explore recent and in-progress blocks in {roomName}."
+    },
+    "links": {
+      "allBlocks": "🗂️ All Blocks",
+      "browseByDate": "🗓️ Browse by Date",
+      "bestOf": "🏅 Best of this Room"
+    },
+    "actions": {
+      "createBlock": "Create a Block",
+      "starTitle": "Star this room",
+      "unstarTitle": "Unstar this room"
+    },
+    "tabs": {
+      "locked": "Locked Blocks",
+      "inProgress": "In-Progress Blocks"
+    },
+    "sections": {
+      "lockedHeader": "Locked blocks",
+      "inProgressHeader": "In-progress blocks"
+    },
+    "empty": {
+      "noDescription": "No description available.",
+      "noLocked": "No locked blocks yet! Blocks auto-lock after 1 hour of inactivity.",
+      "noInProgress": "No in-progress blocks yet! Time to start one.",
+      "noBlocks": "No blocks yet! Create the first and leave your mark. 😎"
+    }
+  }
+}

--- a/i18n/en/translation.json
+++ b/i18n/en/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Translated from",
+    "see": "see",
+    "originalBlock": "original block"
+  }
+}

--- a/i18n/es/blockList.json
+++ b/i18n/es/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "todo el tiempo",
+      "days": "en los últimos {n} días",
+      "day": "en las últimas 24 horas"
+    },
+    "createdBy": "Creado por:",
+    "on": "el"
+  }
+}

--- a/i18n/es/modals.json
+++ b/i18n/es/modals.json
@@ -1,0 +1,17 @@
+{
+  "modals": {
+    "login": {
+      "title": "Inicia sesión",
+      "message": "Necesitas iniciar sesión para continuar.",
+      "messageWithAction": "Necesitas iniciar sesión para {action}.",
+      "cta": "Entrar"
+    },
+    "actions": {
+      "voteOnBlock": "votar en un bloque",
+      "starRoom": "marcar esta sala como favorita"
+    },
+    "errors": {
+      "starToggleFail": "No se pudo actualizar el estado de favorito. Inténtalo de nuevo."
+    }
+  }
+}

--- a/i18n/es/readMore.json
+++ b/i18n/es/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Ver más…",
+    "aria": "Leer el bloque completo: {title}"
+  }
+}

--- a/i18n/es/roomDashboard.json
+++ b/i18n/es/roomDashboard.json
@@ -1,0 +1,32 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Explora los bloques recientes y en progreso en {roomName}."
+    },
+    "links": {
+      "allBlocks": "🗂️ Todos los bloques",
+      "browseByDate": "🗓️ Explorar por fecha",
+      "bestOf": "🏅 Lo mejor de esta sala"
+    },
+    "actions": {
+      "createBlock": "Crear un bloque",
+      "starTitle": "Marcar esta sala como favorita",
+      "unstarTitle": "Quitar de favoritos"
+    },
+    "tabs": {
+      "locked": "Bloques bloqueados",
+      "inProgress": "En progreso"
+    },
+    "sections": {
+      "lockedHeader": "Bloques bloqueados",
+      "inProgressHeader": "Bloques en progreso"
+    },
+    "empty": {
+      "noDescription": "Sin descripción por ahora.",
+      "noLocked": "¡Aún no hay bloqueados! Los bloques se bloquean tras 1 hora sin actividad.",
+      "noInProgress": "¡Aún no hay en progreso! Manos a la obra.",
+      "noBlocks": "¡Todavía no hay bloques! Crea el primero y deja huella. 😎"
+    }
+  }
+}

--- a/i18n/es/translation.json
+++ b/i18n/es/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Traducido de",
+    "see": "ver",
+    "originalBlock": "bloque original"
+  }
+}

--- a/lib/dateHelper.js
+++ b/lib/dateHelper.js
@@ -19,6 +19,30 @@ class DateHelper {
     return moment(date).tz('Europe/London').format(DateHelper.formatMap()[format]);
   }
 
+  /**
+   * Formato largo localizado con Intl (weekday, day, month, year).
+   * lang: BCP-47 ('en', 'es', 'es-MX', etc.)
+   * tz: zona a usar (por defecto Europe/London como tu sitio)
+   */
+  static formatDateI18n(date, lang = 'en', tz = 'Europe/London') {
+    const d = (date instanceof Date) ? date : new Date(date);
+    return new Intl.DateTimeFormat(lang, {
+      timeZone: tz,
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    }).format(d);
+  }
+
+  static currentDateI18n(lang = 'en', tz = 'Europe/London') {
+    return DateHelper.formatDateI18n(Date.now(), lang, tz);
+  }
+
+  static localDateTimeI18n(date, lang = 'en', tz = Intl.DateTimeFormat().resolvedOptions().timeZone) {
+    return new Intl.DateTimeFormat(lang, { timeZone: tz, dateStyle: 'medium', timeStyle: 'short' }).format(new Date(date));
+  }
+
   static localDateWithTime(date) {
     return moment(date).tz(moment.tz.guess()).format('h:mm:ss A z, YYYY-MM-DD');
   }

--- a/public/js/i18n-client.js
+++ b/public/js/i18n-client.js
@@ -1,0 +1,82 @@
+/* Tiny i18n helper for front-end scripts
+ * Reads JSON namespaces injected via <script type="application/json" id="i18n-...">.
+ * API:
+ *   I18n.lang()                            -> "en" | "es" | ...
+ *   I18n.read(id, fallback)                -> object (cached)
+ *   I18n.get(nsId, fallback)               -> object (reads "i18n-${nsId}" script)
+ *   I18n.t(nsIdOrObj, path, params?)       -> string (deep-get + {var} interpolation)
+ *   I18n.interpolate(str, params)          -> string
+ *
+ * Expected script tags (examples):
+ *   <script id="i18n-lang" type="application/json">"es"</script>
+ *   <script id="i18n-modals" type="application/json">{ ... }</script>
+ *   <script id="i18n-roomDashboard" type="application/json">{ ... }</script>
+ */
+(function () {
+  const CACHE = new Map();
+
+  function _readJsonScript(id, fallback) {
+    if (CACHE.has(id)) return CACHE.get(id);
+    const el = document.getElementById(id);
+    if (!el) {
+      CACHE.set(id, fallback);
+      return fallback;
+    }
+    try {
+      const parsed = JSON.parse(el.textContent || el.innerText || 'null');
+      CACHE.set(id, parsed ?? fallback);
+      return parsed ?? fallback;
+    } catch {
+      CACHE.set(id, fallback);
+      return fallback;
+    }
+  }
+
+  function _deepGet(obj, path) {
+    if (!obj) return undefined;
+    return String(path)
+      .split('.')
+      .reduce((o, k) => (o && k in o ? o[k] : undefined), obj);
+  }
+
+  function _interpolate(str, params) {
+    const s = (str == null) ? '' : String(str);
+    if (!params) return s;
+    return s.replace(/\{(\w+)\}/g, (_, k) => (k in params ? String(params[k]) : `{${k}}`));
+  }
+
+  function lang() {
+    // Typically provided by the server into #i18n-lang
+    return _readJsonScript('i18n-lang', 'en');
+  }
+
+  function read(id, fallback = {}) {
+    return _readJsonScript(id, fallback);
+  }
+
+  function get(nsId, fallback = {}) {
+    // convention: script tag id = "i18n-" + nsId
+    return _readJsonScript(`i18n-${nsId}`, fallback);
+  }
+
+  function t(nsOrObj, path, params) {
+    const nsObj = (typeof nsOrObj === 'string') ? get(nsOrObj, {}) : (nsOrObj || {});
+    const val = _deepGet(nsObj, path);
+    // If key missing, return the path itself (nice for dev to spot)
+    return _interpolate(val !== undefined ? val : path, params);
+  }
+
+  // Optional: allow setting/updating namespaces at runtime (rarely needed)
+  function set(nsId, data) {
+    CACHE.set(`i18n-${nsId}`, data || {});
+  }
+
+  window.I18n = {
+    lang,
+    read,
+    get,
+    t,
+    set,
+    interpolate: _interpolate
+  };
+})();

--- a/public/js/star-room.js
+++ b/public/js/star-room.js
@@ -1,11 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const tModals = (path, params) => I18n.t('modals', path, params);
+  const tRoom   = (path, params) => I18n.t('roomDashboard', path, params);
+
   const starButton = document.querySelector('.star-btn');
   if (!starButton) return;
 
   starButton.addEventListener('click', async () => {
     const isLoggedIn = document.body.dataset.isLoggedIn === "true";
     if (!isLoggedIn) {
-      window.showLoginModal("star this room");
+      window.showLoginModal("actions.starRoom");
       return;
     }
 
@@ -32,16 +35,18 @@ document.addEventListener('DOMContentLoaded', () => {
       if (starButton.classList.contains('starred')) {
         iconElem.classList.remove('fa-star-o', 'far');
         iconElem.classList.add('fa-star', 'fas');
-        starButton.title = "Unstar this room"; 
+        starButton.title = tRoom('actions.unstarTitle');
+        starButton.setAttribute('aria-label', tRoom('actions.unstarTitle'));
       } else {
         iconElem.classList.remove('fa-star', 'fas');
         iconElem.classList.add('fa-star-o', 'far');
-        starButton.title = "Star this room"; 
+        starButton.title = tRoom('actions.starTitle');
+        starButton.setAttribute('aria-label', tRoom('actions.starTitle'));
       }
 
     } catch (err) {
       console.error('Error toggling star:', err);
-      alert('Failed to update star status. Please try again.');
+      alert(tModals('errors.starToggleFail'));
     }
   });
 });

--- a/public/js/vote-controls.js
+++ b/public/js/vote-controls.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const tModals = (path, params) => I18n.t('modals', path, params);
   const voteControls = document.querySelectorAll(".vote-controls");
 
   voteControls.forEach((control) => {
@@ -20,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
   async function handleVote(action, voteCountElement, blockId) {
     const isLoggedIn = checkLoginState();
     if (!isLoggedIn) {
-      showLoginModal("vote on a block");
+      showLoginModal("actions.voteOnBlock");
       return;
     }
     try {
@@ -63,10 +64,14 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function showLoginModal(actionType) {
-    const modal        = document.getElementById("login-modal");
+    const modal = document.getElementById("login-modal");
     const modalMessage = document.getElementById("login-modal-message");
-  
-    modalMessage.textContent = `You need to be logged in to ${actionType}.`;
+    if (!modal || !modalMessage) return;
+
+    // actionType es una key: "actions.voteOnBlock"
+    const actionText = tModals(actionType);
+    const msg = tModals("login.messageWithAction", { action: actionText });
+    modalMessage.textContent = msg;
     modal.classList.remove('hidden');
   }
   window.showLoginModal = showLoginModal;

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -18,6 +18,10 @@ html(lang=lang || 'en')
       include schema.pug
       script(defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js")
       script(defer src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js")
+      script#i18n-lang(type='application/json').
+        !{JSON.stringify(lang || 'en')}
+      script#i18n-modals(type='application/json').
+        !{JSON.stringify(__i18n.modals || {})}
   body(data-is-logged-in=user ? "true" : "false" data-user-id=user ? user.id : null)
     div.auth-wrapper
       p#welcome-message= t('layout.welcomeUser')

--- a/views/partials/_block_list.pug
+++ b/views/partials/_block_list.pug
@@ -2,20 +2,21 @@ mixin blockList(blocks, period, label, room_id)
   .tab-period
     | #{label} 
     if period === 'all'
-      | · all time
+      |  · #{t('blockList.period.all')}
     else if period > 1
-      | in the last #{period} days
+      | #{t('blockList.period.days', { n: period })}
     else
-      | in the last 24 hours
+      | #{t('blockList.period.day')}
   ul
     each block in blocks
       li.block-preview
         div.content
           a.block-title(href=`/rooms/${room_id}/blocks/${block._id}`)= block.title
           p
-            | Created by: 
+            | #{t('blockList.createdBy')} 
             a.user-profile-link(href=`/users/${block.creator}`)= block.creator
-            |  on #{new Date(block.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+            |  #{t('blockList.on')} 
+            = new Date(block.createdAt).toLocaleString(lang || 'en', { dateStyle: 'medium', timeStyle: 'short' })
           +translationAttribution(block)
           div(class=['content-preview', {'fade-footer': block.truncated}])!= block.contentHTML
           +readMoreIfTruncated(block, room_id)

--- a/views/partials/_common_scripts.pug
+++ b/views/partials/_common_scripts.pug
@@ -1,3 +1,4 @@
+script(src="/js/i18n-client.js")
 script.
   window.MathJax = {
     loader: {

--- a/views/partials/_login_modal.pug
+++ b/views/partials/_login_modal.pug
@@ -2,6 +2,6 @@
 #login-modal.modal.hidden
   .modal-content
     span.modal-close &times;
-    h2 Please Log In
-    p#login-modal-message You need to be logged in to continue.
-    a.btn.btn-primary(href="/login") Log In
+    h2= t('modals.login.title')
+    p#login-modal-message= t('modals.login.message')
+    a.btn.btn-primary(href="/login")= t('modals.login.cta')

--- a/views/partials/_read_more.pug
+++ b/views/partials/_read_more.pug
@@ -2,5 +2,5 @@ mixin readMoreIfTruncated(item, room_id)
   if item.truncated
     a.more-link(
       href=`/rooms/${room_id}/blocks/${item._id}`
-      aria-label=`Read full block: ${item.title}`
-    ) More...
+      aria-label=t('readMore.aria', { title: item.title })
+    )= t('readMore.more')

--- a/views/partials/_translation_attribution.pug
+++ b/views/partials/_translation_attribution.pug
@@ -1,7 +1,8 @@
 mixin translationAttribution(item)
   if item.originalAuthor && item.originalAuthor !== item.creator
     p.translation-attribution
-      | Translated from 
+      | #{t('translation.prefix')} 
       a.user-profile-link(href=`/users/${item.originalAuthor}`)= item.originalAuthor
-      |  (see 
-      a(href=`/rooms/${item.roomId}/blocks/${item.originalBlock}`) original block)
+      |  (#{t('translation.see')} 
+      a(href=`/rooms/${item.roomId}/blocks/${item.originalBlock}`)= t('translation.originalBlock')
+      |)

--- a/views/rooms.pug
+++ b/views/rooms.pug
@@ -5,9 +5,6 @@ block append head
   // Exporta el diccionario que el JS va a leer
   script#i18n-roomsDirectory(type='application/json').
     !{JSON.stringify(__i18n.roomsDirectory || {})}
-  // Exporta el idioma actual
-  script#i18n-lang(type='application/json').
-    !{JSON.stringify(lang || 'en')}
 
 block nav
   include navLinks

--- a/views/rooms/blocks-dashboard.pug
+++ b/views/rooms/blocks-dashboard.pug
@@ -8,6 +8,8 @@ block nav
   include ../navLinks
 
 block append scripts
+  script#i18n-roomDashboard(type='application/json').
+    !{JSON.stringify(__i18n.roomDashboard || {})}
   script(src="/js/vote-controls.js")
   script(src='/js/modal.js')
   script(src="/js/block-tabs.js")
@@ -25,7 +27,6 @@ block append head
   link(rel='stylesheet' href='/css/table-scroll-fade.css')
 
 prepend content
-  // Instead of storing date in 'header', let's pass it as 'todayLabel' or something
   .room-header
     .room-header-row
       .title-line
@@ -33,7 +34,8 @@ prepend content
           data-room-id=room_id
           data-logged-in=user ? "true" : "false"
           class=isStarred ? "starred" : ""
-          title=isStarred ? "Unstar this room" : "Star this room"
+          title=isStarred ? t('roomDashboard.actions.unstarTitle') : t('roomDashboard.actions.starTitle')
+          aria-label=isStarred ? t('roomDashboard.actions.unstarTitle') : t('roomDashboard.actions.starTitle')
         )
           if isStarred
             // For Font Awesome 4, star is .fa .fa-star when starred
@@ -42,63 +44,63 @@ prepend content
             // Outline star is .fa .fa-star-o
             i.fa.fa-star-o
 
-        h1.room-name= roomMetadata.name
+        h1.room-name= roomMetadata.displayName || roomMetadata.name
 
       // Smaller date text below
       if date
         p.room-date= date
 
-  if roomMetadata && roomMetadata.description
-    p#room-description= roomMetadata.description
+  if roomMetadata && (roomMetadata.displayDescription || roomMetadata.description)
+    p#room-description= roomMetadata.displayDescription || roomMetadata.description
   else
-    p#room-description No description available.
+    p#room-description= t('roomDashboard.empty.noDescription')
   p.room-archive-link
-    a(href=`/rooms/${room_id}/index`) 🗂️ All Blocks
+    a(href=`/rooms/${room_id}/index`)= t('roomDashboard.links.allBlocks')
   p.room-archive-link
-    a(href=`/rooms/${room_id}/archive`) 🗓️ Browse by Date
+    a(href=`/rooms/${room_id}/archive`)= t('roomDashboard.links.browseByDate')
   p.room-archive-link
-    a(href=`/rooms/${room_id}/archive/best-of`) 🏅 Best of this Room
+    a(href=`/rooms/${room_id}/archive/best-of`)= t('roomDashboard.links.bestOf')
 
 append content
   include ../partials/_login_modal
   
   p
-    a.btn(href=`/rooms/${room_id}/blocks/new`) Create a Block
+    a.btn(href=`/rooms/${room_id}/blocks/new`)= t('roomDashboard.actions.createBlock')
 
   //- Tab links
   if useTabs
     .tabs
       ul.tab-links
         li(class="active")
-          a(href="#locked-tab") Locked Blocks
+          a(href="#locked-tab")= t('roomDashboard.tabs.locked')
         li
-          a(href="#inprogress-tab") In-Progress Blocks
+          a(href="#inprogress-tab")= t('roomDashboard.tabs.inProgress')
 
       //- Tab content for Locked Blocks
       .tab-content
         #locked-tab(class="active")
           if lockedBlocks.length
-            +blockList(lockedBlocks, lockedPeriod, "Locked blocks", room_id)
+            +blockList(lockedBlocks, lockedPeriod, t('roomDashboard.sections.lockedHeader'), room_id)
           else
-            p No locked blocks yet! Blocks auto-lock after 1 hour of inactivity.
+            p= t('roomDashboard.empty.noLocked')
 
         //- Tab content for In-Progress Blocks
         #inprogress-tab
           if inProgressBlocks.length
-            +blockList(inProgressBlocks, inProgressPeriod, "In-progress blocks", room_id)
+            +blockList(inProgressBlocks, inProgressPeriod, t('roomDashboard.sections.inProgressHeader'), room_id)
           else
-            p No in-progress blocks yet! ¡Manos a la obra!
+            p= t('roomDashboard.empty.noInProgress')
   else
     if showLockedTab
       // Título/periodo sin UI de tabs
       .tab-content
         #locked-tab.active
-          +blockList(lockedBlocks, lockedPeriod, "Locked blocks", room_id)
+          +blockList(lockedBlocks, lockedPeriod, t('roomDashboard.sections.lockedHeader'), room_id)
 
     else if showInProgressTab
       .tab-content
         #inprogress-tab.active
-          +blockList(inProgressBlocks, inProgressPeriod, "In-progress blocks", room_id)
+          +blockList(inProgressBlocks, inProgressPeriod, t('roomDashboard.sections.inProgressHeader'), room_id)
 
     else
-      p No blocks yet! Crea el primero y deja huella. 😎
+      p= t('roomDashboard.empty.noBlocks')


### PR DESCRIPTION
- app: load base i18n namespaces ['layout','nav','modals'] globally
- route(/rooms/:room_id): addI18n for ['roomDashboard','blockList','translation','readMore','modals']
- room metadata: add displayName/displayDescription with i18n fallback (.get(lang) | [lang] | base)
- dateHelper: add formatDateI18n/currentDateI18n/localDateTimeI18n using Intl + TZ
- views(room dashboard + partials):
  - replace hardcoded strings with t() across templates
  - export #i18n-roomDashboard JSON for page scripts
  - use localized tooltips/aria for star button
  - format per-block timestamps with current lang
- public/js:
  - add i18n-client.js (I18n.t/get/lang + interpolation + caching)
  - vote-controls.js: use modals namespace + localized login prompts
  - star-room.js: localized login prompt, tooltips/aria, and error messages
- layout: export #i18n-lang and #i18n-modals JSON globally
- cleanup: remove duplicate #i18n-lang export in rooms.pug

UI/UX:
- consistent login modal text across pages (en/es)
- accessible: dynamic aria-label/title updates for star button
- dev-friendly: missing keys surface as path strings for easy spotting

Refs: internationalize room dashboard + JS bits end-to-end