### PR TITLE
feat(i18n/archive): localize date views, link room in header, and UTC-safe titles

### DIFF
--- a/i18n/en/archive.json
+++ b/i18n/en/archive.json
@@ -10,6 +10,12 @@
       "prev": "Previous",
       "next": "Next"
     },
+    "title": "📚 Browse Archives",
+    "titleRoom": "📚 {roomName} — Archives",
+    "roomViewing": "Viewing archive for room {roomName}",
+    "viewRoomLink": "View room",
+    "noContent": "No content available yet.",
+    "backToRoom": "← Back to Room Dashboard",
     "calendar": {
       "meta": {
         "description": "View all creative blocks posted in {month} {year}—from quick thoughts to deep reflections. Click any date to explore what was shared.",
@@ -19,11 +25,25 @@
       "prevLabel": "Archive for {month} {year}",
       "nextLabel": "Archive for {month} {year}"
     },
-    "title": "📚 Browse Archives",
-    "titleRoom": "📚 {roomName} — Archives",
-    "roomViewing": "Viewing archive for room {roomName}",
-    "viewRoomLink": "View room",
-    "noContent": "No content available yet.",
-    "backToRoom": "← Back to Room Dashboard"
+    "date": {
+      "meta": {
+        "titleSite": "Archive for {date}",
+        "titleRoom": "{roomName} — Archive for {date}",
+        "descriptionSite": "Explore the blocks written on {date}—from quiet notes to wild confessions.",
+        "descriptionRoom": "On {date}, writers in the {roomName} room left their mark—scroll through reflections, ideas, and expressions shared that day."
+      },
+      "heading": "Archive for {date}",
+      "empty": "No content found for this date.",
+      "labels": {
+        "createdBy": "Created by:",
+        "in": "in",
+        "on": "on {datetime}",
+        "unknownRoom": "Unknown Room"
+      },
+      "nav": {
+        "prevDay": "Previous day",
+        "nextDay": "Next day"
+      }
+    }
   }
 }

--- a/i18n/es/archive.json
+++ b/i18n/es/archive.json
@@ -10,6 +10,12 @@
       "prev": "Anterior",
       "next": "Siguiente"
     },
+    "title": "📚 Explorar archivos",
+    "titleRoom": "📚 {roomName} — Archivos",
+    "roomViewing": "Viendo el archivo de la sala {roomName}",
+    "viewRoomLink": "Ver sala",
+    "noContent": "Todavía no hay contenido.",
+    "backToRoom": "← Volver al panel de la sala",
     "calendar": {
       "meta": {
         "description": "Mira todos los bloques creativos publicados en {month} de {year}—desde ideas rápidas hasta reflexiones profundas. Haz clic en cualquier fecha para explorar lo compartido.",
@@ -19,11 +25,25 @@
       "prevLabel": "Archivo de {month} de {year}",
       "nextLabel": "Archivo de {month} de {year}"
     },
-    "title": "📚 Explorar archivos",
-    "titleRoom": "📚 {roomName} — Archivos",
-    "roomViewing": "Viendo el archivo de la sala {roomName}",
-    "viewRoomLink": "Ver sala",
-    "noContent": "Todavía no hay contenido.",
-    "backToRoom": "← Volver al panel de la sala"
+    "date": {
+      "meta": {
+        "titleSite": "Archivo de {date}",
+        "titleRoom": "{roomName} — Archivo de {date}",
+        "descriptionSite": "Explora los bloques escritos el {date}—de notas tranquilas a confesiones salvajes.",
+        "descriptionRoom": "El {date}, en la sala {roomName}, la gente dejó su huella—recorre ideas, reflexiones y expresiones compartidas."
+      },
+      "heading": "Archivo de {date}",
+      "empty": "No se encontró contenido para esta fecha.",
+      "labels": {
+        "createdBy": "Creado por:",
+        "in": "en",
+        "on": "el {datetime}",
+        "unknownRoom": "Sala desconocida"
+      },
+      "nav": {
+        "prevDay": "Día anterior",
+        "nextDay": "Día siguiente"
+      }
+    }
   }
 }

--- a/public/css/archive.css
+++ b/public/css/archive.css
@@ -58,6 +58,11 @@
   margin: 5px 0;
 }
 
+.room-link {
+  text-decoration: underline dotted;
+  color: #004187;
+}
+
 .archive-nav {
   display: flex;
   justify-content: space-between;

--- a/views/archive/date.pug
+++ b/views/archive/date.pug
@@ -14,6 +14,10 @@ block append head
   link(rel='stylesheet' href='/css/modal.css')
   link(rel='stylesheet' href='/css/translation-attribution.css')
   link(rel='stylesheet' href='/css/table-scroll-fade.css')
+  script#i18n-archive(type='application/json').
+    !{JSON.stringify(__i18n.archive || {})}
+  script#i18n-lang(type='application/json').
+    !{JSON.stringify(lang || 'en')}
   if prevDate
     link(rel="prev" href= roomId
       ? `/rooms/${roomId}/archive/${prevDate.split('-').join('/')}`
@@ -35,8 +39,8 @@ block content
     include ../partials/_archiveNav
     +archiveNav(
       prevDate
-        ? (roomId 
-            ? `/rooms/${roomId}/archive/${prevDate.split('-').join('/')}` 
+        ? (roomId
+            ? `/rooms/${roomId}/archive/${prevDate.split('-').join('/')}`
             : `/archive/${prevDate.split('-').join('/')}`
           )
         : null,
@@ -50,7 +54,13 @@ block content
       nextDate || '',
       'archive-nav'
     )
-    h1 Archive for #{date}
+    if roomId
+      h1
+        a.room-link(href=`/rooms/${roomId}` title=roomName)= roomName
+        |  — 
+        = t('archive.date.heading', { date })
+    else
+      h1= t('archive.date.heading', { date })
 
     if blocks.length
       ul.block-list
@@ -58,26 +68,26 @@ block content
           li.block-item
             div.block-main
               a.block-link(href=`/rooms/${block.roomId}/blocks/${block._id}`)= block.title
-              .block-meta 
-                | Created by: 
+              .block-meta
+                | #{t('archive.date.labels.createdBy')} 
                 a.user-profile-link(href=`/users/${block.creator}`)= block.creator
-                |  in 
-                a.room-link(href=`/rooms/${block.roomId}`)= block.roomId ? block.roomId : 'Unknown Room'
-                |  on #{new Date(block.createdAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+                |  #{t('archive.date.labels.in')} 
+                a.room-link(href=`/rooms/${block.roomId}`)= block.roomId ? block.roomId : t('archive.date.labels.unknownRoom')
+                |  #{t('archive.date.labels.on', { datetime: formatDateTime(block.createdAt) })}
               +translationAttribution(block)
               div(class=['content-preview', {'fade-footer': block.truncated}])!= block.contentHTML
             +readMoreIfTruncated(block, block.roomId)
-            footer.block-footer 
+            footer.block-footer
               include ../partials/_vote_controls
     else
-      p No content found for this date.
+      p= t('archive.date.empty')
   include ../partials/_pagination
   +pagination(
     currentPage,
     totalPages,
     roomId
-      ? `/rooms/${roomId}/archive/${date.split('-').join('/')}`
-      : `/archive/${date.split('-').join('/')}`
+      ? `/rooms/${roomId}/archive/${dateISO.split('-').join('/')}`
+      : `/archive/${dateISO.split('-').join('/')}`
   )
 
   include ../partials/_login_modal


### PR DESCRIPTION
¡Archive con sazón internacional! This refactor wires i18n for the archive-by-date views (site-wide and per-room), adds a linked room name in the H1 for room pages, switches copy to “blocks”, and ensures date titles are timezone-safe (UTC).

Why
- Consistent i18n across archive (calendar + date) under a single `archive` namespace.
- Better UX/SEO: localized titles/descriptions; room name visible & linkable in header.
- Avoid off-by-one date headings by formatting with `timeZone: 'UTC'`.
- Consistent terminology: “blocks” not “posts”.

What changed
- **i18n (en/es):**
  - Add `archive.date.*` keys (meta, heading, empty, labels, nav).
  - Switch wording from “posts” → “blocks”.
  - Keep everything nested in `archive.json` (same namespace used by calendar).
- **Routes:**
  - `/archive/:y/:m/:d` and `/rooms/:roomId/archive/:y/:m/:d`
    - Load `addI18n(['archive','translation','readMore'])`.
    - Build friendly date via `Intl.DateTimeFormat(lang, { dateStyle:'full', timeZone:'UTC' })`.
    - Provide `formatDateTime` helper for per-block timestamps (`dateStyle:'medium', timeStyle:'short'`).
    - Use `dateISO` for pagination URLs.
    - Per-room: resolve `roomDisplayName = displayName || name_i18n[lang] || name`.
- **Template (`views/archive/date.pug`):**
  - Export `#i18n-archive` and `#i18n-lang` for client helpers.
  - H1:
    - Site-wide: `Archive for {date}` (localized).
    - Per-room: `<a class="room-link">Room</a> — Archive for {date}`.
  - Localize meta labels: “Created by / in / on … / Unknown Room”.
  - Use `formatDateTime(block.createdAt)` instead of raw `toLocaleString`.
  - Pagination uses `dateISO`.
- **CSS (`public/css/archive.css`):**
  - Add `.room-link` style (underline dotted + brandy color).

Files touched
- `i18n/en/archive.json`
- `i18n/es/archive.json`
- `server/routes/archive.js`
- `views/archive/date.pug`
- `public/css/archive.css`

i18n keys added (EN)
- `archive.date.meta.titleSite`
- `archive.date.meta.titleRoom`
- `archive.date.meta.descriptionSite`
- `archive.date.meta.descriptionRoom`
- `archive.date.heading`
- `archive.date.empty`
- `archive.date.labels.createdBy`
- `archive.date.labels.in`
- `archive.date.labels.on`
- `archive.date.labels.unknownRoom`
- `archive.date.nav.prevDay`
- `archive.date.nav.nextDay`

i18n keys added (ES)
- `archive.date.meta.titleSite`
- `archive.date.meta.titleRoom`
- `archive.date.meta.descriptionSite`
- `archive.date.meta.descriptionRoom`
- `archive.date.heading`
- `archive.date.empty`
- `archive.date.labels.createdBy`
- `archive.date.labels.in`
- `archive.date.labels.on`
- `archive.date.labels.unknownRoom`
- `archive.date.nav.prevDay`
- `archive.date.nav.nextDay`

QA checklist
- [ ] `/archive/2025/09/06` shows localized title/description and H1 with correct date (UTC safe).
- [ ] `/rooms/:roomId/archive/2025/09/06` shows H1 with linked room name and localized date.
- [ ] Labels under each block are localized in EN/ES and show correct datetime formatting.
- [ ] Pagination links use `dateISO` and navigate correctly.
- [ ] Fallback room name works: `displayName || name_i18n[lang] || name`.
- [ ] No console logs left in production paths.

Backward compatibility
- No breaking changes. Calendar i18n untouched; we only added `archive.date.*`.
- Existing `addI18n(['archive'])` usage remains valid across pages.

Follow-ups (nice-to-have)
- Consider ARIA labels for prev/next day buttons using `archive.date.nav.*`.
- If other pages use `.room-link`, extract style to a shared stylesheet.

Co-authored-by: The Big Rob  🫶