### PR TITLE
feat(i18n): localize Create Block flow + tags partial (EN/ES) and client JS

### DIFF
--- a/i18n/en/blockTags.json
+++ b/i18n/en/blockTags.json
@@ -1,0 +1,12 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tags:",
+      "noTags": "No tags yet! Add some:"
+    },
+    "input": {
+      "placeholder": "New tag",
+      "addButton": "Add"
+    }
+  }
+}

--- a/i18n/en/createBlock.json
+++ b/i18n/en/createBlock.json
@@ -1,0 +1,63 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Create a New Block — Daily Page",
+      "description": "Start a fresh creative block with optional tags, language, and visibility."
+    },
+    "heading": "Create a New Block",
+    "roomInfo": {
+      "roomLabel": "Room:",
+      "unavailable": "Room information not available.",
+      "noDescription": "No description available."
+    },
+    "form": {
+      "title": {
+        "label": "Title:",
+        "placeholder": {
+          "full": "e.g. 'My Masterpiece', 'The Best Idea Ever', 'Clickbait for Nerds'",
+          "short": "e.g. 'My Masterpiece'"
+        }
+      },
+      "description": {
+        "label": "Description (optional):",
+        "placeholder": "Explain your brilliance… or just wing it."
+      },
+      "initialContent": {
+        "label": "Initial Content (optional):",
+        "help": "Start writing here or press “Create” to continue on the full editor page, where you can embed images and collaborate in real time.",
+        "placeholder": "Start your block here, or continue editing after creation…"
+      },
+      "visibility": {
+        "label": "Visibility:"
+      },
+      "submit": "Create Block"
+    },
+    "visibility": {
+      "public": {
+        "label": "Public",
+        "title": "Editable by anyone in real-time. No login needed.",
+        "inline": "Editable by anyone in real-time. No login needed."
+      },
+      "private": {
+        "label": "Private",
+        "title": "Only for logged-in users. Visible after editing is complete.",
+        "inline": "Only for logged-in users. Visible after editing is complete.",
+        "tooltip": "Private blocks are invite-only while you work, and become visible when you’re done."
+      }
+    },
+    "advanced": {
+      "summary": "Advanced options",
+      "lang": { "label": "Language:" },
+      "translate": {
+        "label": "Translate existing block (URL or ID):",
+        "placeholder": "Paste a block URL or ID (optional)",
+        "invalid": "That doesn’t look like a valid block URL or ID.",
+        "fetchError": "Could not fetch block info."
+      }
+    },
+    "messages": {
+      "langExists": "A translation for that language already exists. Please pick another language.",
+      "genericError": "Something went wrong. Please try again."
+    }
+  }
+}

--- a/i18n/es/blockTags.json
+++ b/i18n/es/blockTags.json
@@ -1,0 +1,12 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Etiquetas:",
+      "noTags": "Aún no hay etiquetas. ¡Añade algunas!"
+    },
+    "input": {
+      "placeholder": "Nueva etiqueta",
+      "addButton": "Añadir"
+    }
+  }
+}

--- a/i18n/es/createBlock.json
+++ b/i18n/es/createBlock.json
@@ -1,0 +1,61 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Crear Bloque Nuevo — Daily Page",
+      "description": "Empieza un bloque creativo con tags opcionales, idioma y visibilidad."
+    },
+    "heading": "Crear un Bloque Nuevo",
+    "roomInfo": {
+      "roomLabel": "Sala:",
+      "unavailable": "Info de la sala no disponible.",
+      "noDescription": "Sin descripción."
+    },
+    "form": {
+      "title": {
+        "label": "Título:",
+        "placeholder": {
+          "full": "p. ej. «Mi Obra Maestra», «La Mejor Idea», «Clickbait para Nerds»",
+          "short": "p. ej. «Mi Obra Maestra»"
+        }
+      },
+      "description": {
+        "label": "Descripción (opcional):",
+        "placeholder": "Explica tu genialidad… o improvísala."
+      },
+      "initialContent": {
+        "label": "Contenido Inicial (opcional):",
+        "help": "Escribe aquí o pulsa «Crear» para seguir en el editor completo, donde puedes incrustar imágenes y colaborar en tiempo real.",
+        "placeholder": "Empieza aquí o sigue editando tras la creación…"
+      },
+      "visibility": { "label": "Visibilidad:" },
+      "submit": "Crear Bloque"
+    },
+    "visibility": {
+      "public": {
+        "label": "Público",
+        "title": "Editable por cualquiera en tiempo real. No hace falta login.",
+        "inline": "Editable por cualquiera en tiempo real. No hace falta login."
+      },
+      "private": {
+        "label": "Privado",
+        "title": "Solo para usuarios con sesión iniciada. Visible al terminar la edición.",
+        "inline": "Solo para usuarios con sesión iniciada. Visible al terminar la edición.",
+        "tooltip": "Los bloques privados son solo con invitación mientras trabajas y se hacen visibles al terminar."
+      }
+    },
+    "advanced": {
+      "summary": "Opciones avanzadas",
+      "lang": { "label": "Idioma:" },
+      "translate": {
+        "label": "Traducir bloque existente (URL o ID):",
+        "placeholder": "Pega la URL o el ID del bloque (opcional)",
+        "invalid": "No parece una URL o ID de bloque válido.",
+        "fetchError": "No se pudo obtener la info del bloque."
+      }
+    },
+    "messages": {
+      "langExists": "Ya existe una traducción para ese idioma. Elige otro, porfa.",
+      "genericError": "Algo salió mal. Inténtalo de nuevo."
+    }
+  }
+}

--- a/public/js/create-block-tags.js
+++ b/public/js/create-block-tags.js
@@ -1,28 +1,29 @@
+// public/js/create-block-tags.js
 document.addEventListener('DOMContentLoaded', () => {
   const hiddenTagsInput = document.getElementById('hidden-tags');
   const tagContainer = document.getElementById('tag-container');
   if (!hiddenTagsInput || !tagContainer) return;
 
-  // Actualiza el valor del input oculto a partir de las "pills" de tag
+  const nsTags = I18n.get('blockTags', {});
+  const tTags = (path, params) => I18n.t(nsTags, path, params);
+
   function updateHiddenTags() {
     const pills = tagContainer.querySelectorAll('.tag-pill');
     const tags = Array.from(pills).map(pill => pill.firstChild.textContent.trim());
-    hiddenTagsInput.value = tags.join(','); // CSV
+    hiddenTagsInput.value = tags.join(',');
     updateTagHeader();
   }
 
-  // Actualiza el encabezado según la cantidad de tags
   function updateTagHeader() {
     const tagHeader = document.querySelector('.block-tags-header');
     const pills = tagContainer.querySelectorAll('.tag-pill');
     if (tagHeader) {
       tagHeader.textContent = (pills.length > 0)
-        ? "Tags:"
-        : "No tags yet! Add some:";
+        ? tTags('header.withTags')     // "Tags:"
+        : tTags('header.noTags');      // "No tags yet! Add some:"
     }
   }
 
-  // Eliminar tag: delegación de eventos sobre el contenedor
   tagContainer.addEventListener('click', (e) => {
     if (e.target && e.target.classList.contains('tag-remove')) {
       e.preventDefault();
@@ -32,7 +33,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Agregar un nuevo tag al presionar el botón "Add"
   const addTagBtn = document.getElementById('add-tag-btn');
   if (addTagBtn) {
     addTagBtn.addEventListener('click', (e) => {
@@ -40,17 +40,17 @@ document.addEventListener('DOMContentLoaded', () => {
       const newTagInput = document.getElementById('new-tag');
       const newTag = newTagInput.value.trim();
       if (!newTag) return;
-      // Crea la nueva "pill" para el tag
+
       const newPill = document.createElement('span');
       newPill.classList.add('tag-pill');
       newPill.textContent = newTag;
-      // Botón para remover el tag
+
       const removeBtn = document.createElement('button');
       removeBtn.classList.add('tag-remove');
       removeBtn.setAttribute('data-tag', newTag);
       removeBtn.textContent = ' x';
       newPill.appendChild(removeBtn);
-      // Inserta la nueva pill antes de la sección de "tag-add"
+
       const tagAdd = document.querySelector('.tag-add');
       if (tagAdd) {
         tagContainer.insertBefore(newPill, tagAdd);
@@ -61,4 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
       updateHiddenTags();
     });
   }
+
+  // inits
+  updateTagHeader();
 });

--- a/public/js/create-block.js
+++ b/public/js/create-block.js
@@ -1,128 +1,114 @@
-// Global variables to store the current tooltip anchor and option
+// public/js/create-block.js
 let currentTooltipAnchor = null;
 let currentTooltipOption = null;
-let outsideClickListener = null; // We'll store a reference to the outside click listener
+let outsideClickListener = null;
 let submitBtn = null;
 let existingLangs = [];
 let langSelect = null;
 
-document.addEventListener("DOMContentLoaded", () => {
-  // Dynamic placeholder adjustment for responsive design
-  const titleInput = document.getElementById("title");
-  const fullPlaceholder = "e.g. 'My Masterpiece', 'The Best Idea Ever', 'Clickbait for Nerds'";
-  const shortPlaceholder = "e.g. 'My Masterpiece'";
+document.addEventListener('DOMContentLoaded', () => {
+  const ns = I18n.get('createBlock', {}); // <-- diccionario
+  const t = (path, params) => I18n.t(ns, path, params);
+
+  // Placeholder responsive
+  const titleInput = document.getElementById('title');
+  const fullPlaceholder = titleInput?.dataset?.phFull || t('form.title.placeholder.full');
+  const shortPlaceholder = titleInput?.dataset?.phShort || t('form.title.placeholder.short');
 
   const updatePlaceholder = () => {
-    if (window.innerWidth < 600) {
-      titleInput.placeholder = shortPlaceholder;
-    } else {
-      titleInput.placeholder = fullPlaceholder;
-    }
+    if (!titleInput) return;
+    titleInput.placeholder = (window.innerWidth < 600) ? shortPlaceholder : fullPlaceholder;
   };
-
   updatePlaceholder();
-  window.addEventListener("resize", updatePlaceholder);
+  window.addEventListener('resize', updatePlaceholder);
 
-  // Existing form submission code
-  const form = document.getElementById("block-form");
-
-  form.addEventListener("submit", async (event) => {
+  // Form
+  const form = document.getElementById('block-form');
+  form.addEventListener('submit', async (event) => {
     event.preventDefault();
 
     if (existingLangs.includes(langSelect.value)) {
-      alert("A translation for that language already exists. Please pick another language.");
+      alert(t('messages.langExists'));
       return;
     }
 
     const formData = new FormData(form);
     const data = Object.fromEntries(formData.entries());
 
-    // Extraer los tags desde el partial
+    // tags desde el partial
     const tagContainer = document.getElementById('tag-container');
     let tagsArray = [];
     if (tagContainer) {
       const tagPills = tagContainer.querySelectorAll('.tag-pill');
-      tagPills.forEach(pill => {
-        // Asumimos que el contenido de la pill es el tag (sin el " x")
-        tagsArray.push(pill.firstChild.textContent.trim());
-      });
+      tagPills.forEach(pill => tagsArray.push(pill.firstChild.textContent.trim()));
     }
     data.tags = tagsArray;
-
-    if (!data.content) {
-      data.content = "";
-    }
+    if (!data.content) data.content = '';
 
     try {
       const response = await fetch(form.action, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
 
       if (!response.ok) {
         const errJson = await response.json().catch(() => ({}));
-        const message = errJson?.error || "Something went wrong. Please try again.";
+        const message = errJson?.error || t('messages.genericError');
         throw new Error(message);
       }
 
       const block = await response.json();
       window.location.href = `/rooms/${block.roomId}/blocks/${block._id}/edit`;
     } catch (error) {
-      console.error("Error:", error);
-      alert(error.message);
+      console.error('Error:', error);
+      alert(error.message || t('messages.genericError'));
     }
   });
 
-  /* -----------------------------------------------------
- * Advanced panel helpers
- * ---------------------------------------------------*/
-  langSelect = document.getElementById("lang");
-  const sourceInput = document.getElementById("source-block");
-  const groupIdField = document.getElementById("groupId");
-  const originalBlockField = document.getElementById("originalBlock");
+  // Advanced helpers
+  langSelect = document.getElementById('lang');
+  const sourceInput = document.getElementById('source-block');
+  const groupIdField = document.getElementById('groupId');
+  const originalBlockField = document.getElementById('originalBlock');
   submitBtn = document.querySelector('button[type="submit"]');
 
   existingLangs = [];
 
-  // Default <select> to browser or user-pref
-  const guess = document.documentElement.lang || navigator.language || "en";
-  const short = guess.split("-")[0];
-  [...langSelect.options].forEach(o => {
-    if (o.value === short) o.selected = true;
-  });
+  // Default lang
+  const guess = document.documentElement.lang || I18n.lang() || navigator.language || 'en';
+  const short = String(guess).split('-')[0];
+  [...langSelect.options].forEach(o => { if (o.value === short) o.selected = true; });
 
-  // When user pastes a URL/ID, fetch its groupId
-  sourceInput.addEventListener("blur", async () => {
+  // Fetch info del bloque origen
+  sourceInput.addEventListener('blur', async () => {
     const raw = sourceInput.value.trim();
     if (!raw) {
-      groupIdField.value = "";
-      originalBlockField.value = "";
-      langSelect.querySelectorAll("option").forEach(o => o.disabled = false);
+      groupIdField.value = '';
+      originalBlockField.value = '';
+      langSelect.querySelectorAll('option').forEach(o => o.disabled = false);
       existingLangs = [];
       bumpIfDup();
-
       return;
     }
 
-    // Extract possible UUID from URL
     const match = raw.match(/blocks\/([0-9a-fA-F]{24})/) || raw.match(/^([0-9a-fA-F]{24})$/);
     if (!match) {
-      alert("That doesn’t look like a valid block URL or ID.");
-      groupIdField.value = "";
-      originalBlockField.value = "";
+      alert(t('advanced.translate.invalid'));
+      groupIdField.value = '';
+      originalBlockField.value = '';
       return;
     }
     const id = match[1];
     try {
       const res = await fetch(`/api/v1/blocks/${id}`);
-      if (!res.ok) throw new Error("Block not found");
+      if (!res.ok) throw new Error('NOT_FOUND');
       const json = await res.json();
-      existingLangs = json.translations.map(t => t.lang);
+      existingLangs = json.translations.map(ti => ti.lang);
       groupIdField.value = json.block.groupId;
       originalBlockField.value = id;
 
-      // ### choose a default that isn't taken ###
+      // elegir primer idioma libre
       const allOpts = [...langSelect.options].map(o => o.value);
       const firstFree = allOpts.find(l => !existingLangs.includes(l)) || 'en';
       langSelect.value = firstFree;
@@ -132,115 +118,88 @@ document.addEventListener("DOMContentLoaded", () => {
         if (option) option.disabled = true;
       });
 
-      // Update UI state
       bumpIfDup();
     } catch (err) {
-      alert("Could not fetch block info: " + err.message);
-      groupIdField.value = "";
+      alert(t('advanced.translate.fetchError'));
+      groupIdField.value = '';
     }
   });
-  langSelect.addEventListener("change", bumpIfDup);
-});
+  langSelect.addEventListener('change', bumpIfDup);
 
-function bumpIfDup() {
-  if (!langSelect) return;
-  if (!submitBtn || !Array.isArray(existingLangs)) return;
-  if (existingLangs.includes(langSelect.value)) {
-    submitBtn.disabled = true;
-    submitBtn.title = "That translation already exists.";
-  } else {
-    submitBtn.disabled = false;
-    submitBtn.title = "";
-  }
-}
-
-// Called when the user clicks the help icon
-function toggleTooltip(event, option) {
-  event.stopPropagation(); // Prevent immediate document click from closing the tooltip
-
-  currentTooltipAnchor = event.target;  // The icon
-  currentTooltipOption = option;
-
-  let tooltip = document.getElementById(`${option}-tooltip`);
-
-  // If the tooltip doesn't exist, create it
-  if (!tooltip) {
-    tooltip = document.createElement("div");
-    tooltip.id = `${option}-tooltip`;
-    tooltip.className = "tooltip";
-    tooltip.textContent = "Private blocks are for logged-in users only. They remain hidden until editing is complete and come with a shareable link for invitations.";
-    document.body.appendChild(tooltip);
+  function bumpIfDup() {
+    if (!langSelect || !submitBtn || !Array.isArray(existingLangs)) return;
+    if (existingLangs.includes(langSelect.value)) {
+      submitBtn.disabled = true;
+      submitBtn.title = t('messages.langExists');
+    } else {
+      submitBtn.disabled = false;
+      submitBtn.title = '';
+    }
   }
 
-  // If it's currently hidden (or not set), show it; otherwise hide it
-  if (tooltip.style.display !== "block") {
-    showTooltip(tooltip);
-  } else {
-    hideTooltip(tooltip);
-  }
-}
+  // Tooltips
+  window.toggleTooltip = function (event, option) {
+    event.stopPropagation();
+    currentTooltipAnchor = event.target;
+    currentTooltipOption = option;
 
-// Show the tooltip and attach an outside-click listener
-function showTooltip(tooltip) {
-  tooltip.style.display = "block";
-  positionTooltip(currentTooltipAnchor, tooltip);
+    let tooltip = document.getElementById(`${option}-tooltip`);
+    if (!tooltip) {
+      tooltip = document.createElement('div');
+      tooltip.id = `${option}-tooltip`;
+      tooltip.className = 'tooltip';
+      tooltip.textContent = t(`visibility.${option}.tooltip`);
+      document.body.appendChild(tooltip);
+    } else {
+      tooltip.textContent = t(`visibility.${option}.tooltip`);
+    }
 
-  // Attach an outside-click listener to close the tooltip when clicking anywhere else
-  outsideClickListener = function (e) {
-    if (!tooltip.contains(e.target) && !currentTooltipAnchor.contains(e.target)) {
+    if (tooltip.style.display !== 'block') {
+      showTooltip(tooltip);
+    } else {
       hideTooltip(tooltip);
     }
   };
-  // Use a small delay to avoid immediate hide
-  setTimeout(() => document.addEventListener("click", outsideClickListener), 0);
-}
 
-// Hide the tooltip and remove the outside-click listener
-function hideTooltip(tooltip) {
-  tooltip.style.display = "none";
-  if (outsideClickListener) {
-    document.removeEventListener("click", outsideClickListener);
-    outsideClickListener = null;
-  }
-}
-
-// Position the tooltip relative to its anchor element
-function positionTooltip(anchor, tooltip) {
-  // Make sure tooltip is visible so we can measure its size
-  tooltip.style.display = "block";
-
-  // Get bounding rectangles
-  const anchorRect = anchor.getBoundingClientRect();
-  const tooltipRect = tooltip.getBoundingClientRect();
-
-  // We’ll position the tooltip slightly below the icon
-  const offsetY = 4; // You can tweak this
-  let top = anchorRect.bottom + window.scrollY + offsetY;
-
-  // Center it horizontally relative to the anchor
-  let left = anchorRect.left + window.scrollX + (anchorRect.width / 2) - (tooltipRect.width / 2);
-
-  // Prevent overflowing off the right side
-  if (left + tooltipRect.width > window.innerWidth - 10) {
-    left = window.innerWidth - tooltipRect.width - 10;
-  }
-  // Prevent overflowing off the left side
-  if (left < 10) {
-    left = 10;
+  function showTooltip(tooltip) {
+    tooltip.style.display = 'block';
+    positionTooltip(currentTooltipAnchor, tooltip);
+    outsideClickListener = function (e) {
+      if (!tooltip.contains(e.target) && !currentTooltipAnchor.contains(e.target)) {
+        hideTooltip(tooltip);
+      }
+    };
+    setTimeout(() => document.addEventListener('click', outsideClickListener), 0);
   }
 
-  // Apply the final position
-  tooltip.style.top = `${top}px`;
-  tooltip.style.left = `${left}px`;
-  tooltip.style.maxWidth = "280px";
-}
-
-// Reposition tooltip on window resize if it's visible
-window.addEventListener("resize", () => {
-  if (currentTooltipOption) {
-    const tooltip = document.getElementById(`${currentTooltipOption}-tooltip`);
-    if (tooltip && tooltip.style.display === "block") {
-      positionTooltip(currentTooltipAnchor, tooltip);
+  function hideTooltip(tooltip) {
+    tooltip.style.display = 'none';
+    if (outsideClickListener) {
+      document.removeEventListener('click', outsideClickListener);
+      outsideClickListener = null;
     }
   }
+
+  function positionTooltip(anchor, tooltip) {
+    tooltip.style.display = 'block';
+    const anchorRect = anchor.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const offsetY = 4;
+    let top = anchorRect.bottom + window.scrollY + offsetY;
+    let left = anchorRect.left + window.scrollX + (anchorRect.width / 2) - (tooltipRect.width / 2);
+    if (left + tooltipRect.width > window.innerWidth - 10) left = window.innerWidth - tooltipRect.width - 10;
+    if (left < 10) left = 10;
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.maxWidth = '280px';
+  }
+
+  window.addEventListener('resize', () => {
+    if (currentTooltipOption) {
+      const tooltip = document.getElementById(`${currentTooltipOption}-tooltip`);
+      if (tooltip && tooltip.style.display === 'block') {
+        positionTooltip(currentTooltipAnchor, tooltip);
+      }
+    }
+  });
 });

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -7,6 +7,7 @@ import {
 import { getRoomMetadata } from '../db/roomService.js';
 import { renderMarkdownContent } from '../utils/markdownHelper.js';
 import optionalAuth from '../middleware/optionalAuth.js';
+import { addI18n } from '../services/i18n.js';
 import { canManageBlock } from '../utils/block.js';
 
 const router = express.Router();
@@ -15,7 +16,7 @@ function canonicalBlockPath(doc) {
   return `/rooms/${doc.roomId}/blocks/${doc._id}`;
 }
 
-router.get('/rooms/:room_id/blocks/:block_id', optionalAuth, async (req, res) => {
+router.get('/rooms/:room_id/blocks/:block_id', optionalAuth, addI18n(['blockTags']), async (req, res) => {
   try {
     const { room_id, block_id } = req.params;
     const block = await getBlockById(block_id);

--- a/server/routes/blocks.js
+++ b/server/routes/blocks.js
@@ -5,6 +5,7 @@ import optionalAuth from '../middleware/optionalAuth.js';
 import { getBlockById } from '../db/blockService.js';
 import { getRoomMetadata } from '../db/roomService.js';
 import { getPeerIDs } from '../db/sessionService.js';
+import { addI18n } from '../services/i18n.js';
 import { generateAnonymousId } from '../utils/anonymousId.js';
 import { canManageBlock } from '../utils/block.js';
 import { renderMarkdownContent } from '../utils/markdownHelper.js';
@@ -16,12 +17,14 @@ const backendBaseUrl = `${(config.backendUrl || `http://localhost:${port}`)}`;
 const router = express.Router();
 
 // Render "Create New Block" page
-router.get('/rooms/:room_id/blocks/new', optionalAuth, async (req, res) => {
+router.get('/rooms/:room_id/blocks/new', optionalAuth, addI18n(['createBlock', 'blockTags']), async (req, res) => {
   const { room_id } = req.params;
-  const roomMetadata = await getRoomMetadata(room_id);
+  const lang = res.locals.lang;
+  const roomMetadata = await getRoomMetadata(room_id, lang);
 
   res.render('rooms/create-block', {
-    title: 'Create a New Block',
+    title: res.locals.t('createBlock.meta.title'),
+    description: res.locals.t('createBlock.meta.description'),
     room_id,
     roomMetadata,
     user: req.user,
@@ -29,7 +32,7 @@ router.get('/rooms/:room_id/blocks/new', optionalAuth, async (req, res) => {
 });
 
 // Render Block Editor Page
-router.get('/rooms/:room_id/blocks/:block_id/edit', optionalAuth, async (req, res) => {
+router.get('/rooms/:room_id/blocks/:block_id/edit', optionalAuth, addI18n(['blockTags']), async (req, res) => {
   const { room_id, block_id } = req.params;
   const user = req.user;
   const editTokens = req.cookies.edit_tokens ? JSON.parse(req.cookies.edit_tokens) : [];

--- a/views/partials/_tag_section.pug
+++ b/views/partials/_tag_section.pug
@@ -1,6 +1,6 @@
 mixin tagSection(tags, canManageBlock)
   if tags && tags.length
-    p.block-tags-header Tags:
+    p.block-tags-header= t('blockTags.header.withTags')
     div#tag-container
       each tag in tags
         span.tag-pill
@@ -9,14 +9,14 @@ mixin tagSection(tags, canManageBlock)
             button.tag-remove(data-tag=tag) x
       if canManageBlock
         span.tag-add
-          input#new-tag(type='text' placeholder='New tag')
-          button#add-tag-btn Add
+          input#new-tag(type='text' placeholder=t('blockTags.input.placeholder'))
+          button#add-tag-btn= t('blockTags.input.addButton')
   else
     if canManageBlock
-      p.block-tags-header No tags yet! Add some:
+      p.block-tags-header= t('blockTags.header.noTags')
       div#tag-container
         span.tag-add
-          input#new-tag(type='text' placeholder='New tag')
-          button#add-tag-btn Add
+          input#new-tag(type='text' placeholder=t('blockTags.input.placeholder'))
+          button#add-tag-btn= t('blockTags.input.addButton')
     else
       p.block-tags-header

--- a/views/rooms/create-block.pug
+++ b/views/rooms/create-block.pug
@@ -5,95 +5,104 @@ block nav
 
 block append head
   link(rel='stylesheet' href='/css/create-block.css')
-  link(rel="stylesheet" href="/css/block-tags.css")
-  link(rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css")
+  link(rel='stylesheet' href='/css/block-tags.css')
+  link(rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css')
+
+  // Exporta diccionarios para JS
+  script#i18n-createBlock(type='application/json').
+    !{JSON.stringify(__i18n.createBlock || {})}
+  script#i18n-blockTags(type='application/json').
+    !{JSON.stringify(__i18n.blockTags || {})}
 
 block append scripts
-  script(src="/js/create-block.js")
-  script(src="/js/create-block-tags.js")
+  script(src='/js/create-block.js')
+  script(src='/js/create-block-tags.js')
 
 block content
-  h1 Create a New Block
-  - let descriptionText = 'Room information not available.'
+  h1= t('createBlock.heading')
+
+  - let descriptionFallback = t('createBlock.roomInfo.unavailable')
   if roomMetadata
     h2#room-name
-      | Room: 
-      a(href=`/rooms/${roomMetadata._id}`)= roomMetadata.name
-    - descriptionText = roomMetadata.description || 'No description available.'
+      | #{t('createBlock.roomInfo.roomLabel')} 
+      a(href=`/rooms/${roomMetadata._id}`)= (roomMetadata.displayName || roomMetadata.name)
+    - descriptionFallback = (roomMetadata.displayDescription || roomMetadata.description || t('createBlock.roomInfo.noDescription'))
 
-  p#room-description= descriptionText
+  p#room-description= descriptionFallback
 
-  form#block-form(action=`/api/v1/rooms/${room_id}/blocks` method="POST")
+  form#block-form(action=`/api/v1/rooms/${room_id}/blocks` method='POST')
     .form-group
-      label(for="title") Title:
-      input#title(type="text" name="title" required minlength="3" maxlength="100" 
-        placeholder="e.g. 'My Masterpiece', 'The Best Idea Ever', 'Clickbait for Nerds'"
+      label(for='title')= t('createBlock.form.title.label')
+      input#title(
+        type='text' name='title' required minlength='3' maxlength='100'
+        placeholder=t('createBlock.form.title.placeholder.full')
+        data-ph-full=t('createBlock.form.title.placeholder.full')
+        data-ph-short=t('createBlock.form.title.placeholder.short')
       )
     .form-group
-      label(for="description") Description (optional):
-      textarea#description(name="description" placeholder="Explain your brilliance... or just wing it.")
+      label(for='description')= t('createBlock.form.description.label')
+      textarea#description(name='description' placeholder=t('createBlock.form.description.placeholder'))
     .form-group
-      label(for="initial-content") Initial Content (optional):
-      p.form-help Start writing here or press "Create" to continue on the full editor page, where you can embed images and collaborate in real time.
-      textarea#initial-content(name="content" placeholder="Start your block here, or continue editing after creation...")
+      label(for='initial-content')= t('createBlock.form.initialContent.label')
+      p.form-help= t('createBlock.form.initialContent.help')
+      textarea#initial-content(name='content' placeholder=t('createBlock.form.initialContent.placeholder'))
     .form-group
       include ../partials/_tag_section
-      input#hidden-tags(type="hidden" name="tags")
+      input#hidden-tags(type='hidden' name='tags')
       +tagSection([], true)
     .form-group
-      label Visibility:
+      label= t('createBlock.form.visibility.label')
       .visibility-options
         .option
-          label(for="public-option" title="Editable by anyone in real-time. No login needed.")
-            input#public-option(type="radio" name="visibility" value="public" checked)
-            | Public 
+          label(for='public-option' title=t('createBlock.visibility.public.title'))
+            input#public-option(type='radio' name='visibility' value='public' checked)
+            | #{t('createBlock.visibility.public.label')} 
             i.fas.fa-eye
-          // Inline description for mobile (hidden on desktop)
-          span.visibility-description.hidden-on-desktop Editable by anyone in real-time. No login needed.
+          span.visibility-description.hidden-on-desktop= t('createBlock.visibility.public.inline')
         .option
-          label(for="private-option" title="Only for logged-in users. Visible after editing is complete." class= !user ? "disabled" : "")
-            input#private-option(type="radio" name="visibility" value="private" disabled= !user)
-            | Private 
+          - const disabledClass = !user ? 'disabled' : ''
+          label(for='private-option' title=t('createBlock.visibility.private.title') class=disabledClass)
+            input#private-option(type='radio' name='visibility' value='private' disabled=!user)
+            | #{t('createBlock.visibility.private.label')} 
             i.fas.fa-lock
-            // New info icon with a larger tap target
             i.far.fa-question-circle.info-icon(onclick="toggleTooltip(event, 'private')")
-          // Inline description for mobile (hidden on desktop)
-          span.visibility-description.hidden-on-desktop Only for logged-in users. Visible after editing is complete.
-    // Advanced options (collapsed by default)
-    details#advanced-settings(style="margin-top:1rem")
-      summary(style="cursor:pointer; font-weight:bold") Advanced options
+          span.visibility-description.hidden-on-desktop= t('createBlock.visibility.private.inline')
+
+    details#advanced-settings(style='margin-top:1rem')
+      summary(style='cursor:pointer; font-weight:bold')= t('createBlock.advanced.summary')
       .form-group
-        label(for="lang") Language:
-        select#lang(name="lang")
-          option(value="en" selected) English
-          option(value="es") Español
-          option(value="fr") Français
-          option(value="ru") Русский
-          option(value="id") Bahasa Indonesia
-          option(value="de") Deutsch
-          option(value="it") Italiano
-          option(value="pt") Português
-          option(value="zh") 中文
-          option(value="ja") 日本語
-          option(value="ko") 한국어
-          option(value="ar") العربية
-          option(value="hi") हिन्दी
-          option(value="tr") Türkçe
-          option(value="nl") Nederlands
-          option(value="sv") Svenska
-          option(value="no") Norsk
-          option(value="da") Dansk
-          option(value="fi") Suomi
-          option(value="pl") Polski
-          option(value="cs") Čeština
-          option(value="el") Ελληνικά
-          option(value="he") עברית
-          option(value="th") ไทย
-          option(value="vi") Tiếng Việt
+        label(for='lang')= t('createBlock.advanced.lang.label')
+        select#lang(name='lang')
+          //- mismo listado de opciones; las etiquetas pueden quedarse en su idioma nativo
+          option(value='en' selected) English
+          option(value='es') Español
+          option(value='fr') Français
+          option(value='ru') Русский
+          option(value='id') Bahasa Indonesia
+          option(value='de') Deutsch
+          option(value='it') Italiano
+          option(value='pt') Português
+          option(value='zh') 中文
+          option(value='ja') 日本語
+          option(value='ko') 한국어
+          option(value='ar') العربية
+          option(value='hi') हिन्दी
+          option(value='tr') Türkçe
+          option(value='nl') Nederlands
+          option(value='sv') Svenska
+          option(value='no') Norsk
+          option(value='da') Dansk
+          option(value='fi') Suomi
+          option(value='pl') Polski
+          option(value='cs') Čeština
+          option(value='el') Ελληνικά
+          option(value='he') עברית
+          option(value='th') ไทย
+          option(value='vi') Tiếng Việt
       .form-group
-        label(for="source-block") Translate existing block (URL or ID):
-        input#source-block(type="text" placeholder="Paste a block URL or ID (optional)")
-        // Hidden field populated via JS
-        input(type="hidden" name="groupId" id="groupId")
-        input(type="hidden" name="originalBlock" id="originalBlock")
-    button.btn.btn-primary(type="submit") Create Block
+        label(for='source-block')= t('createBlock.advanced.translate.label')
+        input#source-block(type='text' placeholder=t('createBlock.advanced.translate.placeholder'))
+        input(type='hidden' name='groupId' id='groupId')
+        input(type='hidden' name='originalBlock' id='originalBlock')
+
+    button.btn.btn-primary(type='submit')= t('createBlock.form.submit')


### PR DESCRIPTION
- routes: add addI18n(['createBlock','blockTags']) to /rooms/:id/blocks/new and addI18n(['blockTags']) to block view/edit routes
- views: convert views/rooms/create-block.pug to t('…') keys; export i18n-createBlock & i18n-blockTags JSON to client
- partial: i18n-ize views/partials/_tag_section.pug (headers, input placeholder, Add button)
- client: refactor public/js/create-block.js to use I18n.t() (responsive placeholders, tooltips, alerts, generic errors, langExists)
- client: refactor public/js/create-block-tags.js to use I18n.t() for tag header
  + init header on load
- bundles: add i18n/en|es/createBlock.json and i18n/en|es/blockTags.json
- UX: keep submit disabled when translation for selected lang exists; auto-pick first free lang for translations
- lang source: honor html[lang] / #i18n-lang so Advanced > Language defaults to page locale