### PR TITLE
Add German UI locale support

### DIFF
--- a/i18n/de/about.json
+++ b/i18n/de/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Uber uns",
+      "description": "Was Daily Page ist, wie es funktioniert und warum es als langsamere, freundlichere Ecke des Webs entstanden ist."
+    },
+    "title": "Uber Daily Page",
+    "tagline": "Nahre deinen Geist, nicht deinen Feed.",
+    "mission": {
+      "h2": "Auftrag",
+      "p1": "Ein unabhangiges Schreiblabor - begonnen in meinem Wohnzimmer, angetrieben von der Neugier der Leser.",
+      "p2": "Es ist nicht gebaut, um dein Gehirn zu vernebeln, sondern um es zu nahren: ein Ort, an dem du langsam schreiben kannst, anonym, wenn du magst, und ohne Sorge, jemanden beeindrucken zu mussen."
+    },
+    "how": {
+      "h2": "So funktioniert es",
+      "features": {
+        "rooms": {
+          "label": "Raume",
+          "text": "sind Themenbereiche (denk an \"Subreddit, aber freundlicher\")."
+        },
+        "blocks": {
+          "label": "Blocke",
+          "text": "sind kollaborative Beitrage - jede Person, sogar anonym, kann einen erstellen, ihn bis zur Sperrung bearbeiten und fur andere abstimmen."
+        },
+        "privacy": {
+          "label": "Datenschutz und Teilen",
+          "text": "Offentliche Blocke erscheinen im Feed des Raums. Private Blocke bleiben bis zur Sperrung verborgen, aber du erhaltst einen Link zum Teilen, um Freunde einzuladen."
+        },
+        "markdown": {
+          "label": "Markdown und Medien",
+          "text": "Du schreibst in Markdown, bettest Bilder ein und arbeitest gemeinsam wie in Google Docs."
+        },
+        "trends": {
+          "label": "Trends und Tags",
+          "text": "Tagge deinen Block, verfolge Tag-Trends und entdecke Top-Inhalte (7 T / 30 T / gesamte Zeit)."
+        },
+        "streaks": {
+          "label": "Serien",
+          "text": "Halte deine tagliche Schreibserie am Leben - dein bester Anreiz, jeden Tag aufzutauchen."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Wie wir hierher gekommen sind",
+      "p1": "2018 baute ich ein datumsbasiertes Wiki fur die \"heutige Seite\" und sah zu, wie einige nachdenkliche Schreibende daraus einen Ort fur ihre Gedanken machten. Es wurde nie riesig, aber es pflanzte einen Samen.",
+      "p2": "Heute ist aus diesem Samen Daily Page mit vielen Raumen geworden - ein ruhiges soziales Web fur Introvertierte, Idealisten und alle, die sich ein langsameres Tempo wunschen."
+    },
+    "next": {
+      "h2": "Was als Nachstes kommt",
+      "p1": "Wir fangen gerade erst an: reichhaltigere Einbettungen, tiefere Nutzerstatistiken, Reputations-Ranglisten und mehr Moglichkeiten, durchdachtes Schaffen zu belohnen.",
+      "p2": "Danke, dass du Teil dieses kleinen Indie-Experiments bist."
+    },
+    "cta": {
+      "rooms": "Raume entdecken",
+      "signup": "Der Community beitreten"
+    }
+  }
+}

--- a/i18n/de/anonymousUser.json
+++ b/i18n/de/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Der anonyme Wanderer",
+      "description": "Kein Profil. Keine Vergangenheit. Nur Vibes."
+    },
+    "ascii": {
+      "ariaLabel": "ASCII-Kunst eines verspielten Wesens mit Zitat"
+    },
+    "header": {
+      "title": "Der Anonyme"
+    },
+    "body": {
+      "line1": "Du bist ins Leere gestolpert. Hier gibt es nichts zu sehen -",
+      "line2": "nur einen wandernden Geist ohne Geschichte."
+    },
+    "buttons": {
+      "home": "← Zur Startseite",
+      "signup": "Identitat erstellen"
+    }
+  }
+}

--- a/i18n/de/archive.json
+++ b/i18n/de/archive.json
@@ -1,0 +1,71 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Archiv",
+      "description": "Durchsuche das gesamte Archiv nach Monaten.",
+      "titleRoom": "Daily Page — Archiv · {roomName}",
+      "descriptionRoom": "Entdecke fruhere Texte im Raum {roomName} - Monat fur Monat. Springe zu einem Datum, um zu sehen, was andere im Laufe der Zeit in diesem Raum geteilt haben."
+    },
+    "nav": {
+      "prev": "Zuruck",
+      "next": "Weiter"
+    },
+    "title": "📚 Archive durchsuchen",
+    "titleRoom": "📚 {roomName} — Archivs",
+    "roomViewing": "Archiv fur Raum {roomName} wird angezeigt",
+    "viewRoomLink": "Raum anzeigen",
+    "noContent": "Noch keine Inhalte verfugbar.",
+    "backToRoom": "← Zuruck zum Raum-Dashboard",
+    "calendar": {
+      "meta": {
+        "description": "Sieh alle kreativen Blocke aus {month} {year} - von schnellen Gedanken bis zu tiefen Reflexionen. Klicke auf ein Datum, um zu entdecken, was geteilt wurde.",
+        "descriptionRoom": "Sieh die kreative Aktivitat in {roomName} im {month} {year}. Wahle ein Datum, um die an diesem Tag geteilten Blocke zu entdecken."
+      },
+      "title": "📆 Archiv fur {month} {year}",
+      "prevLabel": "Archiv fur {month} {year}",
+      "nextLabel": "Archiv fur {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Archiv fur {date}",
+        "titleRoom": "{roomName} — Archiv fur {date}",
+        "descriptionSite": "Entdecke die am {date} geschriebenen Blocke - von stillen Notizen bis zu wilden Gestandnissen.",
+        "descriptionRoom": "Am {date} haben Schreibende im Raum {roomName} ihre Spuren hinterlassen - scrolle durch Gedanken, Ideen und Ausdrucksformen dieses Tages."
+      },
+      "heading": "Archiv fur {date}",
+      "empty": "Fur dieses Datum wurden keine Inhalte gefunden.",
+      "labels": {
+        "createdBy": "Erstellt von:",
+        "in": "in",
+        "on": "am {datetime}",
+        "unknownRoom": "Unbekannter Raum"
+      },
+      "nav": {
+        "prevDay": "Vorheriger Tag",
+        "nextDay": "Nachster Tag"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Alle Blocke",
+        "descriptionRoom": "Durchsuche jeden Block, der je im Raum {roomName} gepostet wurde. Sortiere nach Datum, Titel oder Stimmen, um seine Geschichte zu erkunden."
+      },
+      "header": {
+        "allBlocks": "— Alle Blocke"
+      },
+      "sort": {
+        "label": "Sortieren nach",
+        "options": {
+          "date": "Datum",
+          "title": "Titel",
+          "votes": "Stimmen"
+        },
+        "submit": "Los"
+      }
+    },
+    "pagination": {
+      "prev": "← Zuruck",
+      "next": "Weiter →"
+    }
+  }
+}

--- a/i18n/de/auth.json
+++ b/i18n/de/auth.json
@@ -1,0 +1,35 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Anmelden",
+        "description": "Melde dich bei deinem Daily-Page-Konto an, um deine Schreibreise fortzusetzen."
+      },
+      "heading": "Willkommen zuruck!",
+      "subheading": "Melde dich bei deinem Konto an, um deine taglichen Texte weiter zu teilen.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Benutzername oder E-Mail",
+          "placeholder": "Benutzernamen oder E-Mail eingeben"
+        },
+        "password": {
+          "label": "Passwort",
+          "placeholder": "Passwort eingeben"
+        }
+      },
+      "actions": {
+        "submit": "Anmelden"
+      },
+      "feedback": {
+        "success": "Anmeldung erfolgreich! Weiterleitung...",
+        "failedGeneric": "Anmeldung fehlgeschlagen. Bitte versuche es erneut.",
+        "unexpected": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+      },
+      "links": {
+        "forgotPassword": "Passwort vergessen?",
+        "noAccount": "Noch kein Konto?",
+        "signupHere": "Hier registrieren!"
+      }
+    }
+  }
+}

--- a/i18n/de/bestOf.json
+++ b/i18n/de/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Das Beste von Daily Page",
+      "description": "Die beliebtesten Blocke auf Daily Page - lustig, ehrlich, poetisch oder einfach seltsam. Sieh, was am letzten Tag, in der letzten Woche, im letzten Monat und daruber hinaus herausragte.",
+      "titleRoom": "Das Beste aus {roomName}",
+      "descriptionRoom": "Entdecke herausragende Beitrage aus dem Raum {roomName} - die, die Leser in den letzten 24 Stunden, 7 Tagen, 30 Tagen und insgesamt am meisten mochten."
+    },
+    "heading": "🏆 Das Beste von Daily Page",
+    "headingRoomPrefix": "🏆 Das Beste von ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 Stunden",
+      "7d": "🚀 7 Tage",
+      "30d": "🌕 30 Tage",
+      "all": "👑 Gesamte Zeit"
+    },
+    "labels": {
+      "createdBy": "Erstellt von:",
+      "inRoom": "in",
+      "onDate": "am {date}",
+      "unknownRoom": "Unbekannter Raum",
+      "noBlocks": "Keine Blocke gefunden.",
+      "viewRoom": "Raum anzeigen"
+    }
+  }
+}

--- a/i18n/de/blockCommon.json
+++ b/i18n/de/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Entwurf"
+    },
+    "deleteModal": {
+      "title": "Block loschen?",
+      "message": "Diese Aktion kann nicht ruckgangig gemacht werden.",
+      "confirm": "Loschen",
+      "cancel": "Abbrechen",
+      "closeAriaLabel": "Schliessen"
+    },
+    "toasts": {
+      "deleteSuccess": "Block erfolgreich geloscht!",
+      "deleteFailed": "Block konnte nicht geloscht werden."
+    }
+  }
+}

--- a/i18n/de/blockEditor.json
+++ b/i18n/de/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Du)"
+    },
+    "meta": {
+      "title": "Block bearbeiten - {blockTitle}",
+      "titleFallback": "Block bearbeiten"
+    },
+    "errors": {
+      "imageUrlRequired": "Bitte gib eine Bild-URL ein.",
+      "notFound": "Block nicht gefunden oder gehort nicht zu diesem Raum.",
+      "loadFailed": "Beim Laden des Block-Editors ist ein Fehler aufgetreten.",
+      "updateTitleFailed": "Fehler beim Aktualisieren des Titels."
+    },
+    "roomInfo": {
+      "label": "Raum:"
+    },
+    "title": {
+      "placeholder": "Blocktitel eingeben",
+      "editTooltip": "Titel bearbeiten",
+      "lock": "Block sperren",
+      "delete": "Block loschen"
+    },
+    "description": {
+      "label": "Beschreibung",
+      "editTooltip": "Beschreibung bearbeiten",
+      "placeholder": "Beschreibung eingeben",
+      "noDescriptionOwner": "Noch keine Beschreibung...",
+      "noDescriptionViewer": "Keine Beschreibung angegeben...",
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "expand": "Erweitern",
+      "collapse": "Einklappen",
+      "updateError": "Fehler beim Aktualisieren der Beschreibung."
+    },
+    "status": {
+      "lastBackup": "Letzte Sicherung: {datetime}",
+      "lastBackupUnknown": "Letzte Sicherung: unbekannt"
+    },
+    "peers": {
+      "label": "Mitwirkende:"
+    },
+    "toasts": {
+      "blockLocked": "Dieser Block wurde gesperrt!"
+    },
+    "editor": {
+      "placeholder": "Die leere Seite wartet auf deine Stimme; schreibe furchtlos."
+    },
+    "loading": {
+      "label": "Wird geladen",
+      "quote": "Lass die Welt durch dich hindurch brennen. Wirf das Prismenlicht, weissgluhend, aufs Papier.<br>- Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Du hast seit 5 Minuten nichts geschrieben. Klicke auf OK, um die Sitzung fortzusetzen; andernfalls wirst du zum Archiv weitergeleitet.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link zum Teilen",
+      "copyTooltip": "In die Zwischenablage kopieren",
+      "copied": "Kopiert!"
+    },
+    "toolbar": {
+      "insertImage": "Bild einfugen",
+      "insertImageUrlPlaceholder": "Bild-URL eingeben",
+      "insertImageAltPlaceholder": "Alternativtext (optional)",
+      "insertImageConfirm": "Bestatigen",
+      "insertImageCancel": "Abbrechen"
+    },
+    "buttons": {
+      "downloadFile": "Datei herunterladen"
+    },
+    "lockModal": {
+      "messageLine1": "Mochtest du diesen Block wirklich sperren?",
+      "messageLine2": "Damit wird er abgeschlossen und weitere Bearbeitung verhindert.",
+      "confirm": "Sperren",
+      "cancel": "Abbrechen",
+      "successToast": "Block erfolgreich gesperrt.",
+      "errorToast": "Fehler beim Sperren des Blocks."
+    },
+    "tags": {
+      "headerWithTags": "Tags:",
+      "headerNoTags": "Noch keine Tags! Fuge welche hinzu:",
+      "updateError": "Fehler beim Aktualisieren der Tags."
+    },
+    "fullBlock": {
+      "headingPrefix": "Tut uns leid; der Block \"{blockTitle}\" ist jetzt",
+      "headingStatus": "voll belegt.",
+      "retryPrefix": "Bitte",
+      "retryLink": "versuche einen anderen Block",
+      "retrySuffix": "oder komm ein anderes Mal wieder.",
+      "consolationPrefix": "Wahrend du wartest, lies gern",
+      "consolationBestOf": "einige unserer Lieblingsblocke",
+      "consolationMiddle": "oder durchstobere",
+      "consolationArchive": "das Archiv."
+    }
+  }
+}

--- a/i18n/de/blockList.json
+++ b/i18n/de/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "gesamte Zeit",
+      "days": "in den letzten {n} Tagen",
+      "day": "in den letzten 24 Stunden"
+    },
+    "createdBy": "Erstellt von:",
+    "on": "am"
+  }
+}

--- a/i18n/de/blockTags.json
+++ b/i18n/de/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tags:",
+      "noTags": "Noch keine Tags! Fuge welche hinzu:"
+    },
+    "input": {
+      "placeholder": "Neuer Tag",
+      "addButton": "Hinzufugen"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/de/blockView.json
+++ b/i18n/de/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Block - {blockTitle}",
+      "titleFallback": "Block"
+    },
+    "labels": {
+      "room": "Raum",
+      "author": "Autor",
+      "created": "Erstellt",
+      "unknownAuthor": "Anonym",
+      "authorAvatarAlt": "Avatar von {username}",
+      "viewAuthorProfile": "Profil von {username} anzeigen",
+      "lang": "Ubersetzungen: ",
+      "available": "verfugbar"
+    },
+    "buttons": {
+      "edit": "Bearbeiten",
+      "deleteBlock": "Block loschen",
+      "share": "Teilen",
+      "flagContent": "Inhalt melden"
+    },
+    "description": {
+      "label": "Beschreibung",
+      "none": "Keine Beschreibung angegeben...",
+      "expand": "Erweitern",
+      "collapse": "Einklappen"
+    },
+    "editorial": {
+      "heading": "Leseleitfaden",
+      "roleLabel": "Lesetyp",
+      "clusterLabel": "Leitfaden",
+      "sequence": "Teil {sequence}",
+      "primaryPillarHeading": "Hier beginnen",
+      "relatedHeading": "Weiterlesen",
+      "clusterHeading": "Mehr in diesem Leitfaden",
+      "expandSection": "{count} weitere anzeigen",
+      "collapseSection": "Weniger anzeigen",
+      "roleNames": {
+        "pillar": "Kernleitfaden",
+        "companion": "Vertiefung",
+        "texture": "Hintergrund"
+      }
+    },
+    "comments": {
+      "heading": "Kommentare",
+      "count": "{count} Kommentare",
+      "empty": "Noch hat niemand geantwortet. Kommentare erscheinen hier, sobald das Gesprach beginnt.",
+      "composer": {
+        "label": "Kommentar hinzufugen",
+        "placeholder": "Kommentar schreiben...",
+        "submit": "Kommentar posten",
+        "submitting": "Wird gepostet...",
+        "success": "Kommentar gepostet.",
+        "error": "Dein Kommentar kann gerade nicht gepostet werden.",
+        "loginPrompt": "Melde dich an, um am Gesprach teilzunehmen.",
+        "loginCta": "Zum Kommentieren anmelden",
+        "verifyPrompt": "Bestatige deine E-Mail, bevor du kommentierst.",
+        "verifyCta": "E-Mail bestatigen"
+      },
+      "sort": {
+        "label": "Sortieren",
+        "oldestFirst": "Alteste zuerst",
+        "newestFirst": "Neueste zuerst"
+      },
+      "by": "Von",
+      "unknownAuthor": "Unbekannt",
+      "reply": {
+        "action": "Antworten",
+        "label": "Antwort hinzufugen",
+        "placeholder": "Antwort schreiben...",
+        "submit": "Antwort posten",
+        "submitting": "Wird gepostet...",
+        "success": "Antwort gepostet.",
+        "error": "Deine Antwort kann gerade nicht gepostet werden.",
+        "cancel": "Abbrechen",
+        "loginPrompt": "Melde dich an, um zu antworten."
+      },
+      "manage": {
+        "edited": "Bearbeitet",
+        "editAction": "Bearbeiten",
+        "deleteAction": "Loschen",
+        "deleteConfirm": "Diesen Kommentar loschen? Dadurch werden auch alle Antworten darunter entfernt.",
+        "deleteSuccess": "Kommentar geloscht.",
+        "deleteError": "Dieser Kommentar kann gerade nicht geloscht werden.",
+        "forbidden": "Du kannst nur deine eigenen Kommentare verwalten.",
+        "edit": {
+          "label": "Kommentar bearbeiten",
+          "save": "Speichern",
+          "saving": "Wird gespeichert...",
+          "cancel": "Abbrechen",
+          "success": "Kommentar aktualisiert.",
+          "error": "Dieser Kommentar kann gerade nicht aktualisiert werden."
+        }
+      },
+      "report": {
+        "action": "Melden",
+        "pending": "Wird gemeldet...",
+        "success": "Kommentar gemeldet.",
+        "error": "Dieser Kommentar kann gerade nicht gemeldet werden.",
+        "ownError": "Du kannst deinen eigenen Kommentar nicht melden.",
+        "hidden": "Kommentar nach Meldung ausgeblendet.",
+        "reported": "Gemeldet"
+      },
+      "deepLink": {
+        "focused": "Verlinkter Kommentar",
+        "unavailable": "Der verlinkte Kommentar ist nicht mehr verfugbar."
+      },
+      "loadMore": "Weitere Kommentare laden",
+      "loading": "Wird geladen...",
+      "loadError": "Weitere Kommentare konnen gerade nicht geladen werden."
+    },
+    "share": {
+      "title": "Diesen Block teilen",
+      "shareOn": "Teilen auf:",
+      "nativeText": "Sieh dir diesen Block an: {title}",
+      "alt": {
+        "facebook": "Facebook-Logo",
+        "reddit": "Reddit-Logo",
+        "whatsapp": "WhatsApp-Logo",
+        "twitter": "Twitter-Logo"
+      }
+    },
+    "errors": {
+      "notFound": "Block nicht gefunden oder gehort nicht zu diesem Raum.",
+      "loadFailed": "Fehler beim Laden der Blockansicht."
+    }
+  }
+}

--- a/i18n/de/createBlock.json
+++ b/i18n/de/createBlock.json
@@ -1,0 +1,65 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Neuen Block erstellen — Daily Page",
+      "description": "Starte einen frischen kreativen Block mit optionalen Tags, Sprache und Sichtbarkeit."
+    },
+    "heading": "Neuen Block erstellen",
+    "roomInfo": {
+      "roomLabel": "Raum:",
+      "unavailable": "Rauminformationen nicht verfugbar.",
+      "noDescription": "Keine Beschreibung verfugbar."
+    },
+    "form": {
+      "title": {
+        "label": "Titel:",
+        "placeholder": {
+          "full": "z. B. 'Mein Meisterwerk', 'Die beste Idee aller Zeiten', 'Clickbait fur Nerds'",
+          "short": "z. B. 'Mein Meisterwerk'"
+        }
+      },
+      "description": {
+        "label": "Beschreibung (optional):",
+        "placeholder": "Erklare deine Genialitat... oder improvisiere einfach."
+      },
+      "initialContent": {
+        "label": "Anfangsinhalt (optional):",
+        "help": "Beginne hier zu schreiben oder drucke auf \"Erstellen\", um auf der vollstandigen Editorseite weiterzumachen, wo du Bilder einbetten und in Echtzeit zusammenarbeiten kannst.",
+        "placeholder": "Starte deinen Block hier oder bearbeite ihn nach der Erstellung weiter..."
+      },
+      "visibility": {
+        "label": "Sichtbarkeit:"
+      },
+      "submit": "Block erstellen"
+    },
+    "visibility": {
+      "public": {
+        "label": "Offentlich",
+        "title": "Von allen in Echtzeit bearbeitbar. Keine Anmeldung erforderlich.",
+        "inline": "Von allen in Echtzeit bearbeitbar. Keine Anmeldung erforderlich."
+      },
+      "private": {
+        "label": "Privat",
+        "title": "Nur fur angemeldete Benutzer. Sichtbar, nachdem die Bearbeitung abgeschlossen ist.",
+        "inline": "Nur fur angemeldete Benutzer. Sichtbar, nachdem die Bearbeitung abgeschlossen ist.",
+        "tooltip": "Private Blocke sind wahrend der Arbeit nur per Einladung zuganglich und werden sichtbar, wenn du fertig bist."
+      }
+    },
+    "advanced": {
+      "summary": "Erweiterte Optionen",
+      "lang": {
+        "label": "Sprache:"
+      },
+      "translate": {
+        "label": "Vorhandenen Block ubersetzen (URL oder ID):",
+        "placeholder": "Block-URL oder ID einfugen (optional)",
+        "invalid": "Das sieht nicht wie eine gultige Block-URL oder ID aus.",
+        "fetchError": "Blockinformationen konnten nicht abgerufen werden."
+      }
+    },
+    "messages": {
+      "langExists": "Eine Ubersetzung fur diese Sprache existiert bereits. Bitte wahle eine andere Sprache.",
+      "genericError": "Etwas ist schiefgelaufen. Bitte versuche es erneut."
+    }
+  }
+}

--- a/i18n/de/dashboard.json
+++ b/i18n/de/dashboard.json
@@ -1,0 +1,45 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Dashboard",
+      "description": "Dein Daily-Page-Dashboard und Kontouberblick."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbild",
+      "noBio": "Noch keine Bio. Klicke auf \"Bearbeiten\", um eine hinzuzufugen!",
+      "editBio": "Bio bearbeiten",
+      "bioPlaceholder": "Gib hier deine Bio ein",
+      "save": "Speichern",
+      "cancel": "Abbrechen"
+    },
+    "activity": {
+      "title": "Letzte Aktivitat",
+      "none": "Keine neue Aktivitat.",
+      "updatedOn": "Aktualisiert am {date}",
+      "viewAllBlocks": "Alle Blocke anzeigen"
+    },
+    "streak": {
+      "title": "Schreibserie",
+      "line": "{days} Tage in Folge! Weiter so!"
+    },
+    "starredRooms": {
+      "title": "Markierte Raume",
+      "none": "Du hast noch keine Raume markiert. Entdecke Raume, um deine Favoriten zu finden!",
+      "viewAll": "Alle markierten Raume anzeigen",
+      "unnamedRoom": "Unbenannter Raum"
+    },
+    "stats": {
+      "title": "Deine Statistiken",
+      "totalBlocks": "Erstellte Blocke insgesamt",
+      "collaborations": "Zusammenarbeiten",
+      "votesGiven": "Abgegebene Stimmen",
+      "daysActive": "Aktive Tage",
+      "viewDetailed": "Detaillierte Statistiken anzeigen 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Profilbild konnte nicht hochgeladen werden. Bitte versuche es erneut.",
+      "uploadUnexpected": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut.",
+      "bioUpdateFailed": "Fehler beim Aktualisieren der Bio. Bitte versuche es erneut."
+    }
+  }
+}

--- a/i18n/de/detailedStats.json
+++ b/i18n/de/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Detaillierte Statistiken",
+      "description": "Eine detaillierte Aufschlusselung deiner Daily-Page-Aktivitat."
+    },
+    "nav": {
+      "backToDashboard": "← Zuruck zum Dashboard"
+    },
+    "header": {
+      "title": "📊 Deine Statistikubersicht 📊"
+    },
+    "cards": {
+      "totalBlocks": "Erstellte Blocke insgesamt 📝",
+      "collaborations": "Zusammenarbeiten 🤝",
+      "votesGiven": "Abgegebene Stimmen 👍",
+      "daysActive": "Aktive Tage 📆"
+    },
+    "chart": {
+      "datasetLabel": "Deine Statistiken",
+      "labels": {
+        "blocksCreated": "Erstellte Blocke",
+        "collaborations": "Zusammenarbeiten",
+        "votesGiven": "Abgegebene Stimmen",
+        "daysActive": "Aktive Tage"
+      }
+    }
+  }
+}

--- a/i18n/de/errors.json
+++ b/i18n/de/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Hoppla! Etwas ist schiefgelaufen.",
+      "message": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es spater erneut.",
+      "home": "Zur Startseite"
+    },
+    "notFound": {
+      "title": "404 - Seite nicht gefunden",
+      "metaTitle": "Seite nicht gefunden",
+      "message": "Leider konnten wir die gesuchte Seite nicht finden.",
+      "homePrefix": "Du kannst zuruck zu",
+      "homeLink": "der Startseite",
+      "roomsPrefix": "oder dir das ansehen:",
+      "roomsLink": "Raumverzeichnis."
+    }
+  }
+}

--- a/i18n/de/flagModal.json
+++ b/i18n/de/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Unangemessenen Inhalt melden",
+    "fields": {
+      "reason": {
+        "label": "Grund",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Beleidigend (Hassrede oder abwertende Begriffe)",
+          "inappropriate": "Unangemessen (Nacktheit, grafische Inhalte usw.)",
+          "other": "Sonstiges"
+        }
+      },
+      "details": {
+        "label": "Details (optional)",
+        "placeholder": "Beschreibe, was du gesehen hast..."
+      }
+    },
+    "buttons": {
+      "submit": "Meldung absenden",
+      "cancel": "Abbrechen"
+    },
+    "toasts": {
+      "success": "Meldung gesendet - danke!",
+      "failed": "Meldung konnte nicht gesendet werden."
+    }
+  }
+}

--- a/i18n/de/forgotPassword.json
+++ b/i18n/de/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Passwort zurucksetzen",
+      "description": "Fordere einen Link zum Zurucksetzen deines Daily-Page-Kontos an."
+    },
+    "header": {
+      "title": "Passwort vergessen?",
+      "subtitle": "Gib deine E-Mail ein und wir senden dir einen Link zum Zurucksetzen."
+    },
+    "form": {
+      "email": {
+        "label": "E-Mail-Adresse",
+        "placeholder": "E-Mail eingeben"
+      },
+      "submit": "Passwort-Zurucksetzung anfordern"
+    },
+    "feedback": {
+      "successGeneric": "Falls diese E-Mail existiert, wurde ein Link zum Zurucksetzen gesendet.",
+      "missingEmail": "E-Mail ist erforderlich.",
+      "genericError": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+    },
+    "email": {
+      "subject": "Setze dein Daily-Page-Passwort zuruck",
+      "heading": "Anfrage zum Zurucksetzen des Passworts",
+      "headingWithName": "Passwort-Zurucksetzung, {username}",
+      "body": "Klicke auf den Link unten, um dein Passwort zuruckzusetzen.",
+      "cta": "Mein Passwort zurucksetzen",
+      "expires": "Dieser Link lauft in {hours} Stunde(n) ab.",
+      "ignore": "Wenn du keine Passwort-Zurucksetzung angefordert hast, kannst du diese E-Mail ignorieren."
+    }
+  }
+}

--- a/i18n/de/home.json
+++ b/i18n/de/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Top-Blocke der letzten 24 Stunden",
+      "description": "Daily Page ist eine minimalistische, unabhangige Schreibseite, auf der jede Person kreative Gedanken, Erinnerungen oder Experimente veroffentlichen kann - Block fur Block. Entdecke neue Ideen, tritt Raumen bei und bring deine Stimme ein."
+    },
+    "hero": {
+      "eyebrow": "Ein ruhiger Ort zum Schreiben, Lesen und Wiederkommen",
+      "title": "Willkommen bei Daily Page!",
+      "subtitle": "Entdecke die beliebtesten Blocke der letzten 24 Stunden.",
+      "ctaPrefix": "Inspiriert?",
+      "cta": "Einem Raum beitreten",
+      "ctaSuffix": "und erstelle deinen eigenen Block!"
+    },
+    "stats": {
+      "blocks": "Blocke",
+      "rooms": "Raume",
+      "tags": "Tags",
+      "collabsToday": "Zusammenarbeiten heute"
+    },
+    "activity": {
+      "title": "Live auf Daily Page",
+      "subtitle": "Neue Gesprache und Reaktionen auf einen Blick.",
+      "fallbackActor": "Jemand",
+      "inRoom": "in",
+      "comments": {
+        "title": "Neue Kommentare",
+        "more": "Diskussionen durchsuchen",
+        "commentVerb": "kommentierte",
+        "replyVerb": "antwortete auf",
+        "empty": "Noch keine neuen Kommentare. Das nachste Gesprach kann mit deinem Block beginnen."
+      },
+      "reactions": {
+        "title": "Neue Reaktionen",
+        "more": "Top-Blocke durchsuchen",
+        "empty": "Noch keine neuen Reaktionen. Ein guter Beitrag konnte das schnell beleben.",
+        "types": {
+          "heart": "gab ein Herz fur",
+          "leaf": "reagierte mit einem Blatt auf",
+          "wow": "reagierte mit Wow auf",
+          "laugh": "lachte uber"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Hervorgehobener Raum",
+      "roomInfoDays": "Aktivitat in den letzten {days} Tagen: {blocks} Blocke, {votes} Stimmen.",
+      "roomInfo24h": "Aktivitat in den letzten 24 Stunden: {blocks} Blocke, {votes} Stimmen.",
+      "checkItOut": "Ansehen",
+      "blockRibbon": "★ Hervorgehobener Block",
+      "votes": "{n} Stimmen",
+      "noContent": "(Kein Inhalt angegeben...)",
+      "viewBlock": "Block anzeigen"
+    },
+    "trendingTags": {
+      "title": "Trend-Tags",
+      "suffixDays": "(letzte {days} Tage)",
+      "suffixAllTime": "(gesamte Zeit)",
+      "blocks": "{n} Blocke",
+      "votes": "{n} Stimmen",
+      "empty": "Noch keine Trend-Tags. Sei die erste Person, die etwas Cooles taggt!"
+    },
+    "trendingBlocks": {
+      "title": "Trend-Blocke",
+      "suffixDays": "(letzte {days} Tage)",
+      "createdBy": "Erstellt von:",
+      "in": "in",
+      "on": "am",
+      "unknownRoom": "Unbekannter Raum",
+      "empty24h": "Noch keine Blocke in den letzten 24 Stunden. Schau bald wieder vorbei!"
+    }
+  }
+}

--- a/i18n/de/layout.json
+++ b/i18n/de/layout.json
@@ -1,0 +1,18 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Willkommen, Benutzer!",
+    "logout": "Abmelden",
+    "login": "Anmelden / Registrieren",
+    "language": "Sprache",
+    "openMenu": "Hauptmenu offnen",
+    "closeMenu": "Hauptmenu schliessen",
+    "privacy": "Datenschutzerklarung",
+    "uiFallbackNotice": "{requested} ist noch nicht ubersetzt. Vorerst wird {current} angezeigt.",
+    "copyButton": {
+      "copy": "Kopieren",
+      "copied": "Kopiert!"
+    },
+    "copyright": "© {year}"
+  }
+}

--- a/i18n/de/modals.json
+++ b/i18n/de/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Bitte anmelden",
+      "message": "Du musst angemeldet sein, um fortzufahren.",
+      "messageWithAction": "Du musst angemeldet sein, um {action}.",
+      "cta": "Anmelden"
+    },
+    "actions": {
+      "voteOnBlock": "fur einen Block abzustimmen",
+      "starRoom": "diesen Raum zu markieren",
+      "reactToBlock": "auf diesen Beitrag zu reagieren",
+      "commentOnBlock": "diesen Block zu kommentieren",
+      "reportComment": "diesen Kommentar zu melden"
+    },
+    "errors": {
+      "starToggleFail": "Sternstatus konnte nicht aktualisiert werden. Bitte versuche es erneut."
+    }
+  }
+}

--- a/i18n/de/nav.json
+++ b/i18n/de/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Startseite",
+    "rooms": "Raume",
+    "tags": "Tags",
+    "archive": "Archiv",
+    "search": "Suche",
+    "bestOf": "Bestes",
+    "about": "Uber uns",
+    "support": "Support",
+    "otherProjects": "Andere Projekte",
+    "auth": {
+      "welcomePrefix": "Willkommen, ",
+      "welcomeFallbackUser": "du",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Dashboard"
+  }
+}

--- a/i18n/de/notifications.json
+++ b/i18n/de/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Benachrichtigungen",
+      "openMenu": "Benachrichtigungen offnen",
+      "loading": "Benachrichtigungen werden geladen...",
+      "error": "Benachrichtigungen konnen gerade nicht geladen werden.",
+      "empty": "Noch keine Benachrichtigungen.",
+      "markRead": "Als gelesen markieren",
+      "fallbackActor": "Jemand",
+      "fallbackBlockTitle": "dein Block",
+      "item": {
+        "blockComment": "{actorUsername} hat deinen Block \"{blockTitle}\" kommentiert.",
+        "commentReply": "{actorUsername} hat auf deinen Kommentar zu \"{blockTitle}\" geantwortet.",
+        "unknown": "Benachrichtigung"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Neu comment on \"{blockTitle}\"",
+        "heading": "Neuer Kommentar zu deinem Block",
+        "headingWithName": "Hallo {username},",
+        "body": "<strong>{actorUsername}</strong> hat deinen Block <strong>{blockTitle}</strong> kommentiert.",
+        "cta": "Gesprach auf Daily Page ansehen",
+        "fallbackActor": "Jemand",
+        "fallbackBlockTitle": "dein Block"
+      },
+      "commentReply": {
+        "subject": "Neu reply on \"{blockTitle}\"",
+        "heading": "Neue Antwort auf deinen Kommentar",
+        "headingWithName": "Hallo {username},",
+        "body": "<strong>{actorUsername}</strong> hat auf deinen Kommentar zu <strong>{blockTitle}</strong> geantwortet.",
+        "cta": "Gesprach auf Daily Page ansehen",
+        "fallbackActor": "Jemand",
+        "fallbackBlockTitle": "dein Block"
+      }
+    }
+  }
+}

--- a/i18n/de/privacy.json
+++ b/i18n/de/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Datenschutzerklarung",
+      "description": "Wie Daily Page deine Daten sammelt, nutzt und schutzt - in klarer Sprache."
+    },
+    "title": "Datenschutzerklarung",
+    "lastUpdated": "Zuletzt aktualisiert: {date}",
+    "intro": {
+      "h2": "Einfuhrung",
+      "p1": "Daily Page (\"uns\", \"wir\" oder \"unser\") betreibt die Website dailypage.org (im Folgenden \"Dienst\").",
+      "p2": "Diese Seite informiert dich uber unsere Richtlinien zur Erhebung, Nutzung und Offenlegung personenbezogener Daten, wenn du unseren Dienst verwendest."
+    },
+    "collection": {
+      "h2": "Datenerhebung und Nutzung",
+      "p": "Wir erheben nur minimale personenbezogene Daten, um unseren Dienst bereitzustellen und zu verbessern. Dazu gehoren E-Mail-Adressen fur die Kontoverwaltung und Inhalte, die Benutzer freiwillig einreichen."
+    },
+    "usage": {
+      "h2": "Datennutzung",
+      "p": "Erhobene Daten werden ausschliesslich fur Kontoauthentifizierung, Inhaltsmoderation und die Verbesserung der Nutzererfahrung verwendet."
+    },
+    "storage": {
+      "h2": "Datenspeicherung und Sicherheit",
+      "p": "Deine Daten werden sicher gespeichert und ohne ausdruckliche Zustimmung niemals an Dritte weitergegeben oder verkauft, ausser wenn dies gesetzlich vorgeschrieben ist."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "Wir verwenden Cookies ausschliesslich fur Sitzungsverwaltung und zur Verbesserung der Nutzererfahrung. Du kannst Cookies in deinen Browsereinstellungen deaktivieren."
+    },
+    "rights": {
+      "h2": "Deine Rechte",
+      "p": "Du kannst jederzeit die Loschung oder Anderung deiner personenbezogenen Daten verlangen, indem du uns kontaktierst."
+    },
+    "changes": {
+      "h2": "Anderungen an dieser Datenschutzerklarung",
+      "p": "Wir konnen unsere Datenschutzerklarung von Zeit zu Zeit aktualisieren. Anderungen werden auf dieser Seite veroffentlicht."
+    },
+    "contact": {
+      "h2": "Kontakt",
+      "p": "Bei Fragen zu dieser Datenschutzerklarung kontaktiere uns unter:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/de/profile.json
+++ b/i18n/de/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Profil von {username}",
+      "descriptionUser": "Sieh dir die neuesten Aktivitaten, markierten Raume und Statistiken von {username} an."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbild",
+      "noBio": "(Keine Bio verfugbar.)"
+    },
+    "activity": {
+      "title": "Letzte Aktivitat",
+      "updatedOn": "Aktualisiert am {date}",
+      "none": "Keine neue Aktivitat.",
+      "viewAllBlocks": "Alle Blocke anzeigen"
+    },
+    "starredRooms": {
+      "title": "Markierte Raume",
+      "none": "Noch keine markierten Raume.",
+      "unnamedRoom": "Unbenannter Raum"
+    },
+    "stats": {
+      "title": "Benutzerstatistiken",
+      "totalBlocks": "Erstellte Blocke insgesamt",
+      "collaborations": "Zusammenarbeiten",
+      "daysActive": "Aktive Tage"
+    }
+  }
+}

--- a/i18n/de/random.json
+++ b/i18n/de/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Andere Projekte",
+      "description": "Entdecke Baseball-Journaling, zufallige Schreibexperimente und andere Nebenprojekte von Daily Page."
+    },
+    "title": "Andere Projekte",
+    "tagline": "Eine gemutliche Ecke fur Experimente und Nebenprojekte.",
+    "links": {
+      "baseball": "📖 Baseball-Journal",
+      "randomWriter": "🎲 Zufallsschreiber"
+    },
+    "cta": {
+      "backToRooms": "Zuruck zu den Hauptraumen"
+    }
+  }
+}

--- a/i18n/de/randomWriter.json
+++ b/i18n/de/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Zufallsschreiber",
+      "description": "Erzeuge einen endlosen Strom zufalligen Pseudotexts fur Spass, Inspiration oder Chaos."
+    },
+    "title": "Zufallsschreiber",
+    "buttons": {
+      "clear": "Loschen",
+      "stop": "Schreiben stoppen",
+      "start": "Schreiben starten"
+    }
+  }
+}

--- a/i18n/de/reactions.json
+++ b/i18n/de/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} Reaktionen: {count}",
+    "loginToReact": "Zum Reagieren anmelden",
+    "countsLabel": "Reaktionen"
+  }
+}

--- a/i18n/de/readMore.json
+++ b/i18n/de/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Mehr...",
+    "aria": "Vollstandigen Block lesen: {title}"
+  }
+}

--- a/i18n/de/resetPassword.json
+++ b/i18n/de/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Passwort zurucksetzen",
+      "description": "Lege ein neues Passwort fur dein Konto fest."
+    },
+    "header": {
+      "title": "Passwort zurucksetzen",
+      "subtitle": "Wahle ein neues Passwort, um wieder Zugriff zu erhalten."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Neues Passwort",
+        "placeholder": "Neues Passwort eingeben"
+      },
+      "submit": "Neues Passwort festlegen"
+    },
+    "feedback": {
+      "missingToken": "Token fehlt oder ist ungultig.",
+      "missingFields": "Token und neues Passwort sind erforderlich.",
+      "invalidOrExpired": "Ungultiger oder abgelaufener Token.",
+      "success": "Passwort erfolgreich aktualisiert!",
+      "genericError": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+    }
+  }
+}

--- a/i18n/de/roomDashboard.json
+++ b/i18n/de/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Entdecke neue und laufende Blocke in {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Entdecken:",
+      "allBlocks": "🗂️ Alle Blocke",
+      "browseByDate": "🗓️ Nach Datum",
+      "bestOf": "🏅 Das Beste",
+      "searchInRoom": "🔎 Suche"
+    },
+    "actions": {
+      "createBlock": "Block erstellen",
+      "starTitle": "Diesen Raum markieren",
+      "unstarTitle": "Markierung fur diesen Raum entfernen"
+    },
+    "tabs": {
+      "locked": "Gesperrte Blocke",
+      "inProgress": "Blocke in Arbeit"
+    },
+    "sections": {
+      "lockedHeader": "Gesperrte Blocke",
+      "inProgressHeader": "Blocke in Arbeit"
+    },
+    "editorial": {
+      "heading": "Hervorgehobene Leitfaden",
+      "description": "Beginne hier mit den hervorgehobenen Leitfaden, die fur diesen Raum kuratiert wurden.",
+      "roleNames": {
+        "pillar": "Kernleitfaden",
+        "companion": "Leseleitfaden",
+        "texture": "Hintergrundleitfaden"
+      }
+    },
+    "empty": {
+      "noDescription": "Keine Beschreibung verfugbar.",
+      "noLocked": "Noch keine gesperrten Blocke! Blocke werden nach 1 Stunde Inaktivitat automatisch gesperrt.",
+      "noInProgress": "Noch keine Blocke in Arbeit! Zeit, einen zu starten.",
+      "noBlocks": "Noch keine Blocke! Erstelle den ersten und hinterlasse deine Spur. 😎"
+    }
+  }
+}

--- a/i18n/de/roomsDirectory.json
+++ b/i18n/de/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Raumverzeichnis",
+      "description": "Jeder Raum ist eine Tur zu einer anderen Welt. Tritt ein, teile deine Geschichte und baue mit anderen etwas Schoneres auf."
+    },
+    "eyebrow": "Finde deine Ecke",
+    "heading": "Raumverzeichnis",
+    "intro": "Beginne mit den Raumen, die gerade lebendig wirken, oder wandere nach Themen, bis etwas klickt. Jeder Raum ist ein anderer Schreibimpuls, ein Fandom oder eine geteilte Begeisterung, die auf deine Stimme wartet.",
+    "empty": "Momentan sind keine Raume verfugbar. Schau spater wieder vorbei!",
+    "jumpToActive": "Aktive Raume anzeigen",
+    "jumpToTopics": "Nach Thema durchsuchen",
+    "statsLabel": "Highlights des Raumverzeichnisses",
+    "liveNow": "Jetzt live",
+    "recentlyActive": "Kurzlich aktiv",
+    "recentlyActiveSubtitle": "Der schnellste Weg, einen Raum zu finden, in dem gerade Menschen aktiv sind.",
+    "browseByTopic": "Nach Thema durchsuchen",
+    "topicSubtitle": "Offne ein Thema, um seine Raume zu erkunden.",
+    "roomCount": "{count} Raume",
+    "stats": {
+      "rooms": "Raume zum Entdecken",
+      "topics": "Themengruppen",
+      "active": "aktive Auswahl"
+    },
+    "activeUsers": "Aktive Benutzer: {count}",
+    "visitRoom": "Raum besuchen",
+    "close": "Schliessen",
+    "noTitle": "Kein Titel verfugbar",
+    "noDescription": "Keine Beschreibung verfugbar"
+  }
+}

--- a/i18n/de/search.json
+++ b/i18n/de/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Suche",
+      "description": "Offentliche Blocke durchsuchen."
+    },
+    "title": "Suche",
+    "placeholder": "Blocke suchen...",
+    "hint": "Gib mindestens 2 Zeichen ein, um zu suchen.",
+    "noResults": "Keine Ergebnisse gefunden.",
+    "untitled": "Ohne Titel",
+    "votesTitle": "Stimmen",
+    "pageLabel": "Seite",
+    "filters": {
+      "inRoom": "In Raum"
+    },
+    "buttons": {
+      "search": "Suche",
+      "prev": "Zuruck",
+      "next": "Weiter"
+    }
+  }
+}

--- a/i18n/de/signup.json
+++ b/i18n/de/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Konto erstellen",
+      "description": "Registriere dich bei Daily Page, um alle Funktionen zu nutzen."
+    },
+    "header": {
+      "title": "Erstelle dein Konto",
+      "subtitle": "Tritt Daily Page bei, um mit dem Erstellen und Teilen deiner taglichen Texte zu beginnen!"
+    },
+    "form": {
+      "email": {
+        "label": "E-Mail",
+        "placeholder": "E-Mail eingeben"
+      },
+      "username": {
+        "label": "Benutzername",
+        "placeholder": "Benutzernamen eingeben"
+      },
+      "password": {
+        "label": "Passwort",
+        "placeholder": "Passwort eingeben"
+      },
+      "submit": "Registrieren",
+      "feedback": {
+        "success": "Formular erfolgreich gesendet!",
+        "successCreatedVerify": "Konto erfolgreich erstellt! Bitte prufe deine E-Mail, um dein Konto zu bestatigen.",
+        "genericError": "Konto konnte nicht erstellt werden. Bitte versuche es erneut.",
+        "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+      }
+    }
+  }
+}

--- a/i18n/de/starredRooms.json
+++ b/i18n/de/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Alle markierten Raume",
+      "description": "Eine Liste aller Raume, die du markiert hast."
+    },
+    "nav": {
+      "backToDashboard": "← Zuruck zum Dashboard"
+    },
+    "header": {
+      "title": "🌟 Alle deine markierten Raume 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Unbenannter Raum",
+      "noDescription": "Keine Beschreibung."
+    },
+    "empty": {
+      "message": "Du hast noch keine Raume markiert!"
+    }
+  }
+}

--- a/i18n/de/support.json
+++ b/i18n/de/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Hilfe",
+      "description": "Wie du Kontakt aufnimmst, Probleme meldest, Funktionen oder Raume anfragst und Daily Page finanziell unterstutzt."
+    },
+    "contact": {
+      "h1": "★ Ich mochte eine Frage stellen, ein Problem melden oder eine Funktion anfragen.",
+      "p1": {
+        "before": "Wenn du lieber GitHub nutzt, sieh dir bitte",
+        "link": "die Issues dieses Projekts",
+        "after": "an und bring dich ein. Pull Requests sind naturlich ebenfalls willkommen."
+      },
+      "p2": {
+        "before": "Alternativ:",
+        "link": "sende eine E-Mail",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Ich mochte dieses Projekt mit einem Beitrag unterstutzen.",
+      "p1": {
+        "before": "Vielen Dank im Voraus, dass du dieses Projekt finanzierst. Bitte sende Zahlungen sicher uber",
+        "paypal": "PayPal",
+        "middle": "oder, wenn du mochtest,",
+        "amazon": "bestelle ein paar Beutel der Spielzeuge, die ich auf Amazon verkaufe",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Ich mochte einen neuen Raum anfragen.",
+      "form": {
+        "nameLabel": "Raumname",
+        "topicLabel": "Thema (optional)",
+        "descriptionLabel": "Beschreibung",
+        "submit": "Anfrage senden",
+        "success": "Anfrage erfolgreich gesendet!",
+        "errorGeneric": "Anfrage konnte nicht gesendet werden. Bitte versuche es erneut.",
+        "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+      }
+    }
+  }
+}

--- a/i18n/de/tags.json
+++ b/i18n/de/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Tags-Ubersicht",
+      "description": "Durchsuche alle Tags, die auf Daily Page verwendet werden, mit schnellen Zeitfiltern."
+    },
+    "title": "Tags-Ubersicht",
+    "intro": "Entdecke alle Tags, die auf Daily Page verwendet werden.",
+    "tagCloudTitle": "Tag-Cloud",
+    "timeframe": {
+      "last24h": "Letzte 24 Stunden",
+      "last7d": "Letzte 7 Tage",
+      "last30d": "Letzte 30 Tage",
+      "all": "Alle Time"
+    },
+    "error": {
+      "loading": "Fehler beim Laden der Tags-Ubersicht"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Blocke mit Tag"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Blocke insgesamt mit",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Erstellt von:",
+        "inRoom": "in",
+        "unknownRoom": "Unbekannter Raum",
+        "onDate": "am"
+      },
+      "chart": {
+        "label": "Erstellte Blocke im Zeitverlauf"
+      },
+      "empty": {
+        "message": "Noch keine Blocke mit diesem Tag gefunden. Vielleicht solltest du den ersten erstellen? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Fehler beim Laden der Tag-Seite"
+      }
+    }
+  }
+}

--- a/i18n/de/translation.json
+++ b/i18n/de/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Ubersetzt aus",
+    "see": "siehe",
+    "originalBlock": "Originalblock"
+  }
+}

--- a/i18n/de/userBlocks.json
+++ b/i18n/de/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Deine Blocke",
+      "description": "Durchsuche und sortiere alle Blocke, die du erstellt oder an denen du mitgearbeitet hast."
+    },
+    "header": {
+      "dashboardLink": "Dein Dashboard",
+      "profileLink": "Profil von {username}",
+      "allBlocks": "Alle Blocke"
+    },
+    "empty": "Noch keine Blocke.",
+    "pagination": {
+      "prev": "← Zuruck",
+      "next": "Weiter →"
+    },
+    "titleUser": "Blocke von {username}"
+  }
+}

--- a/i18n/de/verifyEmail.json
+++ b/i18n/de/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "E-Mail bestatigen",
+      "description": "Bestatige deine E-Mail-Adresse fur Daily Page."
+    },
+    "header": {
+      "title": "E-Mail wird bestatigt..."
+    },
+    "status": {
+      "checking": "Token wird gepruft, bitte warten...",
+      "missingToken": "Bestatigungstoken fehlt oder ist ungultig.",
+      "genericFailure": "Bestatigung fehlgeschlagen.",
+      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
+      "success": "Dein Konto wurde erfolgreich bestatigt!",
+      "invalidOrExpired": "Ungultiger oder abgelaufener Bestatigungstoken."
+    },
+    "verificationMsg": {
+      "subject": "Bestatige dein Daily-Page-Konto ✨",
+      "heading": "Willkommen bei Daily Page, {username}!",
+      "body": "Bitte bestatige deine E-Mail, indem du unten klickst:",
+      "cta": "E-Mail-Adresse bestatigen",
+      "expires": "Dieser Link lauft in {hours} Stunden ab."
+    }
+  }
+}

--- a/i18n/de/voteControls.json
+++ b/i18n/de/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Hochstimmen",
+    "downvote": "Runterstimmen",
+    "errors": {
+      "failed": "Deine Stimme konnte nicht gespeichert werden."
+    }
+  }
+}

--- a/server/db/notificationService.js
+++ b/server/db/notificationService.js
@@ -91,7 +91,7 @@ async function sendCommentNotificationEmail({
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
   const uiLang = block.lang || 'en';
   const blockUrl = `${baseUrl}/${uiLang}${canonicalCommentPath(block, comment._id || comment.id)}`;
-  const emailLang = ['en', 'es', 'fr', 'ru', 'id'].includes(block.lang) ? block.lang : 'en';
+  const emailLang = ['en', 'es', 'fr', 'ru', 'id', 'de'].includes(block.lang) ? block.lang : 'en';
 
   const { subject, html } = await buildCommentNotificationEmail({
     uiLang: emailLang,

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -13,7 +13,7 @@ import {
 } from '../db/blockService.js';
 import { getTotalRooms } from '../db/roomService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -58,4 +58,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'fr' }).catch(console.error), 2_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'ru' }).catch(console.error), 2_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'id' }).catch(console.error), 3_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'de' }).catch(console.error), 3_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary
- Add complete `i18n/de` UI translation files based on `i18n/en`
- Register `de` as a fully supported UI locale for locale context, hreflang, home cache warming, and notification emails
- Keep DB-backed room name/description translations out of scope

## Validation
- Verified all locale JSON parses successfully
- Verified `i18n/de` matches `i18n/en` file-for-file and key-for-key
- Verified German placeholders match the English source placeholders
