### PR TITLE
feat(i18n): fully localize Best-of archive

### DIFF
--- a/app.js
+++ b/app.js
@@ -426,7 +426,7 @@ const ROOM_BASED_CUTOFF = new Date('2024-12-31');
 
     app.post('/request-room', handleRoomRequest);
 
-    app.get('/rooms/:room_id', optionalAuth,  addI18n(['roomDashboard','blockList','translation','readMore','modals']), async (req, res) => {
+    app.get('/rooms/:room_id', optionalAuth, addI18n(['roomDashboard', 'blockList', 'translation', 'readMore', 'modals']), async (req, res) => {
       try {
         const { room_id } = req.params;
 

--- a/i18n/en/bestOf.json
+++ b/i18n/en/bestOf.json
@@ -1,0 +1,22 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Best of Daily Page",
+      "description": "The most-loved blocks on Daily Page—funny, honest, poetic, or just plain weird. See what stood out over the past day, week, month, and beyond."
+    },
+    "heading": "🏆 Best of Daily Page",
+    "tabs": {
+      "24h": "🔥 24 Hours",
+      "7d": "🚀 7 Days",
+      "30d": "🌕 30 Days",
+      "all": "👑 All Time"
+    },
+    "labels": {
+      "createdBy": "Created by:",
+      "inRoom": "in",
+      "onDate": "on {date}",
+      "unknownRoom": "Unknown Room",
+      "noBlocks": "No blocks found."
+    }
+  }
+}

--- a/i18n/es/bestOf.json
+++ b/i18n/es/bestOf.json
@@ -1,0 +1,22 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Lo mejor de Daily Page",
+      "description": "Los bloques más queridos de Daily Page—graciosos, honestos, poéticos o sencillamente raros. Mira qué destacó en el día, la semana, el mes y más allá."
+    },
+    "heading": "🏆 Lo mejor de Daily Page",
+    "tabs": {
+      "24h": "🔥 24 horas",
+      "7d": "🚀 7 días",
+      "30d": "🌕 30 días",
+      "all": "👑 Históricos"
+    },
+    "labels": {
+      "createdBy": "Creado por:",
+      "inRoom": "en",
+      "onDate": "el {date}",
+      "unknownRoom": "Sala desconocida",
+      "noBlocks": "No se encontraron bloques."
+    }
+  }
+}

--- a/server/routes/archive.js
+++ b/server/routes/archive.js
@@ -78,7 +78,7 @@ router.get('/rooms/:roomId/archive/best-of', optionalAuth, async (req, res) => {
   }
 });
 
-router.get('/archive/best-of', optionalAuth, async (req, res) => {
+router.get('/archive/best-of', optionalAuth, addI18n(['bestOf', 'translation', 'readMore']), async (req, res) => {
   try {
     const preferredLang = req.query.lang
       || req.user?.preferredLang
@@ -99,12 +99,9 @@ router.get('/archive/best-of', optionalAuth, async (req, res) => {
       top24h: top24hDTO, top7d: top7dDTO, top30d: top30dDTO, topAll: topAllDTO
     });
 
-    const description = "The most-loved blocks on Daily Page—funny, honest, poetic, or just plain weird. " +
-      "See what stood out over the past day, week, month, and beyond.";
-
     res.render('archive/best-of', {
-      title: 'Best of Daily Page',
-      description,
+      title: res.locals.t('bestOf.meta.title'),
+      description: res.locals.t('bestOf.meta.description'),
       top24h: top24hDTO,
       top7d: top7dDTO,
       top30d: top30dDTO,

--- a/views/archive/best-of.pug
+++ b/views/archive/best-of.pug
@@ -10,6 +10,11 @@ block append head
   link(rel='stylesheet' href='/css/best-of.css')
   link(rel='stylesheet' href='/css/translation-attribution.css')
   link(rel='stylesheet' href='/css/table-scroll-fade.css')
+  // Export i18n for this page + current lang
+  script#i18n-bestOf(type='application/json').
+    !{JSON.stringify(__i18n.bestOf || {})}
+  script#i18n-lang(type='application/json').
+    !{JSON.stringify(lang || 'en')}
 
 block append scripts
   script(src="/js/vote-controls.js")
@@ -21,15 +26,15 @@ block nav
   include ../navLinks
 
 block content
-  h1 🏆 Best of Daily Page
+  h1= t('bestOf.heading')
 
   // Tab navigation
   .tabs
     ul.tab-links
-      li(class={active: activeTab==='24h'} data-tab="tab-24h") 🔥 24 Hours
-      li(class={active: activeTab==='7d'}  data-tab="tab-7d") 🚀 7 Days
-      li(class={active: activeTab==='30d'} data-tab="tab-30d") 🌕 30 Days
-      li(class={active: activeTab==='all'} data-tab="tab-all") 👑 All Time
+      li(class={active: activeTab==='24h'} data-tab="tab-24h")= t('bestOf.tabs.24h')
+      li(class={active: activeTab==='7d'}  data-tab="tab-7d")= t('bestOf.tabs.7d')
+      li(class={active: activeTab==='30d'} data-tab="tab-30d")= t('bestOf.tabs.30d')
+      li(class={active: activeTab==='all'} data-tab="tab-all")= t('bestOf.tabs.all')
 
   // Tab content
   .tab-content
@@ -51,15 +56,20 @@ mixin renderBlockList(blocks)
           div.content
             a.block-title(href=`/rooms/${block.roomId}/blocks/${block._id}`)= block.title
             p
-              | Created by: 
+              | #{t('bestOf.labels.createdBy')} 
               a.user-profile-link(href=`/users/${block.creator}`)= block.creator
-              |  in 
-              a.room-link(href=`/rooms/${block.roomId}`)= block.roomId ? block.roomId : 'Unknown Room'
-              |  on #{new Date(block.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+              |  #{t('bestOf.labels.inRoom')} 
+              if block.roomId
+                a.room-link(href=`/rooms/${block.roomId}`)= block.roomDisplayName || block.roomId
+              else
+                span.room-link= t('bestOf.labels.unknownRoom')
+              - const _lang = (typeof lang === 'string' ? lang : 'en');
+              - const _date = new Date(block.createdAt).toLocaleString(_lang, { dateStyle: 'medium', timeStyle: 'short' });
+              |  #{t('bestOf.labels.onDate', { date: _date })}
             +translationAttribution(block)
             div(class=['content-preview', {'fade-footer': block.truncated}])!= block.contentHTML
           +readMoreIfTruncated(block, block.roomId)
           footer.block-footer
             include ../partials/_vote_controls
   else
-    p No blocks found.
+    p= t('bestOf.labels.noBlocks')


### PR DESCRIPTION
- Add bestOf namespace (EN/ES) with meta, heading, tabs, labels
- Wire addI18n(['bestOf','translation','readMore']) in /archive/best-of
- Replace hardcoded copy in Pug with t() and export #i18n-bestOf/#i18n-lang
- Localize dates via toLocaleString(lang, …)
- Guard room link when roomId is missing (fallback label)