### PR TITLE
feat(i18n): finalize room-scoped Best Of i18n

### DIFF
--- a/i18n/en/bestOf.json
+++ b/i18n/en/bestOf.json
@@ -2,9 +2,13 @@
   "bestOf": {
     "meta": {
       "title": "Best of Daily Page",
-      "description": "The most-loved blocks on Daily Page—funny, honest, poetic, or just plain weird. See what stood out over the past day, week, month, and beyond."
+      "description": "The most-loved blocks on Daily Page—funny, honest, poetic, or just plain weird. See what stood out over the past day, week, month, and beyond.",
+      "titleRoom": "Best of {roomName}",
+      "descriptionRoom": "Discover standout posts from the {roomName} room—the ones readers loved most over the past 24 hours, 7 days, 30 days, and all time."
     },
     "heading": "🏆 Best of Daily Page",
+    "headingRoomPrefix": "🏆 Best of ",
+    "headingRoomSuffix": "",
     "tabs": {
       "24h": "🔥 24 Hours",
       "7d": "🚀 7 Days",
@@ -16,7 +20,8 @@
       "inRoom": "in",
       "onDate": "on {date}",
       "unknownRoom": "Unknown Room",
-      "noBlocks": "No blocks found."
+      "noBlocks": "No blocks found.",
+      "viewRoom": "View room"
     }
   }
 }

--- a/i18n/es/bestOf.json
+++ b/i18n/es/bestOf.json
@@ -2,9 +2,13 @@
   "bestOf": {
     "meta": {
       "title": "Lo mejor de Daily Page",
-      "description": "Los bloques más queridos de Daily Page—graciosos, honestos, poéticos o sencillamente raros. Mira qué destacó en el día, la semana, el mes y más allá."
+      "description": "Los bloques más queridos de Daily Page—graciosos, honestos, poéticos o sencillamente raros. Mira qué destacó en el día, la semana, el mes y más allá.",
+      "titleRoom": "Lo mejor de {roomName}",
+      "descriptionRoom": "Descubre los posts destacados de la sala {roomName}: los más queridos en las últimas 24 horas, 7 días, 30 días y de todos los tiempos."
     },
     "heading": "🏆 Lo mejor de Daily Page",
+    "headingRoomPrefix": "🏆 Lo mejor de ",
+    "headingRoomSuffix": "",
     "tabs": {
       "24h": "🔥 24 horas",
       "7d": "🚀 7 días",
@@ -16,7 +20,8 @@
       "inRoom": "en",
       "onDate": "el {date}",
       "unknownRoom": "Sala desconocida",
-      "noBlocks": "No se encontraron bloques."
+      "noBlocks": "No se encontraron bloques.",
+      "viewRoom": "Ver sala"
     }
   }
 }

--- a/server/routes/archive.js
+++ b/server/routes/archive.js
@@ -35,7 +35,7 @@ router.get('/archive', optionalAuth, addI18n(['archive']), async (req, res) => {
   }
 });
 
-router.get('/rooms/:roomId/archive/best-of', optionalAuth, async (req, res) => {
+router.get('/rooms/:roomId/archive/best-of', optionalAuth, addI18n(['bestOf', 'translation', 'readMore']), async (req, res) => {
   const { roomId } = req.params;
   const preferredLang = req.query.lang
     || req.user?.preferredLang
@@ -58,18 +58,23 @@ router.get('/rooms/:roomId/archive/best-of', optionalAuth, async (req, res) => {
       top24h: top24hDTO, top7d: top7dDTO, top30d: top30dDTO, topAll: topAllDTO
     });
 
-    const description = `Discover standout posts from the ${roomMetadata.name} room—` +
-      `the ones readers loved most over the past 24 hours, 7 days, 30 days, and all time.`;
+    const roomName =
+      roomMetadata.displayName
+      || roomMetadata.name_i18n?.[preferredLang]
+      || roomMetadata.name;
+
+    const title = res.locals.t('bestOf.meta.titleRoom', { roomName });
+    const description = res.locals.t('bestOf.meta.descriptionRoom', { roomName });
 
     res.render('archive/best-of-room', {
-      title: `Best of ${roomMetadata.name}`,
+      title,
       description,
       top24h: top24hDTO,
       top7d: top7dDTO,
       top30d: top30dDTO,
       topAll: topAllDTO,
       activeTab,
-      roomMetadata,
+      roomMetadata: { ...roomMetadata, roomName },
       user: req.user || null,
     });
   } catch (error) {

--- a/views/archive/best-of-room.pug
+++ b/views/archive/best-of-room.pug
@@ -10,6 +10,11 @@ block append head
   link(rel='stylesheet' href='/css/best-of.css')
   link(rel='stylesheet' href='/css/translation-attribution.css')
   link(rel='stylesheet' href='/css/table-scroll-fade.css')
+  // Export i18n for this page + current lang
+  script#i18n-bestOf(type='application/json').
+    !{JSON.stringify(__i18n.bestOf || {})}
+  script#i18n-lang(type='application/json').
+    !{JSON.stringify(lang || 'en')}
 
 block nav
   include ../navLinks
@@ -21,16 +26,22 @@ block append scripts
   script(src='/js/table-scroll-fade.js')
 
 block content
-  h1 🏆 Best of 
-    a#room-link(href=`/rooms/${roomMetadata._id}`)= roomMetadata.name
+  - const _roomName = roomMetadata.roomName || roomMetadata.name;
+  h1
+    | #{t('bestOf.headingRoomPrefix')}
+    if roomMetadata._id
+      a#room-link(href=`/rooms/${roomMetadata._id}`)= _roomName
+    else
+      span= _roomName
+    | #{t('bestOf.headingRoomSuffix')}
 
   // Tab navigation
   .tabs
     ul.tab-links
-      li(class={active: activeTab==='24h'} data-tab="tab-24h") 🔥 24 Hours
-      li(class={active: activeTab==='7d'}  data-tab="tab-7d") 🚀 7 Days
-      li(class={active: activeTab==='30d'} data-tab="tab-30d") 🌕 30 Days
-      li(class={active: activeTab==='all'} data-tab="tab-all") 👑 All Time
+      li(class={active: activeTab==='24h'} data-tab="tab-24h")= t('bestOf.tabs.24h')
+      li(class={active: activeTab==='7d'}  data-tab="tab-7d")= t('bestOf.tabs.7d')
+      li(class={active: activeTab==='30d'} data-tab="tab-30d")= t('bestOf.tabs.30d')
+      li(class={active: activeTab==='all'} data-tab="tab-all")= t('bestOf.tabs.all')
 
   // Tab content
   .tab-content
@@ -52,15 +63,20 @@ mixin renderBlockList(blocks)
           div.content
             a.block-title(href=`/rooms/${block.roomId}/blocks/${block._id}`)= block.title
             p
-              | Created by: 
+              | #{t('bestOf.labels.createdBy')} 
               a.user-profile-link(href=`/users/${block.creator}`)= block.creator
-              |  in 
-              a.room-link(href=`/rooms/${block.roomId}`)= block.roomId ? block.roomId : 'Unknown Room'
-              |  on #{new Date(block.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+              |  #{t('bestOf.labels.inRoom')} 
+              if block.roomId
+                a.room-link(href=`/rooms/${block.roomId}`)= block.roomDisplayName || block.roomId
+              else
+                span.room-link= t('bestOf.labels.unknownRoom')
+              - const _lang = (typeof lang === 'string' ? lang : 'en');
+              - const _date = new Date(block.createdAt).toLocaleString(_lang, { dateStyle: 'medium', timeStyle: 'short' });
+              |  #{t('bestOf.labels.onDate', { date: _date })}
             +translationAttribution(block)
             div(class=['content-preview', {'fade-footer': block.truncated}])!= block.contentHTML
           +readMoreIfTruncated(block, block.roomId)
           footer.block-footer
             include ../partials/_vote_controls
   else
-    p No blocks found.
+    p= t('bestOf.labels.noBlocks')


### PR DESCRIPTION
– Add headingRoomPrefix/Suffix and room meta strings (EN/ES)
– Wire i18n in /rooms/:roomId/archive/best-of route
– Link only room name inside H1; export #i18n-bestOf/#i18n-lang
– Localize tabs, labels, dates; guard missing room links