### PR TITLE
Add Italian UI locale support

### DIFF
--- a/i18n/de/createBlock.json
+++ b/i18n/de/createBlock.json
@@ -48,7 +48,34 @@
     "advanced": {
       "summary": "Erweiterte Optionen",
       "lang": {
-        "label": "Sprache:"
+        "label": "Sprache:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
       },
       "translate": {
         "label": "Vorhandenen Block ubersetzen (URL oder ID):",

--- a/i18n/en/createBlock.json
+++ b/i18n/en/createBlock.json
@@ -47,7 +47,36 @@
     },
     "advanced": {
       "summary": "Advanced options",
-      "lang": { "label": "Language:" },
+      "lang": {
+        "label": "Language:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
       "translate": {
         "label": "Translate existing block (URL or ID):",
         "placeholder": "Paste a block URL or ID (optional)",

--- a/i18n/es/createBlock.json
+++ b/i18n/es/createBlock.json
@@ -27,7 +27,9 @@
         "help": "Escribe aquí o pulsa «Crear» para seguir en el editor completo, donde puedes incrustar imágenes y colaborar en tiempo real.",
         "placeholder": "Empieza aquí o sigue editando tras la creación…"
       },
-      "visibility": { "label": "Visibilidad:" },
+      "visibility": {
+        "label": "Visibilidad:"
+      },
       "submit": "Crear Bloque"
     },
     "visibility": {
@@ -45,7 +47,36 @@
     },
     "advanced": {
       "summary": "Opciones avanzadas",
-      "lang": { "label": "Idioma:" },
+      "lang": {
+        "label": "Idioma:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
       "translate": {
         "label": "Traducir bloque existente (URL o ID):",
         "placeholder": "Pega la URL o el ID del bloque (opcional)",

--- a/i18n/fr/createBlock.json
+++ b/i18n/fr/createBlock.json
@@ -48,7 +48,34 @@
     "advanced": {
       "summary": "Options avancées",
       "lang": {
-        "label": "Langue :"
+        "label": "Langue :",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
       },
       "translate": {
         "label": "Traduire un bloc existant (URL ou ID) :",

--- a/i18n/id/createBlock.json
+++ b/i18n/id/createBlock.json
@@ -47,7 +47,36 @@
     },
     "advanced": {
       "summary": "Opsi lanjutan",
-      "lang": { "label": "Bahasa:" },
+      "lang": {
+        "label": "Bahasa:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
       "translate": {
         "label": "Terjemahkan blok yang sudah ada (URL atau ID):",
         "placeholder": "Tempel URL blok atau ID (opsional)",

--- a/i18n/it/about.json
+++ b/i18n/it/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page - Informazioni",
+      "description": "Che cos'e Daily Page, come funziona e perche e stato creato come un angolo del web piu lento e gentile."
+    },
+    "title": "Informazioni su Daily Page",
+    "tagline": "Nutri la mente, non il feed.",
+    "mission": {
+      "h2": "Missione",
+      "p1": "Un laboratorio di scrittura indipendente, nato nel mio salotto e alimentato dalla curiosita dei lettori.",
+      "p2": "E costruito non per intorpidire la mente, ma per nutrirla: un posto dove puoi scrivere con calma, anche in forma anonima se vuoi, senza preoccuparti di impressionare nessuno."
+    },
+    "how": {
+      "h2": "Come funziona",
+      "features": {
+        "rooms": {
+          "label": "Stanze",
+          "text": "sono spazi tematici (pensa a un subreddit, ma piu amichevole)."
+        },
+        "blocks": {
+          "label": "Blocchi",
+          "text": "sono post collaborativi: chiunque (anche in forma anonima) puo crearne uno, modificarlo finche non viene bloccato e votare quelli degli altri."
+        },
+        "privacy": {
+          "label": "Privacy e condivisione",
+          "text": "I blocchi pubblici appaiono nel feed della stanza. I blocchi privati restano nascosti finche non vengono bloccati, ma ricevi un link di condivisione per invitare amici."
+        },
+        "markdown": {
+          "label": "Markdown e media",
+          "text": "Scrivi in markdown, incorpori immagini e collabori alle modifiche come in Google Docs."
+        },
+        "trends": {
+          "label": "Tendenze e tag",
+          "text": "Tagga il tuo blocco, segui le tendenze dei tag e scopri i contenuti migliori (7 g / 30 g / sempre)."
+        },
+        "streaks": {
+          "label": "Serie",
+          "text": "Mantieni viva la tua serie di scrittura quotidiana: il miglior incentivo per presentarti ogni giorno."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Come siamo arrivati qui",
+      "p1": "Nel 2018 ho creato una wiki basata sulle date per la pagina del giorno e ho visto alcuni scrittori introspettivi trasformarla in uno spazio per i loro pensieri. Non e mai diventata enorme, ma ha piantato un seme.",
+      "p2": "Arriviamo a oggi: Daily Page e quel seme cresciuto in molte stanze, un social web tranquillo per introversi, idealisti e chiunque desideri un ritmo piu lento."
+    },
+    "next": {
+      "h2": "Prossimi passi",
+      "p1": "Siamo solo all'inizio: incorporamenti piu ricchi, statistiche utente piu approfondite, classifiche di reputazione e altri modi per premiare la creazione ragionata.",
+      "p2": "Grazie per far parte di questo piccolo esperimento indipendente."
+    },
+    "cta": {
+      "rooms": "Esplora le stanze",
+      "signup": "Unisciti alla comunita"
+    }
+  }
+}

--- a/i18n/it/anonymousUser.json
+++ b/i18n/it/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Il viandante anonimo",
+      "description": "Nessun profilo. Nessun passato. Solo vibrazioni."
+    },
+    "ascii": {
+      "ariaLabel": "Arte ASCII di una creatura stravagante con citazione"
+    },
+    "header": {
+      "title": "L'anonimo"
+    },
+    "body": {
+      "line1": "Sei inciampato nel vuoto. Non c'e niente da vedere qui:",
+      "line2": "solo uno spirito errante senza storia."
+    },
+    "buttons": {
+      "home": "← Torna alla home",
+      "signup": "Crea un'identita"
+    }
+  }
+}

--- a/i18n/it/archive.json
+++ b/i18n/it/archive.json
@@ -1,0 +1,71 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page - Archivio",
+      "description": "Esplora l'archivio completo per mese.",
+      "titleRoom": "Daily Page - Archivio · {roomName}",
+      "descriptionRoom": "Esplora gli scritti passati nella stanza {roomName}, mese per mese. Vai a una data qualsiasi per vedere cosa hanno condiviso gli altri in questo spazio nel tempo."
+    },
+    "nav": {
+      "prev": "Precedente",
+      "next": "Successivo"
+    },
+    "title": "📚 Sfoglia gli archivi",
+    "titleRoom": "📚 {roomName} - Archivi",
+    "roomViewing": "Archivio della stanza {roomName}",
+    "viewRoomLink": "Vedi stanza",
+    "noContent": "Nessun contenuto ancora disponibile.",
+    "backToRoom": "← Torna alla dashboard della stanza",
+    "calendar": {
+      "meta": {
+        "description": "Vedi tutti i blocchi creativi pubblicati in {month} {year}, dai pensieri rapidi alle riflessioni profonde. Clicca una data per esplorare cio che e stato condiviso.",
+        "descriptionRoom": "Vedi l'attivita creativa in {roomName} durante {month} {year}. Scegli una data per esplorare i blocchi condivisi quel giorno."
+      },
+      "title": "📆 Archivio per {month} {year}",
+      "prevLabel": "Archivio per {month} {year}",
+      "nextLabel": "Archivio per {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Archivio per {date}",
+        "titleRoom": "{roomName} - Archivio per {date}",
+        "descriptionSite": "Esplora i blocchi scritti il {date}, dalle note tranquille alle confessioni piu sfrenate.",
+        "descriptionRoom": "Il {date}, gli scrittori nella stanza {roomName} hanno lasciato il segno: scorri riflessioni, idee ed espressioni condivise quel giorno."
+      },
+      "heading": "Archivio per {date}",
+      "empty": "Nessun contenuto trovato per questa data.",
+      "labels": {
+        "createdBy": "Creato da:",
+        "in": "in",
+        "on": "il {datetime}",
+        "unknownRoom": "Stanza sconosciuta"
+      },
+      "nav": {
+        "prevDay": "Giorno precedente",
+        "nextDay": "Giorno successivo"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} - Tutti i blocchi",
+        "descriptionRoom": "Sfoglia ogni blocco mai pubblicato nella stanza {roomName}. Ordina per data, titolo o voti per esplorarne la storia."
+      },
+      "header": {
+        "allBlocks": "- Tutti i blocchi"
+      },
+      "sort": {
+        "label": "Ordina per",
+        "options": {
+          "date": "Data",
+          "title": "Titolo",
+          "votes": "Voti"
+        },
+        "submit": "Vai"
+      }
+    },
+    "pagination": {
+      "prev": "← Precedente",
+      "next": "Successivo →"
+    }
+  }
+}

--- a/i18n/it/auth.json
+++ b/i18n/it/auth.json
@@ -1,0 +1,35 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page - Accedi",
+        "description": "Accedi al tuo account Daily Page per continuare il tuo percorso di scrittura."
+      },
+      "heading": "Bentornato!",
+      "subheading": "Accedi al tuo account per continuare a condividere la tua scrittura quotidiana.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Nome utente o email",
+          "placeholder": "Inserisci nome utente o email"
+        },
+        "password": {
+          "label": "Password",
+          "placeholder": "Inserisci la password"
+        }
+      },
+      "actions": {
+        "submit": "Accedi"
+      },
+      "feedback": {
+        "success": "Accesso riuscito! Reindirizzamento...",
+        "failedGeneric": "Accesso non riuscito. Riprova.",
+        "unexpected": "Si e verificato un errore imprevisto. Riprova."
+      },
+      "links": {
+        "forgotPassword": "Hai dimenticato la password?",
+        "noAccount": "Non hai ancora un account?",
+        "signupHere": "Registrati qui!"
+      }
+    }
+  }
+}

--- a/i18n/it/bestOf.json
+++ b/i18n/it/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Il meglio di Daily Page",
+      "description": "I blocchi piu amati su Daily Page: divertenti, sinceri, poetici o semplicemente strani. Scopri cosa si e distinto nell'ultimo giorno, settimana, mese e oltre.",
+      "titleRoom": "Il meglio di {roomName}",
+      "descriptionRoom": "Scopri i post piu notevoli della stanza {roomName}, quelli piu amati dai lettori nelle ultime 24 ore, 7 giorni, 30 giorni e da sempre."
+    },
+    "heading": "🏆 Il meglio di Daily Page",
+    "headingRoomPrefix": "🏆 Il meglio di ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 ore",
+      "7d": "🚀 7 giorni",
+      "30d": "🌕 30 giorni",
+      "all": "👑 Sempre"
+    },
+    "labels": {
+      "createdBy": "Creato da:",
+      "inRoom": "in",
+      "onDate": "il {date}",
+      "unknownRoom": "Stanza sconosciuta",
+      "noBlocks": "Nessun blocco trovato.",
+      "viewRoom": "Vedi stanza"
+    }
+  }
+}

--- a/i18n/it/blockCommon.json
+++ b/i18n/it/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Bozza"
+    },
+    "deleteModal": {
+      "title": "Eliminare il blocco?",
+      "message": "Questa azione non puo essere annullata.",
+      "confirm": "Elimina",
+      "cancel": "Annulla",
+      "closeAriaLabel": "Chiudi"
+    },
+    "toasts": {
+      "deleteSuccess": "Blocco eliminato con successo!",
+      "deleteFailed": "Impossibile eliminare il blocco."
+    }
+  }
+}

--- a/i18n/it/blockEditor.json
+++ b/i18n/it/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Tu)"
+    },
+    "meta": {
+      "title": "Modifica blocco - {blockTitle}",
+      "titleFallback": "Modifica blocco"
+    },
+    "errors": {
+      "imageUrlRequired": "Inserisci l'URL di un'immagine.",
+      "notFound": "Blocco non trovato o non appartenente a questa stanza.",
+      "loadFailed": "Si e verificato un errore durante il caricamento dell'editor del blocco.",
+      "updateTitleFailed": "Errore durante l'aggiornamento del titolo."
+    },
+    "roomInfo": {
+      "label": "Stanza:"
+    },
+    "title": {
+      "placeholder": "Inserisci il titolo del blocco",
+      "editTooltip": "Modifica titolo",
+      "lock": "Blocca blocco",
+      "delete": "Elimina blocco"
+    },
+    "description": {
+      "label": "Descrizione",
+      "editTooltip": "Modifica descrizione",
+      "placeholder": "Inserisci descrizione",
+      "noDescriptionOwner": "Ancora nessuna descrizione...",
+      "noDescriptionViewer": "Nessuna descrizione fornita...",
+      "save": "Salva",
+      "cancel": "Annulla",
+      "expand": "Espandi",
+      "collapse": "Comprimi",
+      "updateError": "Errore durante l'aggiornamento della descrizione."
+    },
+    "status": {
+      "lastBackup": "Ultimo backup: {datetime}",
+      "lastBackupUnknown": "Ultimo backup: sconosciuto"
+    },
+    "peers": {
+      "label": "Partecipanti:"
+    },
+    "toasts": {
+      "blockLocked": "Questo blocco e stato bloccato!"
+    },
+    "editor": {
+      "placeholder": "La pagina bianca aspetta la tua voce; scrivi senza paura."
+    },
+    "loading": {
+      "label": "Caricamento",
+      "quote": "Lascia che il mondo bruci attraverso di te. Getta sulla carta la luce del prisma, bianca e rovente.<br>- Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Non hai scritto nulla per 5 minuti. Fai clic su OK per continuare la sessione; altrimenti verrai reindirizzato all'archivio.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link di condivisione",
+      "copyTooltip": "Copia negli appunti",
+      "copied": "Copiato!"
+    },
+    "toolbar": {
+      "insertImage": "Inserisci immagine",
+      "insertImageUrlPlaceholder": "Inserisci URL immagine",
+      "insertImageAltPlaceholder": "Testo alternativo (opzionale)",
+      "insertImageConfirm": "Conferma",
+      "insertImageCancel": "Annulla"
+    },
+    "buttons": {
+      "downloadFile": "Scarica file"
+    },
+    "lockModal": {
+      "messageLine1": "Vuoi davvero bloccare questo blocco?",
+      "messageLine2": "Questo lo rendera definitivo e impedira ulteriori modifiche.",
+      "confirm": "Blocca",
+      "cancel": "Annulla",
+      "successToast": "Blocco bloccato con successo.",
+      "errorToast": "Errore durante il blocco del blocco."
+    },
+    "tags": {
+      "headerWithTags": "Tag:",
+      "headerNoTags": "Ancora nessun tag! Aggiungine qualcuno:",
+      "updateError": "Errore durante l'aggiornamento dei tag."
+    },
+    "fullBlock": {
+      "headingPrefix": "Spiacenti; il blocco \"{blockTitle}\" ora e",
+      "headingStatus": "completamente occupato.",
+      "retryPrefix": "Per favore",
+      "retryLink": "prova un blocco diverso",
+      "retrySuffix": "oppure torna un'altra volta.",
+      "consolationPrefix": "Mentre aspetti, puoi leggere",
+      "consolationBestOf": "alcuni dei nostri blocchi preferiti",
+      "consolationMiddle": "oppure sfogliare",
+      "consolationArchive": "l'archivio."
+    }
+  }
+}

--- a/i18n/it/blockList.json
+++ b/i18n/it/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "da sempre",
+      "days": "negli ultimi {n} giorni",
+      "day": "nelle ultime 24 ore"
+    },
+    "createdBy": "Creato da:",
+    "on": "il"
+  }
+}

--- a/i18n/it/blockTags.json
+++ b/i18n/it/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tag:",
+      "noTags": "Ancora nessun tag! Aggiungine qualcuno:"
+    },
+    "input": {
+      "placeholder": "Nuovo tag",
+      "addButton": "Aggiungi"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/it/blockView.json
+++ b/i18n/it/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Blocco - {blockTitle}",
+      "titleFallback": "Blocco"
+    },
+    "labels": {
+      "room": "Stanza",
+      "author": "Autore",
+      "created": "Creato",
+      "unknownAuthor": "Anonimo",
+      "authorAvatarAlt": "Avatar di {username}",
+      "viewAuthorProfile": "Vedi il profilo di {username}",
+      "lang": "Traduzioni: ",
+      "available": "disponibili"
+    },
+    "buttons": {
+      "edit": "Modifica",
+      "deleteBlock": "Elimina blocco",
+      "share": "Condividi",
+      "flagContent": "Segnala contenuto"
+    },
+    "description": {
+      "label": "Descrizione",
+      "none": "Nessuna descrizione fornita...",
+      "expand": "Espandi",
+      "collapse": "Comprimi"
+    },
+    "editorial": {
+      "heading": "Guida alla lettura",
+      "roleLabel": "Tipo di lettura",
+      "clusterLabel": "Guida",
+      "sequence": "Parte {sequence}",
+      "primaryPillarHeading": "Inizia qui",
+      "relatedHeading": "Continua a leggere",
+      "clusterHeading": "Altro in questa guida",
+      "expandSection": "Mostra altri {count}",
+      "collapseSection": "Mostra meno",
+      "roleNames": {
+        "pillar": "Guida principale",
+        "companion": "Approfondimento",
+        "texture": "Contesto"
+      }
+    },
+    "comments": {
+      "heading": "Commenti",
+      "count": "{count} commenti",
+      "empty": "Nessuno ha ancora risposto. I commenti appariranno qui quando iniziera la conversazione.",
+      "composer": {
+        "label": "Aggiungi un commento",
+        "placeholder": "Scrivi un commento...",
+        "submit": "Pubblica commento",
+        "submitting": "Pubblicazione...",
+        "success": "Commento pubblicato.",
+        "error": "Al momento non e possibile pubblicare il commento.",
+        "loginPrompt": "Accedi per partecipare alla conversazione.",
+        "loginCta": "Accedi per commentare",
+        "verifyPrompt": "Verifica la tua email prima di pubblicare un commento.",
+        "verifyCta": "Verifica email"
+      },
+      "sort": {
+        "label": "Ordina",
+        "oldestFirst": "Prima i piu vecchi",
+        "newestFirst": "Prima i piu recenti"
+      },
+      "by": "Da",
+      "unknownAuthor": "Sconosciuto",
+      "reply": {
+        "action": "Rispondi",
+        "label": "Aggiungi una risposta",
+        "placeholder": "Scrivi una risposta...",
+        "submit": "Pubblica risposta",
+        "submitting": "Pubblicazione...",
+        "success": "Risposta pubblicata.",
+        "error": "Al momento non e possibile pubblicare la risposta.",
+        "cancel": "Annulla",
+        "loginPrompt": "Accedi per rispondere."
+      },
+      "manage": {
+        "edited": "Modificato",
+        "editAction": "Modifica",
+        "deleteAction": "Elimina",
+        "deleteConfirm": "Eliminare questo commento? Verranno rimosse anche tutte le risposte sotto di esso.",
+        "deleteSuccess": "Commento eliminato.",
+        "deleteError": "Al momento non e possibile eliminare questo commento.",
+        "forbidden": "Puoi gestire solo i tuoi commenti.",
+        "edit": {
+          "label": "Modifica commento",
+          "save": "Salva",
+          "saving": "Salvataggio...",
+          "cancel": "Annulla",
+          "success": "Commento aggiornato.",
+          "error": "Al momento non e possibile aggiornare questo commento."
+        }
+      },
+      "report": {
+        "action": "Segnala",
+        "pending": "Segnalazione...",
+        "success": "Commento segnalato.",
+        "error": "Al momento non e possibile segnalare questo commento.",
+        "ownError": "Non puoi segnalare il tuo commento.",
+        "hidden": "Commento nascosto dopo la segnalazione.",
+        "reported": "Segnalato"
+      },
+      "deepLink": {
+        "focused": "Commento collegato",
+        "unavailable": "Il commento collegato non e piu disponibile."
+      },
+      "loadMore": "Carica altri commenti",
+      "loading": "Caricamento...",
+      "loadError": "Al momento non e possibile caricare altri commenti."
+    },
+    "share": {
+      "title": "Condividi questo blocco",
+      "shareOn": "Condividi su:",
+      "nativeText": "Dai un'occhiata a questo blocco: {title}",
+      "alt": {
+        "facebook": "Logo Facebook",
+        "reddit": "Logo Reddit",
+        "whatsapp": "Logo WhatsApp",
+        "twitter": "Logo Twitter"
+      }
+    },
+    "errors": {
+      "notFound": "Blocco non trovato o non appartenente a questa stanza.",
+      "loadFailed": "Errore durante il caricamento della vista del blocco."
+    }
+  }
+}

--- a/i18n/it/createBlock.json
+++ b/i18n/it/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Crea un nuovo blocco - Daily Page",
+      "description": "Inizia un nuovo blocco creativo con tag, lingua e visibilita opzionali."
+    },
+    "heading": "Crea un nuovo blocco",
+    "roomInfo": {
+      "roomLabel": "Stanza:",
+      "unavailable": "Informazioni sulla stanza non disponibili.",
+      "noDescription": "Nessuna descrizione disponibile."
+    },
+    "form": {
+      "title": {
+        "label": "Titolo:",
+        "placeholder": {
+          "full": "es. 'Il mio capolavoro', 'La migliore idea di sempre', 'Clickbait per nerd'",
+          "short": "es. 'Il mio capolavoro'"
+        }
+      },
+      "description": {
+        "label": "Descrizione (opzionale):",
+        "placeholder": "Spiega la tua genialita... oppure improvvisa."
+      },
+      "initialContent": {
+        "label": "Contenuto iniziale (opzionale):",
+        "help": "Inizia a scrivere qui oppure premi Crea per continuare nella pagina completa dell'editor, dove puoi incorporare immagini e collaborare in tempo reale.",
+        "placeholder": "Inizia il blocco qui, oppure continua a modificarlo dopo la creazione..."
+      },
+      "visibility": {
+        "label": "Visibilita:"
+      },
+      "submit": "Crea blocco"
+    },
+    "visibility": {
+      "public": {
+        "label": "Pubblico",
+        "title": "Modificabile da chiunque in tempo reale. Nessun accesso richiesto.",
+        "inline": "Modificabile da chiunque in tempo reale. Nessun accesso richiesto."
+      },
+      "private": {
+        "label": "Privato",
+        "title": "Solo per utenti registrati. Visibile al termine della modifica.",
+        "inline": "Solo per utenti registrati. Visibile al termine della modifica.",
+        "tooltip": "I blocchi privati sono solo su invito mentre lavori e diventano visibili quando hai finito."
+      }
+    },
+    "advanced": {
+      "summary": "Opzioni avanzate",
+      "lang": {
+        "label": "Lingua:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Traduci blocco esistente (URL o ID):",
+        "placeholder": "Incolla un URL o ID del blocco (opzionale)",
+        "invalid": "Non sembra un URL o ID di blocco valido.",
+        "fetchError": "Impossibile recuperare le informazioni del blocco."
+      }
+    },
+    "messages": {
+      "langExists": "Esiste gia una traduzione per quella lingua. Scegline un'altra.",
+      "genericError": "Qualcosa e andato storto. Riprova."
+    }
+  }
+}

--- a/i18n/it/dashboard.json
+++ b/i18n/it/dashboard.json
@@ -1,0 +1,45 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Dashboard",
+      "description": "La tua dashboard di Daily Page e panoramica dell'account."
+    },
+    "profile": {
+      "profilePicAlt": "Immagine del profilo",
+      "noBio": "Ancora nessuna bio. Fai clic su \"Modifica\" per aggiungerne una!",
+      "editBio": "Modifica bio",
+      "bioPlaceholder": "Inserisci qui la tua bio",
+      "save": "Salva",
+      "cancel": "Annulla"
+    },
+    "activity": {
+      "title": "Attivita recente",
+      "none": "Nessuna attivita recente.",
+      "updatedOn": "Aggiornato il {date}",
+      "viewAllBlocks": "Vedi tutti i blocchi"
+    },
+    "streak": {
+      "title": "Serie di scrittura",
+      "line": "{days} giorni di fila! Continua cosi!"
+    },
+    "starredRooms": {
+      "title": "Stanze preferite",
+      "none": "Non hai ancora aggiunto stanze ai preferiti. Inizia a esplorare per trovare le tue preferite!",
+      "viewAll": "Vedi tutte le stanze preferite",
+      "unnamedRoom": "Stanza senza nome"
+    },
+    "stats": {
+      "title": "Le tue statistiche",
+      "totalBlocks": "Blocchi totali creati",
+      "collaborations": "Collaborazioni",
+      "votesGiven": "Voti dati",
+      "daysActive": "Giorni attivi",
+      "viewDetailed": "Vedi statistiche dettagliate 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Caricamento dell'immagine del profilo non riuscito. Riprova.",
+      "uploadUnexpected": "Si e verificato un errore imprevisto. Riprova.",
+      "bioUpdateFailed": "Errore durante l'aggiornamento della bio. Riprova."
+    }
+  }
+}

--- a/i18n/it/detailedStats.json
+++ b/i18n/it/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Statistiche dettagliate",
+      "description": "Un resoconto dettagliato della tua attivita su Daily Page."
+    },
+    "nav": {
+      "backToDashboard": "← Torna alla dashboard"
+    },
+    "header": {
+      "title": "📊 Panoramica delle tue statistiche 📊"
+    },
+    "cards": {
+      "totalBlocks": "Blocchi totali creati 📝",
+      "collaborations": "Collaborazioni 🤝",
+      "votesGiven": "Voti dati 👍",
+      "daysActive": "Giorni attivi 📆"
+    },
+    "chart": {
+      "datasetLabel": "Le tue statistiche",
+      "labels": {
+        "blocksCreated": "Blocchi creati",
+        "collaborations": "Collaborazioni",
+        "votesGiven": "Voti dati",
+        "daysActive": "Giorni attivi"
+      }
+    }
+  }
+}

--- a/i18n/it/errors.json
+++ b/i18n/it/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ops! Qualcosa e andato storto.",
+      "message": "Si e verificato un errore imprevisto. Riprova piu tardi.",
+      "home": "Torna alla home"
+    },
+    "notFound": {
+      "title": "404 - Pagina non trovata",
+      "metaTitle": "Pagina non trovata",
+      "message": "Spiacenti, non siamo riusciti a trovare la pagina che cercavi.",
+      "homePrefix": "Puoi tornare a",
+      "homeLink": "la homepage",
+      "roomsPrefix": "oppure dare un'occhiata alla",
+      "roomsLink": "directory delle stanze."
+    }
+  }
+}

--- a/i18n/it/flagModal.json
+++ b/i18n/it/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Segnala contenuto inappropriato",
+    "fields": {
+      "reason": {
+        "label": "Motivo",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Offensivo (linguaggio d'odio o insulti)",
+          "inappropriate": "Inappropriato (nudita, contenuti grafici, ecc.)",
+          "other": "Altro"
+        }
+      },
+      "details": {
+        "label": "Dettagli (opzionale)",
+        "placeholder": "Descrivi cosa hai visto..."
+      }
+    },
+    "buttons": {
+      "submit": "Invia segnalazione",
+      "cancel": "Annulla"
+    },
+    "toasts": {
+      "success": "Segnalazione inviata, grazie!",
+      "failed": "Invio della segnalazione non riuscito."
+    }
+  }
+}

--- a/i18n/it/forgotPassword.json
+++ b/i18n/it/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Reimposta password",
+      "description": "Richiedi un link di reimpostazione per il tuo account Daily Page."
+    },
+    "header": {
+      "title": "Hai dimenticato la password?",
+      "subtitle": "Inserisci la tua email e ti invieremo un link di reimpostazione."
+    },
+    "form": {
+      "email": {
+        "label": "Indirizzo email",
+        "placeholder": "Inserisci la tua email"
+      },
+      "submit": "Richiedi reimpostazione password"
+    },
+    "feedback": {
+      "successGeneric": "Se quell'email esiste, e stato inviato un link di reimpostazione.",
+      "missingEmail": "L'email e obbligatoria.",
+      "genericError": "Qualcosa e andato storto. Riprova.",
+      "unexpectedError": "Si e verificato un errore imprevisto. Riprova."
+    },
+    "email": {
+      "subject": "Reimposta la password di Daily Page",
+      "heading": "Richiesta di reimpostazione password",
+      "headingWithName": "Richiesta di reimpostazione password, {username}",
+      "body": "Fai clic sul link qui sotto per reimpostare la password.",
+      "cta": "Reimposta la mia password",
+      "expires": "Questo link scade tra {hours} ora/e.",
+      "ignore": "Se non hai richiesto la reimpostazione della password, puoi ignorare questa email."
+    }
+  }
+}

--- a/i18n/it/home.json
+++ b/i18n/it/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Blocchi migliori nelle ultime 24 ore",
+      "description": "Daily Page e un sito di scrittura minimale e indipendente dove chiunque puo pubblicare pensieri creativi, ricordi o esperimenti, un blocco alla volta. Esplora nuove idee, entra nelle stanze e fai sentire la tua voce."
+    },
+    "hero": {
+      "eyebrow": "Un posto tranquillo per scrivere, leggere e tornare",
+      "title": "Benvenuto su Daily Page!",
+      "subtitle": "Esplora i blocchi piu popolari delle ultime 24 ore.",
+      "ctaPrefix": "Ti senti ispirato?",
+      "cta": "Entra in una stanza",
+      "ctaSuffix": "e crea il tuo blocco!"
+    },
+    "stats": {
+      "blocks": "Blocchi",
+      "rooms": "Stanze",
+      "tags": "Tag",
+      "collabsToday": "Collaborazioni oggi"
+    },
+    "activity": {
+      "title": "In diretta su Daily Page",
+      "subtitle": "Conversazioni e reazioni fresche, tutte a colpo d'occhio.",
+      "fallbackActor": "Qualcuno",
+      "inRoom": "in",
+      "comments": {
+        "title": "Commenti recenti",
+        "more": "Cerca discussioni",
+        "commentVerb": "ha commentato",
+        "replyVerb": "ha risposto a",
+        "empty": "Ancora nessun commento recente. La prossima conversazione puo iniziare dal tuo blocco."
+      },
+      "reactions": {
+        "title": "Reazioni recenti",
+        "more": "Sfoglia i blocchi migliori",
+        "empty": "Ancora nessuna reazione recente. Un buon post potrebbe ravvivare tutto in fretta.",
+        "types": {
+          "heart": "ha messo un cuore a",
+          "leaf": "ha reagito con una foglia a",
+          "wow": "ha reagito con wow a",
+          "laugh": "ha riso di"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Stanza in evidenza",
+      "roomInfoDays": "Attivita negli ultimi {days} giorni: {blocks} blocchi, {votes} voti.",
+      "roomInfo24h": "Attivita nelle ultime 24 ore: {blocks} blocchi, {votes} voti.",
+      "checkItOut": "Dai un'occhiata",
+      "blockRibbon": "★ Blocco in evidenza",
+      "votes": "{n} voti",
+      "noContent": "(Nessun contenuto fornito...)",
+      "viewBlock": "Vedi blocco"
+    },
+    "trendingTags": {
+      "title": "Tag di tendenza",
+      "suffixDays": "(ultimi {days} giorni)",
+      "suffixAllTime": "(sempre)",
+      "blocks": "{n} blocchi",
+      "votes": "{n} voti",
+      "empty": "Ancora nessun tag di tendenza. Sii il primo a taggare qualcosa di interessante!"
+    },
+    "trendingBlocks": {
+      "title": "Blocchi di tendenza",
+      "suffixDays": "(ultimi {days} giorni)",
+      "createdBy": "Creato da:",
+      "in": "in",
+      "on": "il",
+      "unknownRoom": "Stanza sconosciuta",
+      "empty24h": "Ancora nessun blocco nelle ultime 24 ore. Torna presto, compa!"
+    }
+  }
+}

--- a/i18n/it/layout.json
+++ b/i18n/it/layout.json
@@ -1,0 +1,18 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Benvenuto, utente!",
+    "logout": "Esci",
+    "login": "Accedi / Registrati",
+    "language": "Lingua",
+    "openMenu": "Apri menu principale",
+    "closeMenu": "Chiudi menu principale",
+    "privacy": "Informativa sulla privacy",
+    "uiFallbackNotice": "{requested} non e ancora tradotto. Per ora viene mostrato {current}.",
+    "copyButton": {
+      "copy": "Copia",
+      "copied": "Copiato!"
+    },
+    "copyright": "© {year}"
+  }
+}

--- a/i18n/it/modals.json
+++ b/i18n/it/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Effettua l'accesso",
+      "message": "Devi effettuare l'accesso per continuare.",
+      "messageWithAction": "Devi effettuare l'accesso per {action}.",
+      "cta": "Accedi"
+    },
+    "actions": {
+      "voteOnBlock": "votare un blocco",
+      "starRoom": "aggiungere questa stanza ai preferiti",
+      "reactToBlock": "reagire a questo post",
+      "commentOnBlock": "commentare questo blocco",
+      "reportComment": "segnalare questo commento"
+    },
+    "errors": {
+      "starToggleFail": "Impossibile aggiornare lo stato del preferito. Riprova."
+    }
+  }
+}

--- a/i18n/it/nav.json
+++ b/i18n/it/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Home",
+    "rooms": "Stanze",
+    "tags": "Tag",
+    "archive": "Archivio",
+    "search": "Cerca",
+    "bestOf": "Il meglio",
+    "about": "Info",
+    "support": "Supporto",
+    "otherProjects": "Altri progetti",
+    "auth": {
+      "welcomePrefix": "Benvenuto, ",
+      "welcomeFallbackUser": "te",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Dashboard"
+  }
+}

--- a/i18n/it/notifications.json
+++ b/i18n/it/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Notifiche",
+      "openMenu": "Apri notifiche",
+      "loading": "Caricamento notifiche...",
+      "error": "Al momento non e possibile caricare le notifiche.",
+      "empty": "Ancora nessuna notifica.",
+      "markRead": "Segna come letta",
+      "fallbackActor": "Qualcuno",
+      "fallbackBlockTitle": "il tuo blocco",
+      "item": {
+        "blockComment": "{actorUsername} ha commentato il tuo blocco \"{blockTitle}\".",
+        "commentReply": "{actorUsername} ha risposto al tuo commento su \"{blockTitle}\".",
+        "unknown": "Notifica"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Nuovo commento su \"{blockTitle}\"",
+        "heading": "Nuovo commento sul tuo blocco",
+        "headingWithName": "Ciao {username},",
+        "body": "<strong>{actorUsername}</strong> ha commentato il tuo blocco <strong>{blockTitle}</strong>.",
+        "cta": "Vedi la conversazione su Daily Page",
+        "fallbackActor": "Qualcuno",
+        "fallbackBlockTitle": "il tuo blocco"
+      },
+      "commentReply": {
+        "subject": "Nuova risposta su \"{blockTitle}\"",
+        "heading": "Nuova risposta al tuo commento",
+        "headingWithName": "Ciao {username},",
+        "body": "<strong>{actorUsername}</strong> ha risposto al tuo commento su <strong>{blockTitle}</strong>.",
+        "cta": "Vedi la conversazione su Daily Page",
+        "fallbackActor": "Qualcuno",
+        "fallbackBlockTitle": "il tuo blocco"
+      }
+    }
+  }
+}

--- a/i18n/it/privacy.json
+++ b/i18n/it/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page - Informativa sulla privacy",
+      "description": "Come Daily Page raccoglie, usa e protegge i tuoi dati, in parole semplici."
+    },
+    "title": "Informativa sulla privacy",
+    "lastUpdated": "Ultimo aggiornamento: {date}",
+    "intro": {
+      "h2": "Introduzione",
+      "p1": "Daily Page (\"noi\", \"ci\" o \"nostro\") gestisce il sito dailypage.org (di seguito il \"Servizio\").",
+      "p2": "Questa pagina ti informa sulle nostre politiche relative alla raccolta, all'uso e alla divulgazione dei dati personali quando usi il nostro Servizio."
+    },
+    "collection": {
+      "h2": "Raccolta e uso delle informazioni",
+      "p": "Raccogliamo dati personali minimi per migliorare e fornire il nostro Servizio. Questo include indirizzi email per la gestione dell'account e contenuti inviati volontariamente dagli utenti."
+    },
+    "usage": {
+      "h2": "Uso dei dati",
+      "p": "I dati raccolti vengono usati solo per l'autenticazione dell'account, la moderazione dei contenuti e il miglioramento dell'esperienza utente."
+    },
+    "storage": {
+      "h2": "Archiviazione e sicurezza dei dati",
+      "p": "I tuoi dati sono archiviati in modo sicuro e non vengono mai condivisi o venduti a terzi senza consenso esplicito, salvo quanto richiesto dalla legge."
+    },
+    "cookies": {
+      "h2": "Cookie",
+      "p": "Usiamo i cookie solo per la gestione della sessione e per migliorare l'esperienza utente. Puoi disattivarli dalle impostazioni del browser."
+    },
+    "rights": {
+      "h2": "I tuoi diritti",
+      "p": "Puoi richiedere in qualsiasi momento l'eliminazione o la modifica dei tuoi dati personali contattandoci."
+    },
+    "changes": {
+      "h2": "Modifiche a questa informativa sulla privacy",
+      "p": "Potremmo aggiornare periodicamente la nostra informativa sulla privacy. Le modifiche saranno pubblicate su questa pagina."
+    },
+    "contact": {
+      "h2": "Contattaci",
+      "p": "Per domande su questa informativa sulla privacy, contattaci a:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/it/profile.json
+++ b/i18n/it/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Profilo di {username}",
+      "descriptionUser": "Vedi l'attivita recente, le stanze preferite e le statistiche di {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Immagine del profilo",
+      "noBio": "(Nessuna bio disponibile.)"
+    },
+    "activity": {
+      "title": "Attivita recente",
+      "updatedOn": "Aggiornato il {date}",
+      "none": "Nessuna attivita recente.",
+      "viewAllBlocks": "Vedi tutti i blocchi"
+    },
+    "starredRooms": {
+      "title": "Stanze preferite",
+      "none": "Ancora nessuna stanza preferita.",
+      "unnamedRoom": "Stanza senza nome"
+    },
+    "stats": {
+      "title": "Statistiche utente",
+      "totalBlocks": "Blocchi totali creati",
+      "collaborations": "Collaborazioni",
+      "daysActive": "Giorni attivi"
+    }
+  }
+}

--- a/i18n/it/random.json
+++ b/i18n/it/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page - Altri progetti",
+      "description": "Esplora diari sul baseball, esperimenti di scrittura casuale e altri progetti paralleli di Daily Page."
+    },
+    "title": "Altri progetti",
+    "tagline": "Un angolo accogliente per esperimenti e missioni secondarie.",
+    "links": {
+      "baseball": "📖 Diario di baseball",
+      "randomWriter": "🎲 Scrittore casuale"
+    },
+    "cta": {
+      "backToRooms": "Torna alle stanze principali"
+    }
+  }
+}

--- a/i18n/it/randomWriter.json
+++ b/i18n/it/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page - Scrittore casuale",
+      "description": "Genera un flusso infinito di pseudo-testo casuale per divertimento, ispirazione o caos."
+    },
+    "title": "Scrittore casuale",
+    "buttons": {
+      "clear": "Cancella",
+      "stop": "Interrompi scrittura",
+      "start": "Avvia scrittura"
+    }
+  }
+}

--- a/i18n/it/reactions.json
+++ b/i18n/it/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "Reazioni {emoji}: {count}",
+    "loginToReact": "Accedi per reagire",
+    "countsLabel": "Reazioni"
+  }
+}

--- a/i18n/it/readMore.json
+++ b/i18n/it/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Altro...",
+    "aria": "Leggi il blocco completo: {title}"
+  }
+}

--- a/i18n/it/resetPassword.json
+++ b/i18n/it/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Reimposta la password",
+      "description": "Imposta una nuova password per il tuo account."
+    },
+    "header": {
+      "title": "Reimposta la password",
+      "subtitle": "Scegli una nuova password per recuperare l'accesso."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Nuova password",
+        "placeholder": "Inserisci nuova password"
+      },
+      "submit": "Imposta nuova password"
+    },
+    "feedback": {
+      "missingToken": "Token mancante o non valido.",
+      "missingFields": "Token e nuova password sono obbligatori.",
+      "invalidOrExpired": "Token non valido o scaduto.",
+      "success": "Password aggiornata con successo!",
+      "genericError": "Qualcosa e andato storto. Riprova.",
+      "unexpectedError": "Si e verificato un errore imprevisto. Riprova."
+    }
+  }
+}

--- a/i18n/it/roomDashboard.json
+++ b/i18n/it/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page - {roomName}",
+      "description": "Esplora i blocchi recenti e in corso in {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Esplora:",
+      "allBlocks": "🗂️ Tutti i blocchi",
+      "browseByDate": "🗓️ Per data",
+      "bestOf": "🏅 Il meglio",
+      "searchInRoom": "🔎 Cerca"
+    },
+    "actions": {
+      "createBlock": "Crea un blocco",
+      "starTitle": "Aggiungi questa stanza ai preferiti",
+      "unstarTitle": "Rimuovi questa stanza dai preferiti"
+    },
+    "tabs": {
+      "locked": "Blocchi bloccati",
+      "inProgress": "Blocchi in corso"
+    },
+    "sections": {
+      "lockedHeader": "Blocchi bloccati",
+      "inProgressHeader": "Blocchi in corso"
+    },
+    "editorial": {
+      "heading": "Guide in evidenza",
+      "description": "Inizia da qui con le guide in evidenza curate per questa stanza.",
+      "roleNames": {
+        "pillar": "Guida principale",
+        "companion": "Guida alla lettura",
+        "texture": "Guida di contesto"
+      }
+    },
+    "empty": {
+      "noDescription": "Nessuna descrizione disponibile.",
+      "noLocked": "Ancora nessun blocco bloccato! I blocchi si bloccano automaticamente dopo 1 ora di inattivita.",
+      "noInProgress": "Ancora nessun blocco in corso! E il momento di iniziarne uno.",
+      "noBlocks": "Ancora nessun blocco! Crea il primo e lascia il segno. 😎"
+    }
+  }
+}

--- a/i18n/it/roomsDirectory.json
+++ b/i18n/it/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Directory delle stanze",
+      "description": "Ogni stanza e una porta verso un mondo diverso. Entra, condividi la tua storia e unisciti agli altri per costruire qualcosa di bello."
+    },
+    "eyebrow": "Trova il tuo angolo",
+    "heading": "Directory delle stanze",
+    "intro": "Inizia dalle stanze che sembrano vive in questo momento, oppure vaga per argomento finche qualcosa non scatta. Ogni stanza e uno spunto di scrittura, un fandom o un'ossessione condivisa che aspetta la tua voce.",
+    "empty": "Al momento non ci sono stanze disponibili. Torna piu tardi!",
+    "jumpToActive": "Vedi stanze attive",
+    "jumpToTopics": "Sfoglia per argomento",
+    "statsLabel": "Punti salienti della directory delle stanze",
+    "liveNow": "Attive ora",
+    "recentlyActive": "Attive di recente",
+    "recentlyActiveSubtitle": "Il modo piu rapido per trovare una stanza con persone presenti ora.",
+    "browseByTopic": "Sfoglia per argomento",
+    "topicSubtitle": "Apri un argomento per esplorarne le stanze.",
+    "roomCount": "{count} stanze",
+    "stats": {
+      "rooms": "stanze da esplorare",
+      "topics": "gruppi di argomenti",
+      "active": "scelte attive"
+    },
+    "activeUsers": "Utenti attivi: {count}",
+    "visitRoom": "Visita stanza",
+    "close": "Chiudi",
+    "noTitle": "Nessun titolo disponibile",
+    "noDescription": "Nessuna descrizione disponibile"
+  }
+}

--- a/i18n/it/search.json
+++ b/i18n/it/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Cerca",
+      "description": "Cerca nei blocchi pubblici."
+    },
+    "title": "Cerca",
+    "placeholder": "Cerca blocchi...",
+    "hint": "Digita almeno 2 caratteri per cercare.",
+    "noResults": "Nessun risultato trovato.",
+    "untitled": "Senza titolo",
+    "votesTitle": "Voti",
+    "pageLabel": "Pagina",
+    "filters": {
+      "inRoom": "Nella stanza"
+    },
+    "buttons": {
+      "search": "Cerca",
+      "prev": "Prec",
+      "next": "Successivo"
+    }
+  }
+}

--- a/i18n/it/signup.json
+++ b/i18n/it/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Crea un account",
+      "description": "Registrati a Daily Page per accedere a tutte le funzionalita."
+    },
+    "header": {
+      "title": "Crea il tuo account",
+      "subtitle": "Unisciti a Daily Page per iniziare a creare e condividere la tua scrittura quotidiana!"
+    },
+    "form": {
+      "email": {
+        "label": "Email",
+        "placeholder": "Inserisci la tua email"
+      },
+      "username": {
+        "label": "Nome utente",
+        "placeholder": "Inserisci il nome utente"
+      },
+      "password": {
+        "label": "Password",
+        "placeholder": "Inserisci una password"
+      },
+      "submit": "Registrati",
+      "feedback": {
+        "success": "Invio del modulo riuscito!",
+        "successCreatedVerify": "Account creato con successo! Controlla la tua email per verificarlo.",
+        "genericError": "Creazione dell'account non riuscita. Riprova.",
+        "unexpectedError": "Si e verificato un errore imprevisto. Riprova."
+      }
+    }
+  }
+}

--- a/i18n/it/starredRooms.json
+++ b/i18n/it/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Tutte le stanze preferite",
+      "description": "Un elenco di tutte le stanze che hai aggiunto ai preferiti."
+    },
+    "nav": {
+      "backToDashboard": "← Torna alla dashboard"
+    },
+    "header": {
+      "title": "🌟 Tutte le tue stanze preferite 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Stanza senza nome",
+      "noDescription": "Nessuna descrizione."
+    },
+    "empty": {
+      "message": "Non hai ancora aggiunto stanze ai preferiti!"
+    }
+  }
+}

--- a/i18n/it/support.json
+++ b/i18n/it/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page - Supporto",
+      "description": "Come metterti in contatto, segnalare problemi, richiedere funzionalita o stanze e sostenere economicamente Daily Page."
+    },
+    "contact": {
+      "h1": "★ Vorrei fare una domanda, segnalare un problema o richiedere una funzionalita.",
+      "p1": {
+        "before": "Se preferisci usare GitHub, controlla",
+        "link": "le issue di questo progetto",
+        "after": "e aggiungi la tua voce. Naturalmente sono benvenute anche le pull request."
+      },
+      "p2": {
+        "before": "In alternativa,",
+        "link": "invia un'email",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Vorrei sostenere questo progetto con un contributo.",
+      "p1": {
+        "before": "Grazie in anticipo per finanziare questo progetto. Invia i pagamenti in modo sicuro tramite",
+        "paypal": "PayPal",
+        "middle": "oppure, se preferisci,",
+        "amazon": "ordina qualche sacchetto dei giocattoli che vendo su Amazon",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Vorrei richiedere una nuova stanza.",
+      "form": {
+        "nameLabel": "Nome stanza",
+        "topicLabel": "Argomento (opzionale)",
+        "descriptionLabel": "Descrizione",
+        "submit": "Invia richiesta",
+        "success": "Richiesta inviata con successo!",
+        "errorGeneric": "Invio della richiesta non riuscito. Riprova.",
+        "errorUnexpected": "Si e verificato un errore imprevisto. Riprova."
+      }
+    }
+  }
+}

--- a/i18n/it/tags.json
+++ b/i18n/it/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page - Panoramica tag",
+      "description": "Sfoglia tutti i tag usati su Daily Page, con filtri rapidi per periodo."
+    },
+    "title": "Panoramica tag",
+    "intro": "Esplora tutti i tag usati in Daily Page.",
+    "tagCloudTitle": "Nuvola di tag",
+    "timeframe": {
+      "last24h": "Ultime 24 ore",
+      "last7d": "Ultimi 7 giorni",
+      "last30d": "Ultimi 30 giorni",
+      "all": "Sempre"
+    },
+    "error": {
+      "loading": "Errore durante il caricamento della panoramica tag"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Blocchi taggati con"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Blocchi totali con",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Creato da:",
+        "inRoom": "in",
+        "unknownRoom": "Stanza sconosciuta",
+        "onDate": "il"
+      },
+      "chart": {
+        "label": "Blocchi creati nel tempo"
+      },
+      "empty": {
+        "message": "Ancora nessun blocco trovato con questo tag. Forse dovresti creare il primo? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Errore durante il caricamento della pagina del tag"
+      }
+    }
+  }
+}

--- a/i18n/it/translation.json
+++ b/i18n/it/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Tradotto da",
+    "see": "vedi",
+    "originalBlock": "blocco originale"
+  }
+}

--- a/i18n/it/userBlocks.json
+++ b/i18n/it/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "I tuoi blocchi",
+      "description": "Sfoglia e ordina tutti i blocchi che hai creato o a cui hai collaborato."
+    },
+    "header": {
+      "dashboardLink": "La tua dashboard",
+      "profileLink": "Profilo di {username}",
+      "allBlocks": "Tutti i blocchi"
+    },
+    "empty": "Ancora nessun blocco.",
+    "pagination": {
+      "prev": "← Precedente",
+      "next": "Successivo →"
+    },
+    "titleUser": "Blocchi di {username}"
+  }
+}

--- a/i18n/it/verifyEmail.json
+++ b/i18n/it/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Verifica email",
+      "description": "Verifica il tuo indirizzo email per Daily Page."
+    },
+    "header": {
+      "title": "Verifica della tua email..."
+    },
+    "status": {
+      "checking": "Controllo del token, attendi...",
+      "missingToken": "Token di verifica mancante o non valido.",
+      "genericFailure": "Verifica non riuscita.",
+      "unexpectedError": "Si e verificato un errore imprevisto.",
+      "success": "Il tuo account e stato verificato con successo!",
+      "invalidOrExpired": "Token di verifica non valido o scaduto."
+    },
+    "verificationMsg": {
+      "subject": "Verifica il tuo account Daily Page ✨",
+      "heading": "Benvenuto su Daily Page, {username}!",
+      "body": "Verifica la tua email facendo clic qui sotto:",
+      "cta": "Verifica indirizzo email",
+      "expires": "Questo link scade tra {hours} ore."
+    }
+  }
+}

--- a/i18n/it/voteControls.json
+++ b/i18n/it/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Voto positivo",
+    "downvote": "Voto negativo",
+    "errors": {
+      "failed": "Impossibile salvare il voto."
+    }
+  }
+}

--- a/i18n/ru/createBlock.json
+++ b/i18n/ru/createBlock.json
@@ -48,7 +48,34 @@
     "advanced": {
       "summary": "Дополнительные параметры",
       "lang": {
-        "label": "Язык:"
+        "label": "Язык:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
       },
       "translate": {
         "label": "Перевести существующий блок (URL или ID):",

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {

--- a/views/rooms/create-block.pug
+++ b/views/rooms/create-block.pug
@@ -67,32 +67,14 @@ block content
       .form-group
         label(for='lang')= t('createBlock.advanced.lang.label')
         select#lang(name='lang')
-          //- mismo listado de opciones; las etiquetas pueden quedarse en su idioma nativo
-          option(value='en' selected) English
-          option(value='es') Español
-          option(value='fr') Français
-          option(value='ru') Русский
-          option(value='id') Bahasa Indonesia
-          option(value='de') Deutsch
-          option(value='it') Italiano
-          option(value='pt') Português
-          option(value='zh') 中文
-          option(value='ja') 日本語
-          option(value='ko') 한국어
-          option(value='ar') العربية
-          option(value='hi') हिन्दी
-          option(value='tr') Türkçe
-          option(value='nl') Nederlands
-          option(value='sv') Svenska
-          option(value='no') Norsk
-          option(value='da') Dansk
-          option(value='fi') Suomi
-          option(value='pl') Polski
-          option(value='cs') Čeština
-          option(value='el') Ελληνικά
-          option(value='he') עברית
-          option(value='th') ไทย
-          option(value='vi') Tiếng Việt
+          -
+            const contentLangCodes = [
+              'en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja',
+              'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl',
+              'cs', 'el', 'he', 'th', 'vi'
+            ];
+          each code in contentLangCodes
+            option(value=code selected=code === 'en')= t(`createBlock.advanced.lang.options.${code}`)
       .form-group
         label(for='source-block')= t('createBlock.advanced.translate.label')
         input#source-block(type='text' placeholder=t('createBlock.advanced.translate.placeholder'))


### PR DESCRIPTION
## Summary
- Added complete `i18n/it` locale files translated from the English source JSON.
- Registered `it` as a fully supported UI locale and notification email locale.
- Moved the create-block language dropdown labels into i18n and added labels across locales.

## Validation
- Parsed all locale JSON successfully.
- Verified `i18n/it` matches `i18n/en` file-for-file and key-for-key.
- Confirmed `it` is recognized by the UI locale support list.
- Confirmed `views/rooms/create-block.pug` compiles.
