### PR TITLE
Add Bahasa Indonesia UI localization

### DIFF
--- a/i18n/id/about.json
+++ b/i18n/id/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Tentang",
+      "description": "Apa itu Daily Page, cara kerjanya, dan mengapa dibuat sebagai sudut web yang lebih pelan dan ramah."
+    },
+    "title": "Tentang Daily Page",
+    "tagline": "Isi pikiranmu, bukan feed-mu.",
+    "mission": {
+      "h2": "Misi",
+      "p1": "Laboratorium menulis indie—dimulai dari ruang tamu saya, digerakkan oleh rasa ingin tahu pembaca.",
+      "p2": "Ini dibangun bukan untuk merusak otakmu, tetapi untuk menyehatkannya: tempat kamu bisa menulis perlahan, anonim jika mau, dan tidak perlu khawatir membuat siapa pun terkesan."
+    },
+    "how": {
+      "h2": "Cara Kerjanya",
+      "features": {
+        "rooms": {
+          "label": "Ruang",
+          "text": "adalah silo topik (bayangkan “subreddit, tetapi lebih ramah”)."
+        },
+        "blocks": {
+          "label": "Blok",
+          "text": "adalah posting kolaboratif—siapa pun (bahkan “anonim”) dapat membuatnya, mengeditnya sampai terkunci, dan memberi suara pada karya orang lain."
+        },
+        "privacy": {
+          "label": "Privasi & Berbagi",
+          "text": "Blok publik tampil di feed ruang. Blok privat tersembunyi sampai terkunci, tetapi kamu mendapat tautan berbagi untuk mengundang teman."
+        },
+        "markdown": {
+          "label": "Markdown & Media",
+          "text": "Kamu menulis dalam markdown, menyematkan gambar, dan menyunting bersama seperti di Google Docs."
+        },
+        "trends": {
+          "label": "Tren & Tag",
+          "text": "Tandai blokmu, pantau tren tag, dan temukan konten teratas (7 h / 30 h / sepanjang waktu)."
+        },
+        "streaks": {
+          "label": "Runtunan",
+          "text": "Jaga runtunan menulis harianmu tetap hidup—insentif terbaikmu untuk hadir setiap hari."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Bagaimana Kita Sampai di Sini",
+      "p1": "Pada 2018, saya membuat wiki berbasis tanggal untuk “halaman hari ini” dan melihat beberapa penulis reflektif mengubahnya menjadi ruang untuk pikiran mereka. Itu tidak pernah menjadi besar—tetapi menanam sebuah benih.",
+      "p2": "Maju cepat ke sekarang, dan Daily Page adalah benih itu yang tumbuh menjadi banyak ruang—web sosial yang tenang untuk introver, idealis, dan siapa pun yang merindukan tempo yang lebih pelan."
+    },
+    "next": {
+      "h2": "Selanjutnya",
+      "p1": "Kami baru mulai: sematan yang lebih kaya, statistik pengguna yang lebih dalam, papan peringkat reputasi, dan lebih banyak cara untuk menghargai kreasi yang penuh pikir.",
+      "p2": "Terima kasih sudah menjadi bagian dari eksperimen indie kecil ini."
+    },
+    "cta": {
+      "rooms": "Jelajahi Ruang",
+      "signup": "Bergabung dengan Komunitas"
+    }
+  }
+}

--- a/i18n/id/anonymousUser.json
+++ b/i18n/id/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Pengembara Anonim",
+      "description": "Tanpa profil. Tanpa masa lalu. Hanya suasana."
+    },
+    "ascii": {
+      "ariaLabel": "Seni ASCII makhluk jenaka dengan kutipan"
+    },
+    "header": {
+      "title": "Sang Anonim"
+    },
+    "body": {
+      "line1": "Kamu tersandung masuk ke kehampaan. Tidak ada yang bisa dilihat di sini—",
+      "line2": "hanya roh pengembara tanpa cerita."
+    },
+    "buttons": {
+      "home": "← Kembali ke beranda",
+      "signup": "Buat identitas"
+    }
+  }
+}

--- a/i18n/id/archive.json
+++ b/i18n/id/archive.json
@@ -1,0 +1,71 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arsip",
+      "description": "Jelajahi seluruh arsip berdasarkan bulan.",
+      "titleRoom": "Daily Page — Arsip · {roomName}",
+      "descriptionRoom": "Jelajahi tulisan lama di ruang {roomName}—bulan demi bulan. Lompat ke tanggal mana pun untuk melihat apa yang dibagikan orang lain di ruang ini dari waktu ke waktu."
+    },
+    "nav": {
+      "prev": "Sebelumnya",
+      "next": "Berikutnya"
+    },
+    "title": "📚 Jelajahi Arsip",
+    "titleRoom": "📚 {roomName} — Arsip",
+    "roomViewing": "Melihat arsip untuk ruang {roomName}",
+    "viewRoomLink": "Lihat ruang",
+    "noContent": "Belum ada konten.",
+    "backToRoom": "← Kembali ke Dasbor Ruang",
+    "calendar": {
+      "meta": {
+        "description": "Lihat semua blok kreatif yang diposting pada {month} {year}—dari pikiran singkat hingga refleksi mendalam. Klik tanggal mana pun untuk menjelajahi apa yang dibagikan.",
+        "descriptionRoom": "Lihat aktivitas kreatif di {roomName} selama {month} {year}. Pilih tanggal untuk menjelajahi blok yang dibagikan hari itu."
+      },
+      "title": "📆 Arsip untuk {month} {year}",
+      "prevLabel": "Arsip untuk {month} {year}",
+      "nextLabel": "Arsip untuk {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Arsip untuk {date}",
+        "titleRoom": "{roomName} — Arsip untuk {date}",
+        "descriptionSite": "Jelajahi blok yang ditulis pada {date}—dari catatan tenang hingga pengakuan liar.",
+        "descriptionRoom": "Pada {date}, para penulis di ruang {roomName} meninggalkan jejak mereka—gulir melalui refleksi, ide, dan ungkapan yang dibagikan hari itu."
+      },
+      "heading": "Arsip untuk {date}",
+      "empty": "Tidak ada konten untuk tanggal ini.",
+      "labels": {
+        "createdBy": "Dibuat oleh:",
+        "in": "di",
+        "on": "pada {datetime}",
+        "unknownRoom": "Ruang Tidak Dikenal"
+      },
+      "nav": {
+        "prevDay": "Hari sebelumnya",
+        "nextDay": "Hari berikutnya"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Semua Blok",
+        "descriptionRoom": "Telusuri setiap blok yang pernah diposting di ruang {roomName}. Urutkan berdasarkan tanggal, judul, atau suara untuk menjelajahi riwayatnya."
+      },
+      "header": {
+        "allBlocks": "— Semua Blok"
+      },
+      "sort": {
+        "label": "Urutkan berdasarkan",
+        "options": {
+          "date": "Tanggal",
+          "title": "Judul",
+          "votes": "Suara"
+        },
+        "submit": "Buka"
+      }
+    },
+    "pagination": {
+      "prev": "← Sebelumnya",
+      "next": "Berikutnya →"
+    }
+  }
+}

--- a/i18n/id/auth.json
+++ b/i18n/id/auth.json
@@ -1,0 +1,35 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Masuk",
+        "description": "Masuk ke akun Daily Page untuk melanjutkan perjalanan menulismu."
+      },
+      "heading": "Selamat Datang Kembali!",
+      "subheading": "Masuk ke akunmu untuk terus membagikan tulisan harianmu.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Nama pengguna atau Email",
+          "placeholder": "Masukkan nama pengguna atau emailmu"
+        },
+        "password": {
+          "label": "Kata Sandi",
+          "placeholder": "Masukkan kata sandimu"
+        }
+      },
+      "actions": {
+        "submit": "Masuk"
+      },
+      "feedback": {
+        "success": "Berhasil masuk! Mengalihkan...",
+        "failedGeneric": "Gagal masuk. Silakan coba lagi.",
+        "unexpected": "Terjadi kesalahan tak terduga. Silakan coba lagi."
+      },
+      "links": {
+        "forgotPassword": "Lupa kata sandi?",
+        "noAccount": "Belum punya akun?",
+        "signupHere": "Daftar di sini!"
+      }
+    }
+  }
+}

--- a/i18n/id/bestOf.json
+++ b/i18n/id/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Terbaik di Daily Page",
+      "description": "Blok yang paling disukai di Daily Page—lucu, jujur, puitis, atau sekadar aneh. Lihat yang menonjol selama hari, minggu, bulan terakhir, dan seterusnya.",
+      "titleRoom": "Terbaik dari {roomName}",
+      "descriptionRoom": "Temukan posting menonjol dari ruang {roomName}—yang paling disukai pembaca selama 24 jam, 7 hari, 30 hari terakhir, dan sepanjang waktu."
+    },
+    "heading": "🏆 Terbaik di Daily Page",
+    "headingRoomPrefix": "🏆 Terbaik dari ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 Jam",
+      "7d": "🚀 7 Hari",
+      "30d": "🌕 30 Hari",
+      "all": "👑 Sepanjang Waktu"
+    },
+    "labels": {
+      "createdBy": "Dibuat oleh:",
+      "inRoom": "di",
+      "onDate": "pada {date}",
+      "unknownRoom": "Ruang Tidak Dikenal",
+      "noBlocks": "Tidak ada blok ditemukan.",
+      "viewRoom": "Lihat ruang"
+    }
+  }
+}

--- a/i18n/id/blockCommon.json
+++ b/i18n/id/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Draf"
+    },
+    "deleteModal": {
+      "title": "Hapus Blok?",
+      "message": "Tindakan ini tidak dapat dibatalkan.",
+      "confirm": "Hapus",
+      "cancel": "Batal",
+      "closeAriaLabel": "Tutup"
+    },
+    "toasts": {
+      "deleteSuccess": "Blok berhasil dihapus!",
+      "deleteFailed": "Gagal menghapus blok."
+    }
+  }
+}

--- a/i18n/id/blockEditor.json
+++ b/i18n/id/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Kamu)"
+    },
+    "meta": {
+      "title": "Edit Blok - {blockTitle}",
+      "titleFallback": "Edit Blok"
+    },
+    "errors": {
+      "imageUrlRequired": "Masukkan URL gambar.",
+      "notFound": "Blok tidak ditemukan atau bukan milik ruang ini.",
+      "loadFailed": "Terjadi kesalahan saat memuat editor blok.",
+      "updateTitleFailed": "Kesalahan saat memperbarui judul."
+    },
+    "roomInfo": {
+      "label": "Ruang:"
+    },
+    "title": {
+      "placeholder": "Masukkan judul blok",
+      "editTooltip": "Edit Judul",
+      "lock": "Kunci Blok",
+      "delete": "Hapus Blok"
+    },
+    "description": {
+      "label": "Deskripsi",
+      "editTooltip": "Edit Deskripsi",
+      "placeholder": "Masukkan deskripsi",
+      "noDescriptionOwner": "Belum ada deskripsi...",
+      "noDescriptionViewer": "Tidak ada deskripsi...",
+      "save": "Simpan",
+      "cancel": "Batal",
+      "expand": "Perluas",
+      "collapse": "Ciutkan",
+      "updateError": "Kesalahan saat memperbarui deskripsi."
+    },
+    "status": {
+      "lastBackup": "Cadangan terakhir: {datetime}",
+      "lastBackupUnknown": "Cadangan terakhir: Tidak diketahui"
+    },
+    "peers": {
+      "label": "Rekan:"
+    },
+    "toasts": {
+      "blockLocked": "Blok ini telah dikunci!"
+    },
+    "editor": {
+      "placeholder": "Halaman kosong menunggu suaramu; menulislah tanpa takut."
+    },
+    "loading": {
+      "label": "Memuat",
+      "quote": "Biarkan dunia membakar lewat dirimu. Lemparkan cahaya prisma, putih membara, ke atas kertas.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Kamu belum menulis apa pun selama 5 menit. Klik OK untuk melanjutkan sesi; jika tidak, kamu akan dialihkan ke arsip.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Tautan Berbagi",
+      "copyTooltip": "Salin ke Clipboard",
+      "copied": "Tersalin!"
+    },
+    "toolbar": {
+      "insertImage": "Sisipkan Gambar",
+      "insertImageUrlPlaceholder": "Masukkan URL gambar",
+      "insertImageAltPlaceholder": "Teks alt (opsional)",
+      "insertImageConfirm": "Konfirmasi",
+      "insertImageCancel": "Batal"
+    },
+    "buttons": {
+      "downloadFile": "Unduh file"
+    },
+    "lockModal": {
+      "messageLine1": "Yakin ingin mengunci blok ini?",
+      "messageLine2": "Ini akan memfinalkannya dan mencegah pengeditan lebih lanjut.",
+      "confirm": "Kunci",
+      "cancel": "Batal",
+      "successToast": "Blok berhasil dikunci.",
+      "errorToast": "Kesalahan saat mengunci blok."
+    },
+    "tags": {
+      "headerWithTags": "Tag:",
+      "headerNoTags": "Belum ada tag! Tambahkan beberapa:",
+      "updateError": "Kesalahan saat memperbarui tag."
+    },
+    "fullBlock": {
+      "headingPrefix": "Maaf; blok \"{blockTitle}\" sekarang",
+      "headingStatus": "sudah penuh.",
+      "retryPrefix": "Silakan",
+      "retryLink": "coba blok lain",
+      "retrySuffix": "atau kembali lain waktu.",
+      "consolationPrefix": "Sambil menunggu, silakan baca",
+      "consolationBestOf": "beberapa blok favorit kami",
+      "consolationMiddle": "atau telusuri",
+      "consolationArchive": "arsip."
+    }
+  }
+}

--- a/i18n/id/blockList.json
+++ b/i18n/id/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "sepanjang waktu",
+      "days": "dalam {n} hari terakhir",
+      "day": "dalam 24 jam terakhir"
+    },
+    "createdBy": "Dibuat oleh:",
+    "on": "pada"
+  }
+}

--- a/i18n/id/blockTags.json
+++ b/i18n/id/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tag:",
+      "noTags": "Belum ada tag! Tambahkan beberapa:"
+    },
+    "input": {
+      "placeholder": "Tag baru",
+      "addButton": "Tambah"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/id/blockView.json
+++ b/i18n/id/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Blok - {blockTitle}",
+      "titleFallback": "Blok"
+    },
+    "labels": {
+      "room": "Ruang",
+      "author": "Penulis",
+      "created": "Dibuat",
+      "unknownAuthor": "Anonim",
+      "authorAvatarAlt": "avatar {username}",
+      "viewAuthorProfile": "Lihat profil {username}",
+      "lang": "Terjemahan: ",
+      "available": "tersedia"
+    },
+    "buttons": {
+      "edit": "Edit",
+      "deleteBlock": "Hapus Blok",
+      "share": "Bagikan",
+      "flagContent": "Laporkan Konten"
+    },
+    "description": {
+      "label": "Deskripsi",
+      "none": "Tidak ada deskripsi...",
+      "expand": "Perluas",
+      "collapse": "Ciutkan"
+    },
+    "editorial": {
+      "heading": "Panduan membaca",
+      "roleLabel": "Jenis bacaan",
+      "clusterLabel": "Panduan",
+      "sequence": "Bagian {sequence}",
+      "primaryPillarHeading": "Mulai di sini",
+      "relatedHeading": "Lanjut membaca",
+      "clusterHeading": "Lainnya dalam panduan ini",
+      "expandSection": "Tampilkan {count} lagi",
+      "collapseSection": "Tampilkan lebih sedikit",
+      "roleNames": {
+        "pillar": "Panduan inti",
+        "companion": "Bahasan mendalam",
+        "texture": "Latar belakang"
+      }
+    },
+    "comments": {
+      "heading": "Komentar",
+      "count": "{count} komentar",
+      "empty": "Belum ada yang membalas. Komentar akan muncul di sini ketika percakapan dimulai.",
+      "composer": {
+        "label": "Tambahkan komentar",
+        "placeholder": "Tulis komentar...",
+        "submit": "Kirim komentar",
+        "submitting": "Mengirim...",
+        "success": "Komentar diposting.",
+        "error": "Tidak dapat memposting komentarmu saat ini.",
+        "loginPrompt": "Masuk untuk bergabung dalam percakapan.",
+        "loginCta": "Masuk untuk berkomentar",
+        "verifyPrompt": "Verifikasi emailmu sebelum memposting komentar.",
+        "verifyCta": "Verifikasi email"
+      },
+      "sort": {
+        "label": "Urutkan",
+        "oldestFirst": "Terlama dulu",
+        "newestFirst": "Terbaru dulu"
+      },
+      "by": "Oleh",
+      "unknownAuthor": "Tidak diketahui",
+      "reply": {
+        "action": "Balas",
+        "label": "Tambahkan balasan",
+        "placeholder": "Tulis balasan...",
+        "submit": "Kirim balasan",
+        "submitting": "Mengirim...",
+        "success": "Balasan diposting.",
+        "error": "Tidak dapat memposting balasanmu saat ini.",
+        "cancel": "Batal",
+        "loginPrompt": "Masuk untuk membalas."
+      },
+      "manage": {
+        "edited": "Diedit",
+        "editAction": "Edit",
+        "deleteAction": "Hapus",
+        "deleteConfirm": "Hapus komentar ini? Ini juga akan menghapus semua balasan di bawahnya.",
+        "deleteSuccess": "Komentar dihapus.",
+        "deleteError": "Tidak dapat menghapus komentar ini saat ini.",
+        "forbidden": "Kamu hanya dapat mengelola komentarmu sendiri.",
+        "edit": {
+          "label": "Edit komentar",
+          "save": "Simpan",
+          "saving": "Menyimpan...",
+          "cancel": "Batal",
+          "success": "Komentar diperbarui.",
+          "error": "Tidak dapat memperbarui komentar ini saat ini."
+        }
+      },
+      "report": {
+        "action": "Laporkan",
+        "pending": "Melaporkan...",
+        "success": "Komentar dilaporkan.",
+        "error": "Tidak dapat melaporkan komentar ini saat ini.",
+        "ownError": "Kamu tidak dapat melaporkan komentarmu sendiri.",
+        "hidden": "Komentar disembunyikan setelah laporan.",
+        "reported": "Dilaporkan"
+      },
+      "deepLink": {
+        "focused": "Komentar tertaut",
+        "unavailable": "Komentar tertaut tidak lagi tersedia."
+      },
+      "loadMore": "Muat komentar lainnya",
+      "loading": "Memuat...",
+      "loadError": "Tidak dapat memuat komentar lainnya saat ini."
+    },
+    "share": {
+      "title": "Bagikan Blok ini",
+      "shareOn": "Bagikan di:",
+      "nativeText": "Lihat blok ini: {title}",
+      "alt": {
+        "facebook": "Logo Facebook",
+        "reddit": "Logo Reddit",
+        "whatsapp": "Logo WhatsApp",
+        "twitter": "Logo Twitter"
+      }
+    },
+    "errors": {
+      "notFound": "Blok tidak ditemukan atau bukan milik ruang ini.",
+      "loadFailed": "Kesalahan saat memuat tampilan blok."
+    }
+  }
+}

--- a/i18n/id/createBlock.json
+++ b/i18n/id/createBlock.json
@@ -1,0 +1,63 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Buat Blok Baru — Daily Page",
+      "description": "Mulai blok kreatif baru dengan tag, bahasa, dan visibilitas opsional."
+    },
+    "heading": "Buat Blok Baru",
+    "roomInfo": {
+      "roomLabel": "Ruang:",
+      "unavailable": "Informasi ruang tidak tersedia.",
+      "noDescription": "Tidak ada deskripsi."
+    },
+    "form": {
+      "title": {
+        "label": "Judul:",
+        "placeholder": {
+          "full": "mis. 'Mahakaryaku', 'Ide Terbaik yang Pernah Ada', 'Clickbait untuk Nerd'",
+          "short": "mis. 'Mahakaryaku'"
+        }
+      },
+      "description": {
+        "label": "Deskripsi (opsional):",
+        "placeholder": "Jelaskan kecemerlanganmu… atau langsung saja."
+      },
+      "initialContent": {
+        "label": "Konten Awal (opsional):",
+        "help": "Mulai menulis di sini atau tekan “Buat” untuk melanjutkan di halaman editor penuh, tempat kamu bisa menyematkan gambar dan berkolaborasi secara real time.",
+        "placeholder": "Mulai blokmu di sini, atau lanjutkan mengedit setelah dibuat…"
+      },
+      "visibility": {
+        "label": "Visibilitas:"
+      },
+      "submit": "Buat Blok"
+    },
+    "visibility": {
+      "public": {
+        "label": "Publik",
+        "title": "Dapat diedit siapa pun secara real time. Tidak perlu masuk.",
+        "inline": "Dapat diedit siapa pun secara real time. Tidak perlu masuk."
+      },
+      "private": {
+        "label": "Privat",
+        "title": "Hanya untuk pengguna yang masuk. Terlihat setelah pengeditan selesai.",
+        "inline": "Hanya untuk pengguna yang masuk. Terlihat setelah pengeditan selesai.",
+        "tooltip": "Blok privat hanya dapat diakses lewat undangan saat kamu bekerja, dan menjadi terlihat saat kamu selesai."
+      }
+    },
+    "advanced": {
+      "summary": "Opsi lanjutan",
+      "lang": { "label": "Bahasa:" },
+      "translate": {
+        "label": "Terjemahkan blok yang sudah ada (URL atau ID):",
+        "placeholder": "Tempel URL blok atau ID (opsional)",
+        "invalid": "Itu tidak terlihat seperti URL atau ID blok yang valid.",
+        "fetchError": "Tidak dapat mengambil info blok."
+      }
+    },
+    "messages": {
+      "langExists": "Terjemahan untuk bahasa itu sudah ada. Pilih bahasa lain.",
+      "genericError": "Ada yang salah. Silakan coba lagi."
+    }
+  }
+}

--- a/i18n/id/dashboard.json
+++ b/i18n/id/dashboard.json
@@ -1,0 +1,45 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Dasbor",
+      "description": "Dasbor Daily Page dan ringkasan akunmu."
+    },
+    "profile": {
+      "profilePicAlt": "Foto Profil",
+      "noBio": "Belum ada bio. Klik \"Edit\" untuk menambahkannya!",
+      "editBio": "Edit Bio",
+      "bioPlaceholder": "Masukkan biomu di sini",
+      "save": "Simpan",
+      "cancel": "Batal"
+    },
+    "activity": {
+      "title": "Aktivitas Terbaru",
+      "none": "Tidak ada aktivitas terbaru.",
+      "updatedOn": "Diperbarui pada {date}",
+      "viewAllBlocks": "Lihat Semua Blok"
+    },
+    "streak": {
+      "title": "Runtunan Menulis",
+      "line": "{days} hari berturut-turut! Teruskan!"
+    },
+    "starredRooms": {
+      "title": "Ruang Berbintang",
+      "none": "Kamu belum memberi bintang pada ruang mana pun. Mulai jelajahi untuk menemukan favoritmu!",
+      "viewAll": "Lihat Semua Ruang Berbintang",
+      "unnamedRoom": "Ruang Tanpa Nama"
+    },
+    "stats": {
+      "title": "Statistikmu",
+      "totalBlocks": "Total Blok Dibuat",
+      "collaborations": "Kolaborasi",
+      "votesGiven": "Suara Diberikan",
+      "daysActive": "Hari Aktif",
+      "viewDetailed": "Lihat Statistik Terperinci 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Gagal mengunggah foto profil. Silakan coba lagi.",
+      "uploadUnexpected": "Terjadi kesalahan tak terduga. Silakan coba lagi.",
+      "bioUpdateFailed": "Kesalahan saat memperbarui bio. Silakan coba lagi."
+    }
+  }
+}

--- a/i18n/id/detailedStats.json
+++ b/i18n/id/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Statistik Terperinci",
+      "description": "Rincian terperinci aktivitas Daily Page-mu."
+    },
+    "nav": {
+      "backToDashboard": "← Kembali ke Dasbor"
+    },
+    "header": {
+      "title": "📊 Ringkasan Statistikmu 📊"
+    },
+    "cards": {
+      "totalBlocks": "Total Blok Dibuat 📝",
+      "collaborations": "Kolaborasi 🤝",
+      "votesGiven": "Suara Diberikan 👍",
+      "daysActive": "Hari Aktif 📆"
+    },
+    "chart": {
+      "datasetLabel": "Statistikmu",
+      "labels": {
+        "blocksCreated": "Blok Dibuat",
+        "collaborations": "Kolaborasi",
+        "votesGiven": "Suara Diberikan",
+        "daysActive": "Hari Aktif"
+      }
+    }
+  }
+}

--- a/i18n/id/errors.json
+++ b/i18n/id/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ups! Ada yang salah.",
+      "message": "Terjadi kesalahan tak terduga. Silakan coba lagi nanti.",
+      "home": "Kembali ke Beranda"
+    },
+    "notFound": {
+      "title": "404 - Halaman Tidak Ditemukan",
+      "metaTitle": "Halaman Tidak Ditemukan",
+      "message": "Maaf, kami tidak dapat menemukan halaman yang kamu cari.",
+      "homePrefix": "Kamu bisa kembali ke",
+      "homeLink": "beranda",
+      "roomsPrefix": "atau melihat",
+      "roomsLink": "direktori ruang."
+    }
+  }
+}

--- a/i18n/id/flagModal.json
+++ b/i18n/id/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Laporkan Konten yang Tidak Pantas",
+    "fields": {
+      "reason": {
+        "label": "Alasan",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Menyinggung (ujaran kebencian atau hinaan)",
+          "inappropriate": "Tidak pantas (ketelanjangan, konten grafis, dll.)",
+          "other": "Lainnya"
+        }
+      },
+      "details": {
+        "label": "Detail (opsional)",
+        "placeholder": "Jelaskan apa yang kamu lihat…"
+      }
+    },
+    "buttons": {
+      "submit": "Kirim Laporan",
+      "cancel": "Batal"
+    },
+    "toasts": {
+      "success": "Laporan dikirim—terima kasih!",
+      "failed": "Gagal mengirim laporan."
+    }
+  }
+}

--- a/i18n/id/forgotPassword.json
+++ b/i18n/id/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Reset Kata Sandi",
+      "description": "Minta tautan reset untuk akun Daily Page-mu."
+    },
+    "header": {
+      "title": "Lupa Kata Sandi?",
+      "subtitle": "Masukkan emailmu dan kami akan mengirim tautan reset."
+    },
+    "form": {
+      "email": {
+        "label": "Alamat Email",
+        "placeholder": "Masukkan emailmu"
+      },
+      "submit": "Minta Reset Kata Sandi"
+    },
+    "feedback": {
+      "successGeneric": "Jika email itu ada, tautan reset telah dikirim.",
+      "missingEmail": "Email wajib diisi.",
+      "genericError": "Ada yang salah. Silakan coba lagi.",
+      "unexpectedError": "Terjadi kesalahan tak terduga. Silakan coba lagi."
+    },
+    "email": {
+      "subject": "Reset kata sandi Daily Page-mu",
+      "heading": "Permintaan Reset Kata Sandi",
+      "headingWithName": "Permintaan Reset Kata Sandi, {username}",
+      "body": "Klik tautan di bawah untuk mereset kata sandimu.",
+      "cta": "Reset Kata Sandi Saya",
+      "expires": "Tautan ini kedaluwarsa dalam {hours} jam.",
+      "ignore": "Jika kamu tidak meminta reset kata sandi, kamu dapat mengabaikan email ini."
+    }
+  }
+}

--- a/i18n/id/home.json
+++ b/i18n/id/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Blok Teratas dalam 24 Jam Terakhir",
+      "description": "Daily Page adalah situs menulis indie minimalis tempat siapa pun dapat memposting pikiran kreatif, kenangan, atau eksperimen—satu blok setiap kali. Jelajahi ide baru, bergabung dengan ruang, dan sumbangkan suaramu."
+    },
+    "hero": {
+      "eyebrow": "Tempat tenang untuk menulis, membaca, dan kembali",
+      "title": "Selamat datang di Daily Page!",
+      "subtitle": "Jelajahi blok paling populer dari 24 jam terakhir.",
+      "ctaPrefix": "Merasa terinspirasi?",
+      "cta": "Bergabung dengan ruang",
+      "ctaSuffix": "dan buat blokmu sendiri!"
+    },
+    "stats": {
+      "blocks": "Blok",
+      "rooms": "Ruang",
+      "tags": "Tag",
+      "collabsToday": "Kolaborasi Hari Ini"
+    },
+    "activity": {
+      "title": "Langsung di Daily Page",
+      "subtitle": "Percakapan dan reaksi segar, semua dalam satu pandangan.",
+      "fallbackActor": "Seseorang",
+      "inRoom": "di",
+      "comments": {
+        "title": "Komentar terbaru",
+        "more": "Cari diskusi",
+        "commentVerb": "mengomentari",
+        "replyVerb": "membalas di",
+        "empty": "Belum ada komentar terbaru. Percakapan berikutnya bisa dimulai dengan blokmu."
+      },
+      "reactions": {
+        "title": "Reaksi terbaru",
+        "more": "Telusuri blok teratas",
+        "empty": "Belum ada reaksi terbaru. Posting yang bagus bisa segera menghidupkannya.",
+        "types": {
+          "heart": "memberi hati pada",
+          "leaf": "bereaksi dengan daun pada",
+          "wow": "bereaksi wow pada",
+          "laugh": "tertawa pada"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Ruang Unggulan",
+      "roomInfoDays": "Aktivitas selama {days} hari terakhir: {blocks} blok, {votes} suara.",
+      "roomInfo24h": "Aktivitas selama 24 jam terakhir: {blocks} blok, {votes} suara.",
+      "checkItOut": "Lihat",
+      "blockRibbon": "★ Blok Unggulan",
+      "votes": "{n} suara",
+      "noContent": "(Tidak ada konten...)",
+      "viewBlock": "Lihat Blok"
+    },
+    "trendingTags": {
+      "title": "Tag Tren",
+      "suffixDays": "({days} hari terakhir)",
+      "suffixAllTime": "(sepanjang waktu)",
+      "blocks": "{n} blok",
+      "votes": "{n} suara",
+      "empty": "Belum ada tag tren. Jadilah yang pertama menandai sesuatu yang keren!"
+    },
+    "trendingBlocks": {
+      "title": "Blok Tren",
+      "suffixDays": "({days} hari terakhir)",
+      "createdBy": "Dibuat oleh:",
+      "in": "di",
+      "on": "pada",
+      "unknownRoom": "Ruang Tidak Dikenal",
+      "empty24h": "Belum ada blok dalam 24 jam terakhir. Cek lagi segera, kawan!"
+    }
+  }
+}

--- a/i18n/id/layout.json
+++ b/i18n/id/layout.json
@@ -1,0 +1,18 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Selamat datang, Pengguna!",
+    "logout": "Keluar",
+    "login": "Masuk / Daftar",
+    "language": "Bahasa",
+    "openMenu": "Buka menu utama",
+    "closeMenu": "Tutup menu utama",
+    "privacy": "Kebijakan Privasi",
+    "uiFallbackNotice": "{requested} belum diterjemahkan. Menampilkan {current} untuk saat ini.",
+    "copyButton": {
+      "copy": "Salin",
+      "copied": "Tersalin!"
+    },
+    "copyright": "© {year}"
+  }
+}

--- a/i18n/id/modals.json
+++ b/i18n/id/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Silakan Masuk",
+      "message": "Kamu perlu masuk untuk melanjutkan.",
+      "messageWithAction": "Kamu perlu masuk untuk {action}.",
+      "cta": "Masuk"
+    },
+    "actions": {
+      "voteOnBlock": "memberi suara pada blok",
+      "starRoom": "memberi bintang pada ruang ini",
+      "reactToBlock": "bereaksi pada posting ini",
+      "commentOnBlock": "mengomentari blok ini",
+      "reportComment": "melaporkan komentar ini"
+    },
+    "errors": {
+      "starToggleFail": "Gagal memperbarui status bintang. Silakan coba lagi."
+    }
+  }
+}

--- a/i18n/id/nav.json
+++ b/i18n/id/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Beranda",
+    "rooms": "Ruang",
+    "tags": "Tag",
+    "archive": "Arsip",
+    "search": "Cari",
+    "bestOf": "Terbaik",
+    "about": "Tentang",
+    "support": "Dukungan",
+    "otherProjects": "Proyek Lain",
+    "auth": {
+      "welcomePrefix": "Selamat datang, ",
+      "welcomeFallbackUser": "kamu",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Dasbor"
+  }
+}

--- a/i18n/id/notifications.json
+++ b/i18n/id/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Notifikasi",
+      "openMenu": "Buka notifikasi",
+      "loading": "Memuat notifikasi...",
+      "error": "Tidak dapat memuat notifikasi saat ini.",
+      "empty": "Belum ada notifikasi.",
+      "markRead": "Tandai dibaca",
+      "fallbackActor": "Seseorang",
+      "fallbackBlockTitle": "blokmu",
+      "item": {
+        "blockComment": "{actorUsername} mengomentari blokmu \"{blockTitle}\".",
+        "commentReply": "{actorUsername} membalas komentarmu di \"{blockTitle}\".",
+        "unknown": "Notifikasi"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Komentar baru di \"{blockTitle}\"",
+        "heading": "Komentar baru di blokmu",
+        "headingWithName": "Hai {username},",
+        "body": "<strong>{actorUsername}</strong> mengomentari blokmu <strong>{blockTitle}</strong>.",
+        "cta": "Lihat percakapan di Daily Page",
+        "fallbackActor": "Seseorang",
+        "fallbackBlockTitle": "blokmu"
+      },
+      "commentReply": {
+        "subject": "Balasan baru di \"{blockTitle}\"",
+        "heading": "Balasan baru untuk komentarmu",
+        "headingWithName": "Hai {username},",
+        "body": "<strong>{actorUsername}</strong> membalas komentarmu di <strong>{blockTitle}</strong>.",
+        "cta": "Lihat percakapan di Daily Page",
+        "fallbackActor": "Seseorang",
+        "fallbackBlockTitle": "blokmu"
+      }
+    }
+  }
+}

--- a/i18n/id/privacy.json
+++ b/i18n/id/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Kebijakan Privasi",
+      "description": "Bagaimana Daily Page mengumpulkan, menggunakan, dan melindungi datamu, dengan bahasa sederhana."
+    },
+    "title": "Kebijakan Privasi",
+    "lastUpdated": "Terakhir diperbarui: {date}",
+    "intro": {
+      "h2": "Pengantar",
+      "p1": "Daily Page (\"kami\") mengoperasikan situs web dailypage.org (selanjutnya disebut \"Layanan\").",
+      "p2": "Halaman ini memberi tahu kamu tentang kebijakan kami terkait pengumpulan, penggunaan, dan pengungkapan data pribadi saat kamu menggunakan Layanan kami."
+    },
+    "collection": {
+      "h2": "Pengumpulan dan Penggunaan Informasi",
+      "p": "Kami mengumpulkan data pribadi minimal untuk meningkatkan dan menyediakan Layanan kami. Ini mencakup alamat email untuk pengelolaan akun dan konten yang dikirim secara sukarela oleh pengguna."
+    },
+    "usage": {
+      "h2": "Penggunaan Data",
+      "p": "Data yang dikumpulkan digunakan semata-mata untuk autentikasi akun, moderasi konten, dan meningkatkan pengalaman pengguna."
+    },
+    "storage": {
+      "h2": "Penyimpanan & Keamanan Data",
+      "p": "Datamu disimpan dengan aman dan tidak pernah dibagikan atau dijual kepada pihak ketiga tanpa persetujuan eksplisit, kecuali diwajibkan oleh hukum."
+    },
+    "cookies": {
+      "h2": "Cookie",
+      "p": "Kami menggunakan cookie hanya untuk pengelolaan sesi dan meningkatkan pengalaman pengguna. Kamu dapat menonaktifkan cookie melalui pengaturan browsermu."
+    },
+    "rights": {
+      "h2": "Hakmu",
+      "p": "Kamu dapat meminta penghapusan atau perubahan data pribadimu kapan saja dengan menghubungi kami."
+    },
+    "changes": {
+      "h2": "Perubahan pada Kebijakan Privasi Ini",
+      "p": "Kami dapat memperbarui Kebijakan Privasi kami dari waktu ke waktu. Perubahan akan diposting di halaman ini."
+    },
+    "contact": {
+      "h2": "Hubungi Kami",
+      "p": "Untuk pertanyaan tentang Kebijakan Privasi ini, hubungi kami di:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/id/profile.json
+++ b/i18n/id/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Profil {username}",
+      "descriptionUser": "Lihat aktivitas terbaru, ruang berbintang, dan statistik {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Foto profil",
+      "noBio": "(Tidak ada bio.)"
+    },
+    "activity": {
+      "title": "Aktivitas Terbaru",
+      "updatedOn": "Diperbarui pada {date}",
+      "none": "Tidak ada aktivitas terbaru.",
+      "viewAllBlocks": "Lihat Semua Blok"
+    },
+    "starredRooms": {
+      "title": "Ruang Berbintang",
+      "none": "Belum ada ruang berbintang.",
+      "unnamedRoom": "Ruang Tanpa Nama"
+    },
+    "stats": {
+      "title": "Statistik Pengguna",
+      "totalBlocks": "Total Blok Dibuat",
+      "collaborations": "Kolaborasi",
+      "daysActive": "Hari Aktif"
+    }
+  }
+}

--- a/i18n/id/random.json
+++ b/i18n/id/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Proyek Lain",
+      "description": "Jelajahi jurnal baseball, eksperimen menulis acak, dan proyek sampingan lain dari Daily Page."
+    },
+    "title": "Proyek Lain",
+    "tagline": "Sudut nyaman untuk eksperimen dan misi sampingan.",
+    "links": {
+      "baseball": "📖 Jurnal Baseball",
+      "randomWriter": "🎲 Penulis Acak"
+    },
+    "cta": {
+      "backToRooms": "Kembali ke Ruang Utama"
+    }
+  }
+}

--- a/i18n/id/randomWriter.json
+++ b/i18n/id/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Penulis Acak",
+      "description": "Buat aliran teks semu acak tanpa akhir untuk bersenang-senang, inspirasi, atau kekacauan."
+    },
+    "title": "Penulis Acak",
+    "buttons": {
+      "clear": "Bersihkan",
+      "stop": "Berhenti menulis",
+      "start": "Mulai menulis"
+    }
+  }
+}

--- a/i18n/id/reactions.json
+++ b/i18n/id/reactions.json
@@ -1,0 +1,7 @@
+{
+    "reactions": {
+        "aria": "Reaksi {emoji}: {count}",
+        "loginToReact": "Masuk untuk bereaksi",
+        "countsLabel": "Reaksi"
+    }
+}

--- a/i18n/id/readMore.json
+++ b/i18n/id/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Selengkapnya...",
+    "aria": "Baca blok lengkap: {title}"
+  }
+}

--- a/i18n/id/resetPassword.json
+++ b/i18n/id/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Reset Kata Sandimu",
+      "description": "Atur kata sandi baru untuk akunmu."
+    },
+    "header": {
+      "title": "Reset Kata Sandimu",
+      "subtitle": "Pilih kata sandi baru untuk mendapatkan akses kembali."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Kata Sandi Baru",
+        "placeholder": "Masukkan kata sandi baru"
+      },
+      "submit": "Atur Kata Sandi Baru"
+    },
+    "feedback": {
+      "missingToken": "Token hilang atau tidak valid.",
+      "missingFields": "Token dan kata sandi baru wajib diisi.",
+      "invalidOrExpired": "Token tidak valid atau kedaluwarsa.",
+      "success": "Kata sandi berhasil diperbarui!",
+      "genericError": "Ada yang salah. Silakan coba lagi.",
+      "unexpectedError": "Terjadi kesalahan tak terduga. Silakan coba lagi."
+    }
+  }
+}

--- a/i18n/id/roomDashboard.json
+++ b/i18n/id/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Jelajahi blok terbaru dan yang sedang dikerjakan di {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Jelajahi:",
+      "allBlocks": "🗂️ Semua blok",
+      "browseByDate": "🗓️ Berdasarkan tanggal",
+      "bestOf": "🏅 Terbaik",
+      "searchInRoom": "🔎 Cari"
+    },
+    "actions": {
+      "createBlock": "Buat Blok",
+      "starTitle": "Beri bintang pada ruang ini",
+      "unstarTitle": "Hapus bintang dari ruang ini"
+    },
+    "tabs": {
+      "locked": "Blok Terkunci",
+      "inProgress": "Blok Sedang Dikerjakan"
+    },
+    "sections": {
+      "lockedHeader": "Blok terkunci",
+      "inProgressHeader": "Blok sedang dikerjakan"
+    },
+    "editorial": {
+      "heading": "Panduan unggulan",
+      "description": "Mulai di sini dengan panduan unggulan yang dikurasi untuk ruang ini.",
+      "roleNames": {
+        "pillar": "Panduan inti",
+        "companion": "Panduan membaca",
+        "texture": "Panduan latar belakang"
+      }
+    },
+    "empty": {
+      "noDescription": "Tidak ada deskripsi.",
+      "noLocked": "Belum ada blok terkunci! Blok terkunci otomatis setelah 1 jam tidak aktif.",
+      "noInProgress": "Belum ada blok yang sedang dikerjakan! Saatnya memulai satu.",
+      "noBlocks": "Belum ada blok! Buat yang pertama dan tinggalkan jejakmu. 😎"
+    }
+  }
+}

--- a/i18n/id/roomsDirectory.json
+++ b/i18n/id/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Direktori Ruang",
+      "description": "Setiap ruang adalah pintu menuju dunia yang berbeda. Masuklah, bagikan ceritamu, dan bergabung dengan orang lain untuk membangun sesuatu yang indah."
+    },
+    "eyebrow": "Temukan sudutmu",
+    "heading": "Direktori Ruang",
+    "intro": "Mulailah dari ruang yang terasa hidup saat ini, atau jelajahi berdasarkan topik sampai sesuatu terasa pas. Setiap ruang adalah prompt menulis, fandom, atau obsesi bersama yang berbeda dan menunggu suaramu.",
+    "empty": "Tidak ada ruang yang tersedia saat ini. Cek lagi nanti!",
+    "jumpToActive": "Lihat ruang aktif",
+    "jumpToTopics": "Telusuri berdasarkan topik",
+    "statsLabel": "Sorotan direktori ruang",
+    "liveNow": "Aktif sekarang",
+    "recentlyActive": "Baru Aktif",
+    "recentlyActiveSubtitle": "Cara tercepat menemukan ruang yang sedang berisi orang saat ini.",
+    "browseByTopic": "Telusuri berdasarkan topik",
+    "topicSubtitle": "Buka topik untuk menjelajahi ruang-ruangnya.",
+    "roomCount": "{count} ruang",
+    "stats": {
+      "rooms": "ruang untuk dijelajahi",
+      "topics": "kelompok topik",
+      "active": "pilihan aktif"
+    },
+    "activeUsers": "Pengguna Aktif: {count}",
+    "visitRoom": "Kunjungi Ruang",
+    "close": "Tutup",
+    "noTitle": "Tidak Ada Judul",
+    "noDescription": "Tidak Ada Deskripsi"
+  }
+}

--- a/i18n/id/search.json
+++ b/i18n/id/search.json
@@ -1,0 +1,23 @@
+{
+    "search": {
+        "meta": {
+            "title": "Cari",
+            "description": "Cari blok publik."
+        },
+        "title": "Cari",
+        "placeholder": "Cari blok...",
+        "hint": "Ketik setidaknya 2 karakter untuk mencari.",
+        "noResults": "Tidak ada hasil ditemukan.",
+        "untitled": "Tanpa judul",
+        "votesTitle": "Suara",
+        "pageLabel": "Halaman",
+        "filters": {
+            "inRoom": "Di ruang"
+        },
+        "buttons": {
+            "search": "Cari",
+            "prev": "Sebelumnya",
+            "next": "Berikutnya"
+        }
+    }
+}

--- a/i18n/id/signup.json
+++ b/i18n/id/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Buat Akun",
+      "description": "Daftar ke Daily Page untuk mengakses semua fitur."
+    },
+    "header": {
+      "title": "Buat Akunmu",
+      "subtitle": "Bergabunglah dengan Daily Page untuk mulai membuat dan membagikan tulisan harianmu!"
+    },
+    "form": {
+      "email": {
+        "label": "Email",
+        "placeholder": "Masukkan emailmu"
+      },
+      "username": {
+        "label": "Nama Pengguna",
+        "placeholder": "Masukkan nama penggunamu"
+      },
+      "password": {
+        "label": "Kata Sandi",
+        "placeholder": "Masukkan kata sandi"
+      },
+      "submit": "Daftar",
+      "feedback": {
+        "success": "Formulir berhasil dikirim!",
+        "successCreatedVerify": "Akun berhasil dibuat! Silakan cek emailmu untuk memverifikasi akun.",
+        "genericError": "Gagal membuat akun. Silakan coba lagi.",
+        "unexpectedError": "Terjadi kesalahan tak terduga. Silakan coba lagi."
+      }
+    }
+  }
+}

--- a/i18n/id/starredRooms.json
+++ b/i18n/id/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Semua Ruang Berbintang",
+      "description": "Daftar semua ruang yang kamu beri bintang."
+    },
+    "nav": {
+      "backToDashboard": "← Kembali ke Dasbor"
+    },
+    "header": {
+      "title": "🌟 Semua Ruang Berbintangmu 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Ruang Tanpa Nama",
+      "noDescription": "Tidak ada deskripsi."
+    },
+    "empty": {
+      "message": "Kamu belum memberi bintang pada ruang mana pun!"
+    }
+  }
+}

--- a/i18n/id/support.json
+++ b/i18n/id/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Dukungan",
+      "description": "Cara menghubungi kami, melaporkan masalah, meminta fitur atau ruang, dan mendukung Daily Page secara finansial."
+    },
+    "contact": {
+      "h1": "★ Saya ingin mengajukan pertanyaan, melaporkan masalah, atau meminta fitur.",
+      "p1": {
+        "before": "Jika kamu lebih suka menggunakan GitHub, silakan cek",
+        "link": "issue proyek ini",
+        "after": "dan tambahkan suaramu. Pull request juga tentu diterima."
+      },
+      "p2": {
+        "before": "Atau,",
+        "link": "kirim email",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Saya ingin mendukung proyek ini melalui kontribusi.",
+      "p1": {
+        "before": "Terima kasih sebelumnya karena mendanai proyek ini. Silakan kirim pembayaran dengan aman melalui",
+        "paypal": "PayPal",
+        "middle": "atau, jika kamu mau,",
+        "amazon": "pesan beberapa kantong mainan yang saya jual di Amazon",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Saya ingin meminta ruang baru.",
+      "form": {
+        "nameLabel": "Nama Ruang",
+        "topicLabel": "Topik (opsional)",
+        "descriptionLabel": "Deskripsi",
+        "submit": "Kirim Permintaan",
+        "success": "Permintaan berhasil dikirim!",
+        "errorGeneric": "Gagal mengirim permintaan. Silakan coba lagi.",
+        "errorUnexpected": "Terjadi kesalahan tak terduga. Silakan coba lagi."
+      }
+    }
+  }
+}

--- a/i18n/id/tags.json
+++ b/i18n/id/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Ikhtisar Tag",
+      "description": "Telusuri semua tag yang digunakan di Daily Page, dengan filter cepat berdasarkan waktu."
+    },
+    "title": "Ikhtisar Tag",
+    "intro": "Jelajahi semua tag yang digunakan di Daily Page.",
+    "tagCloudTitle": "Awan Tag",
+    "timeframe": {
+      "last24h": "24 Jam Terakhir",
+      "last7d": "7 Hari Terakhir",
+      "last30d": "30 Hari Terakhir",
+      "all": "Sepanjang Waktu"
+    },
+    "error": {
+      "loading": "Kesalahan saat memuat ikhtisar tag"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Blok yang diberi tag"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Total blok dengan",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Dibuat oleh:",
+        "inRoom": "di",
+        "unknownRoom": "Ruang Tidak Dikenal",
+        "onDate": "pada"
+      },
+      "chart": {
+        "label": "Blok Dibuat dari Waktu ke Waktu"
+      },
+      "empty": {
+        "message": "Belum ada blok dengan tag ini. Mungkin kamu harus membuat yang pertama? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Kesalahan saat memuat halaman tag"
+      }
+    }
+  }
+}

--- a/i18n/id/translation.json
+++ b/i18n/id/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Diterjemahkan dari",
+    "see": "lihat",
+    "originalBlock": "blok asli"
+  }
+}

--- a/i18n/id/userBlocks.json
+++ b/i18n/id/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Blokmu",
+      "description": "Telusuri dan urutkan semua blok yang kamu buat atau kerjakan bersama."
+    },
+    "header": {
+      "dashboardLink": "Dasbormu",
+      "profileLink": "Profil {username}",
+      "allBlocks": "Semua Blok"
+    },
+    "empty": "Belum ada blok.",
+    "pagination": {
+      "prev": "← Sebelumnya",
+      "next": "Berikutnya →"
+    },
+    "titleUser": "Blok {username}"
+  }
+}

--- a/i18n/id/verifyEmail.json
+++ b/i18n/id/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+    "verifyEmail": {
+        "meta": {
+            "title": "Verifikasi Email",
+            "description": "Verifikasi alamat emailmu untuk Daily Page."
+        },
+        "header": {
+            "title": "Memverifikasi emailmu..."
+        },
+        "status": {
+            "checking": "Memeriksa token, harap tunggu...",
+            "missingToken": "Token verifikasi hilang atau tidak valid.",
+            "genericFailure": "Verifikasi gagal.",
+            "unexpectedError": "Terjadi kesalahan tak terduga.",
+            "success": "Akunmu berhasil diverifikasi!",
+            "invalidOrExpired": "Token verifikasi tidak valid atau kedaluwarsa."
+        },
+        "verificationMsg": {
+            "subject": "Verifikasi akun Daily Page-mu ✨",
+            "heading": "Selamat datang di Daily Page, {username}!",
+            "body": "Silakan verifikasi emailmu dengan mengeklik di bawah:",
+            "cta": "Verifikasi Alamat Email",
+            "expires": "Tautan ini kedaluwarsa dalam {hours} jam."
+        }
+    }
+}

--- a/i18n/id/voteControls.json
+++ b/i18n/id/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Naikkan suara",
+    "downvote": "Turunkan suara",
+    "errors": {
+      "failed": "Gagal menyimpan suaramu."
+    }
+  }
+}

--- a/server/db/notificationService.js
+++ b/server/db/notificationService.js
@@ -91,7 +91,7 @@ async function sendCommentNotificationEmail({
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
   const uiLang = block.lang || 'en';
   const blockUrl = `${baseUrl}/${uiLang}${canonicalCommentPath(block, comment._id || comment.id)}`;
-  const emailLang = ['en', 'es', 'fr'].includes(block.lang) ? block.lang : 'en';
+  const emailLang = ['en', 'es', 'fr', 'ru', 'id'].includes(block.lang) ? block.lang : 'en';
 
   const { subject, html } = await buildCommentNotificationEmail({
     uiLang: emailLang,

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -13,7 +13,7 @@ import {
 } from '../db/blockService.js';
 import { getTotalRooms } from '../db/roomService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -56,4 +56,6 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'en' }).catch(console.error), 1_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'es' }).catch(console.error), 1_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'fr' }).catch(console.error), 2_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'ru' }).catch(console.error), 2_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'id' }).catch(console.error), 3_000);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary
- Adds a complete `i18n/id` locale tree translated from English for Bahasa Indonesia
- Registers `id` as a fully supported UI locale instead of fallback-only
- Enables Indonesian hreflang, home cache warming, and localized comment notification emails
- Aligns existing Russian full-locale support in the same support lists

## Validation
- Parsed all locale JSON successfully
- Verified `i18n/id` matches `i18n/en` file-for-file and key-for-key
- Verified interpolation placeholders match English
- Ran `npx jasmine`, but the suite currently fails before running because `spec/broadcastSpec.js` imports `lib/broadcast` without an ESM-resolvable extension
