### PR TITLE
Add Portuguese UI locale support

### DIFF
--- a/i18n/pt/about.json
+++ b/i18n/pt/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Sobre",
+      "description": "O que é o Daily Page, como funciona e por que foi criado como um canto mais lento e gentil da web."
+    },
+    "title": "Sobre o Daily Page",
+    "tagline": "Alimente sua mente, não o seu feed.",
+    "mission": {
+      "h2": "Missão",
+      "p1": "Um laboratório independente de escrita, iniciado na minha sala de estar e movido pela curiosidade dos leitores.",
+      "p2": "Ele foi criado não para apodrecer seu cérebro, mas para nutri-lo: um lugar onde você pode escrever devagar, anonimamente se quiser, e nunca se preocupar em impressionar ninguém."
+    },
+    "how": {
+      "h2": "Como Funciona",
+      "features": {
+        "rooms": {
+          "label": "Salas",
+          "text": "são silos de tópicos (pense em “subreddit, mas mais amigável”)."
+        },
+        "blocks": {
+          "label": "Blocos",
+          "text": "são posts colaborativos: qualquer pessoa (até “anônima”) pode criar um, editá-lo até que seja bloqueado e votar nos outros."
+        },
+        "privacy": {
+          "label": "Privacidade e Compartilhamento",
+          "text": "Blocos públicos ficam no feed da sala. Blocos privados ficam ocultos até serem bloqueados, mas você recebe um link de compartilhamento para convidar amigos."
+        },
+        "markdown": {
+          "label": "Markdown e Mídia",
+          "text": "Você escreve em markdown, incorpora imagens e coedita como no Google Docs."
+        },
+        "trends": {
+          "label": "Tendências e Tags",
+          "text": "Marque seu bloco, acompanhe tendências de tags e descubra os melhores conteúdos (7 dias / 30 dias / todos os tempos)."
+        },
+        "streaks": {
+          "label": "Sequências",
+          "text": "Mantenha viva sua sequência diária de escrita: seu melhor incentivo para aparecer todos os dias."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Como Chegamos Aqui",
+      "p1": "Em 2018, criei uma wiki baseada em datas para a “página de hoje” e vi alguns escritores introspectivos transformá-la em uma válvula de escape para seus pensamentos. Ela nunca ficou enorme, mas plantou uma semente.",
+      "p2": "Avançando para agora, o Daily Page é essa semente transformada em muitas salas: uma web social tranquila para introvertidos, idealistas e qualquer pessoa que deseje um ritmo mais lento."
+    },
+    "next": {
+      "h2": "O Que Vem a Seguir",
+      "p1": "Estamos apenas começando: incorporações mais ricas, estatísticas de usuário mais profundas, rankings de reputação e mais formas de recompensar a criação cuidadosa.",
+      "p2": "Obrigado por fazer parte deste pequeno experimento independente."
+    },
+    "cta": {
+      "rooms": "Explorar Salas",
+      "signup": "Entrar na Comunidade"
+    }
+  }
+}

--- a/i18n/pt/anonymousUser.json
+++ b/i18n/pt/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "O Viajante Anônimo",
+      "description": "Sem perfil. Sem passado. Só boas vibrações."
+    },
+    "ascii": {
+      "ariaLabel": "Arte ASCII de criatura caprichosa com citação"
+    },
+    "header": {
+      "title": "O Anônimo"
+    },
+    "body": {
+      "line1": "Você tropeçou no vazio. Não há nada para ver aqui —",
+      "line2": "apenas um espírito errante sem história."
+    },
+    "buttons": {
+      "home": "← Voltar para o início",
+      "signup": "Criar uma identidade"
+    }
+  }
+}

--- a/i18n/pt/archive.json
+++ b/i18n/pt/archive.json
@@ -1,0 +1,71 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arquivo",
+      "description": "Explore o arquivo completo por mês.",
+      "titleRoom": "Daily Page — Arquivo · {roomName}",
+      "descriptionRoom": "Explore textos anteriores na sala {roomName}, mês a mês. Pule para qualquer data para ver o que outras pessoas compartilharam neste espaço ao longo do tempo."
+    },
+    "nav": {
+      "prev": "Anterior",
+      "next": "Próximo"
+    },
+    "title": "📚 Navegar pelos Arquivos",
+    "titleRoom": "📚 {roomName} — Arquivos",
+    "roomViewing": "Visualizando o arquivo da sala {roomName}",
+    "viewRoomLink": "Ver sala",
+    "noContent": "Ainda não há conteúdo disponível.",
+    "backToRoom": "← Voltar ao Painel da Sala",
+    "calendar": {
+      "meta": {
+        "description": "Veja todos os blocos criativos publicados em {month} de {year}, de pensamentos rápidos a reflexões profundas. Clique em qualquer data para explorar o que foi compartilhado.",
+        "descriptionRoom": "Veja a atividade criativa em {roomName} durante {month} de {year}. Escolha uma data para explorar os blocos compartilhados naquele dia."
+      },
+      "title": "📆 Arquivo de {month} de {year}",
+      "prevLabel": "Arquivo de {month} de {year}",
+      "nextLabel": "Arquivo de {month} de {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Arquivo de {date}",
+        "titleRoom": "{roomName} — Arquivo de {date}",
+        "descriptionSite": "Explore os blocos escritos em {date}, de notas silenciosas a confissões intensas.",
+        "descriptionRoom": "Em {date}, escritores na sala {roomName} deixaram sua marca: percorra reflexões, ideias e expressões compartilhadas naquele dia."
+      },
+      "heading": "Arquivo de {date}",
+      "empty": "Nenhum conteúdo encontrado para esta data.",
+      "labels": {
+        "createdBy": "Criado por:",
+        "in": "em",
+        "on": "em {datetime}",
+        "unknownRoom": "Sala Desconhecida"
+      },
+      "nav": {
+        "prevDay": "Dia anterior",
+        "nextDay": "Próximo dia"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Todos os Blocos",
+        "descriptionRoom": "Navegue por todos os blocos já publicados na sala {roomName}. Ordene por data, título ou votos para explorar sua história."
+      },
+      "header": {
+        "allBlocks": "— Todos os Blocos"
+      },
+      "sort": {
+        "label": "Ordenar por",
+        "options": {
+          "date": "Data",
+          "title": "Título",
+          "votes": "Votos"
+        },
+        "submit": "Ir"
+      }
+    },
+    "pagination": {
+      "prev": "← Anterior",
+      "next": "Próximo →"
+    }
+  }
+}

--- a/i18n/pt/auth.json
+++ b/i18n/pt/auth.json
@@ -1,0 +1,35 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Entrar",
+        "description": "Entre na sua conta do Daily Page para continuar sua jornada de escrita."
+      },
+      "heading": "Boas-vindas de volta!",
+      "subheading": "Entre na sua conta para continuar compartilhando sua escrita diária.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Nome de usuário ou Email",
+          "placeholder": "Digite seu nome de usuário ou email"
+        },
+        "password": {
+          "label": "Senha",
+          "placeholder": "Digite sua senha"
+        }
+      },
+      "actions": {
+        "submit": "Entrar"
+      },
+      "feedback": {
+        "success": "Login realizado com sucesso! Redirecionando...",
+        "failedGeneric": "Falha no login. Tente novamente.",
+        "unexpected": "Ocorreu um erro inesperado. Tente novamente."
+      },
+      "links": {
+        "forgotPassword": "Esqueceu sua senha?",
+        "noAccount": "Ainda não tem uma conta?",
+        "signupHere": "Cadastre-se aqui!"
+      }
+    }
+  }
+}

--- a/i18n/pt/bestOf.json
+++ b/i18n/pt/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Melhores do Daily Page",
+      "description": "Os blocos mais amados no Daily Page: engraçados, honestos, poéticos ou simplesmente estranhos. Veja o que se destacou no último dia, semana, mês e além.",
+      "titleRoom": "Melhores de {roomName}",
+      "descriptionRoom": "Descubra posts em destaque da sala {roomName}: aqueles que os leitores mais amaram nas últimas 24 horas, 7 dias, 30 dias e em todos os tempos."
+    },
+    "heading": "🏆 Melhores do Daily Page",
+    "headingRoomPrefix": "🏆 Melhores de ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 Horas",
+      "7d": "🚀 7 Dias",
+      "30d": "🌕 30 Dias",
+      "all": "👑 Todos os Tempos"
+    },
+    "labels": {
+      "createdBy": "Criado por:",
+      "inRoom": "em",
+      "onDate": "em {date}",
+      "unknownRoom": "Sala Desconhecida",
+      "noBlocks": "Nenhum bloco encontrado.",
+      "viewRoom": "Ver sala"
+    }
+  }
+}

--- a/i18n/pt/blockCommon.json
+++ b/i18n/pt/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Rascunho"
+    },
+    "deleteModal": {
+      "title": "Excluir Bloco?",
+      "message": "Esta ação não pode ser desfeita.",
+      "confirm": "Excluir",
+      "cancel": "Cancelar",
+      "closeAriaLabel": "Fechar"
+    },
+    "toasts": {
+      "deleteSuccess": "Bloco excluído com sucesso!",
+      "deleteFailed": "Falha ao excluir bloco."
+    }
+  }
+}

--- a/i18n/pt/blockEditor.json
+++ b/i18n/pt/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Você)"
+    },
+    "meta": {
+      "title": "Editar Bloco - {blockTitle}",
+      "titleFallback": "Editar Bloco"
+    },
+    "errors": {
+      "imageUrlRequired": "Digite uma URL de imagem.",
+      "notFound": "Bloco não encontrado ou não pertence a esta sala.",
+      "loadFailed": "Ocorreu um erro ao carregar o editor de blocos.",
+      "updateTitleFailed": "Erro ao atualizar o título."
+    },
+    "roomInfo": {
+      "label": "Sala:"
+    },
+    "title": {
+      "placeholder": "Digite o título do bloco",
+      "editTooltip": "Editar Título",
+      "lock": "Bloquear Bloco",
+      "delete": "Excluir Bloco"
+    },
+    "description": {
+      "label": "Descrição",
+      "editTooltip": "Editar Descrição",
+      "placeholder": "Digite a descrição",
+      "noDescriptionOwner": "Ainda não há descrição...",
+      "noDescriptionViewer": "Nenhuma descrição fornecida...",
+      "save": "Salvar",
+      "cancel": "Cancelar",
+      "expand": "Expandir",
+      "collapse": "Recolher",
+      "updateError": "Erro ao atualizar a descrição."
+    },
+    "status": {
+      "lastBackup": "Último backup: {datetime}",
+      "lastBackupUnknown": "Último backup: Desconhecido"
+    },
+    "peers": {
+      "label": "Pares:"
+    },
+    "toasts": {
+      "blockLocked": "Este bloco foi bloqueado!"
+    },
+    "editor": {
+      "placeholder": "A página em branco espera sua voz; escreva sem medo."
+    },
+    "loading": {
+      "label": "Carregando",
+      "quote": "Deixe o mundo queimar através de você. Lance a luz do prisma, branca e quente, no papel.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Você não escreveu nada por 5 minutos. Clique em OK para continuar a sessão; caso contrário, você será redirecionado para o arquivo.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link de Compartilhamento",
+      "copyTooltip": "Copiar para a Área de Transferência",
+      "copied": "Copiado!"
+    },
+    "toolbar": {
+      "insertImage": "Inserir Imagem",
+      "insertImageUrlPlaceholder": "Digite a URL da imagem",
+      "insertImageAltPlaceholder": "Texto alternativo (opcional)",
+      "insertImageConfirm": "Confirmar",
+      "insertImageCancel": "Cancelar"
+    },
+    "buttons": {
+      "downloadFile": "Baixar arquivo"
+    },
+    "lockModal": {
+      "messageLine1": "Tem certeza de que deseja bloquear este bloco?",
+      "messageLine2": "Isso irá finalizá-lo e impedir novas edições.",
+      "confirm": "Bloquear",
+      "cancel": "Cancelar",
+      "successToast": "Bloco bloqueado com sucesso.",
+      "errorToast": "Erro ao bloquear bloco."
+    },
+    "tags": {
+      "headerWithTags": "Tags:",
+      "headerNoTags": "Ainda não há tags! Adicione algumas:",
+      "updateError": "Erro ao atualizar tags."
+    },
+    "fullBlock": {
+      "headingPrefix": "Desculpe; o bloco \"{blockTitle}\" agora está",
+      "headingStatus": "totalmente ocupado.",
+      "retryPrefix": "Por favor,",
+      "retryLink": "tente um bloco diferente",
+      "retrySuffix": "ou volte em outra hora.",
+      "consolationPrefix": "Enquanto espera, fique à vontade para ler",
+      "consolationBestOf": "alguns dos nossos blocos favoritos",
+      "consolationMiddle": "ou navegar pelo",
+      "consolationArchive": "arquivo."
+    }
+  }
+}

--- a/i18n/pt/blockList.json
+++ b/i18n/pt/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "todos os tempos",
+      "days": "nos últimos {n} dias",
+      "day": "nas últimas 24 horas"
+    },
+    "createdBy": "Criado por:",
+    "on": "em"
+  }
+}

--- a/i18n/pt/blockTags.json
+++ b/i18n/pt/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tags:",
+      "noTags": "Ainda não há tags! Adicione algumas:"
+    },
+    "input": {
+      "placeholder": "Nova tag",
+      "addButton": "Adicionar"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/pt/blockView.json
+++ b/i18n/pt/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Bloco - {blockTitle}",
+      "titleFallback": "Bloco"
+    },
+    "labels": {
+      "room": "Sala",
+      "author": "Autor",
+      "created": "Criado",
+      "unknownAuthor": "Anônimo",
+      "authorAvatarAlt": "Avatar de {username}",
+      "viewAuthorProfile": "Ver perfil de {username}",
+      "lang": "Traduções: ",
+      "available": "disponível"
+    },
+    "buttons": {
+      "edit": "Editar",
+      "deleteBlock": "Excluir Bloco",
+      "share": "Compartilhar",
+      "flagContent": "Denunciar Conteúdo"
+    },
+    "description": {
+      "label": "Descrição",
+      "none": "Nenhuma descrição fornecida...",
+      "expand": "Expandir",
+      "collapse": "Recolher"
+    },
+    "editorial": {
+      "heading": "Guia de leitura",
+      "roleLabel": "Tipo de leitura",
+      "clusterLabel": "Guia",
+      "sequence": "Parte {sequence}",
+      "primaryPillarHeading": "Comece aqui",
+      "relatedHeading": "Continue lendo",
+      "clusterHeading": "Mais neste guia",
+      "expandSection": "Mostrar mais {count}",
+      "collapseSection": "Mostrar menos",
+      "roleNames": {
+        "pillar": "Guia principal",
+        "companion": "Aprofundamento",
+        "texture": "Contexto"
+      }
+    },
+    "comments": {
+      "heading": "Comentários",
+      "count": "{count} comentários",
+      "empty": "Ninguém respondeu ainda. Os comentários aparecerão aqui quando a conversa começar.",
+      "composer": {
+        "label": "Adicionar um comentário",
+        "placeholder": "Escreva um comentário...",
+        "submit": "Publicar comentário",
+        "submitting": "Publicando...",
+        "success": "Comentário publicado.",
+        "error": "Não foi possível publicar seu comentário agora.",
+        "loginPrompt": "Entre para participar da conversa.",
+        "loginCta": "Entrar para comentar",
+        "verifyPrompt": "Verifique seu email antes de publicar um comentário.",
+        "verifyCta": "Verificar email"
+      },
+      "sort": {
+        "label": "Ordenar",
+        "oldestFirst": "Mais antigos primeiro",
+        "newestFirst": "Mais recentes primeiro"
+      },
+      "by": "Por",
+      "unknownAuthor": "Desconhecido",
+      "reply": {
+        "action": "Responder",
+        "label": "Adicionar uma resposta",
+        "placeholder": "Escreva uma resposta...",
+        "submit": "Publicar resposta",
+        "submitting": "Publicando...",
+        "success": "Resposta publicada.",
+        "error": "Não foi possível publicar sua resposta agora.",
+        "cancel": "Cancelar",
+        "loginPrompt": "Entre para responder."
+      },
+      "manage": {
+        "edited": "Editado",
+        "editAction": "Editar",
+        "deleteAction": "Excluir",
+        "deleteConfirm": "Excluir este comentário? Isso também removerá todas as respostas abaixo dele.",
+        "deleteSuccess": "Comentário excluído.",
+        "deleteError": "Não foi possível excluir este comentário agora.",
+        "forbidden": "Você só pode gerenciar seus próprios comentários.",
+        "edit": {
+          "label": "Editar comentário",
+          "save": "Salvar",
+          "saving": "Salvando...",
+          "cancel": "Cancelar",
+          "success": "Comentário atualizado.",
+          "error": "Não foi possível atualizar este comentário agora."
+        }
+      },
+      "report": {
+        "action": "Denunciar",
+        "pending": "Denunciando...",
+        "success": "Comentário denunciado.",
+        "error": "Não foi possível denunciar este comentário agora.",
+        "ownError": "Você não pode denunciar seu próprio comentário.",
+        "hidden": "Comentário ocultado após denúncia.",
+        "reported": "Denunciado"
+      },
+      "deepLink": {
+        "focused": "Comentário vinculado",
+        "unavailable": "O comentário vinculado não está mais disponível."
+      },
+      "loadMore": "Carregar mais comentários",
+      "loading": "Carregando...",
+      "loadError": "Não foi possível carregar mais comentários agora."
+    },
+    "share": {
+      "title": "Compartilhar este Bloco",
+      "shareOn": "Compartilhar em:",
+      "nativeText": "Confira este bloco: {title}",
+      "alt": {
+        "facebook": "Logo do Facebook",
+        "reddit": "Logo do Reddit",
+        "whatsapp": "Logo do WhatsApp",
+        "twitter": "Logo do Twitter"
+      }
+    },
+    "errors": {
+      "notFound": "Bloco não encontrado ou não pertence a esta sala.",
+      "loadFailed": "Erro ao carregar a visualização do bloco."
+    }
+  }
+}

--- a/i18n/pt/createBlock.json
+++ b/i18n/pt/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Criar um Novo Bloco — Daily Page",
+      "description": "Comece um novo bloco criativo com tags, idioma e visibilidade opcionais."
+    },
+    "heading": "Criar um Novo Bloco",
+    "roomInfo": {
+      "roomLabel": "Sala:",
+      "unavailable": "Informações da sala não disponíveis.",
+      "noDescription": "Nenhuma descrição disponível."
+    },
+    "form": {
+      "title": {
+        "label": "Título:",
+        "placeholder": {
+          "full": "ex.: 'Minha Obra-Prima', 'A Melhor Ideia de Todas', 'Clickbait para Nerds'",
+          "short": "ex.: 'Minha Obra-Prima'"
+        }
+      },
+      "description": {
+        "label": "Descrição (opcional):",
+        "placeholder": "Explique seu brilhantismo... ou improvise."
+      },
+      "initialContent": {
+        "label": "Conteúdo Inicial (opcional):",
+        "help": "Comece a escrever aqui ou pressione “Criar” para continuar na página completa do editor, onde você pode incorporar imagens e colaborar em tempo real.",
+        "placeholder": "Comece seu bloco aqui ou continue editando após a criação..."
+      },
+      "visibility": {
+        "label": "Visibilidade:"
+      },
+      "submit": "Criar Bloco"
+    },
+    "visibility": {
+      "public": {
+        "label": "Público",
+        "title": "Editável por qualquer pessoa em tempo real. Não precisa fazer login.",
+        "inline": "Editável por qualquer pessoa em tempo real. Não precisa fazer login."
+      },
+      "private": {
+        "label": "Privado",
+        "title": "Apenas para usuários logados. Visível após a conclusão da edição.",
+        "inline": "Apenas para usuários logados. Visível após a conclusão da edição.",
+        "tooltip": "Blocos privados são somente por convite enquanto você trabalha e ficam visíveis quando você termina."
+      }
+    },
+    "advanced": {
+      "summary": "Opções avançadas",
+      "lang": {
+        "label": "Idioma:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Traduzir bloco existente (URL ou ID):",
+        "placeholder": "Cole uma URL ou ID de bloco (opcional)",
+        "invalid": "Isso não parece uma URL ou ID de bloco válido.",
+        "fetchError": "Não foi possível buscar informações do bloco."
+      }
+    },
+    "messages": {
+      "langExists": "Já existe uma tradução para esse idioma. Escolha outro idioma.",
+      "genericError": "Algo deu errado. Tente novamente."
+    }
+  }
+}

--- a/i18n/pt/dashboard.json
+++ b/i18n/pt/dashboard.json
@@ -1,0 +1,45 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Painel",
+      "description": "Seu painel do Daily Page e visão geral da conta."
+    },
+    "profile": {
+      "profilePicAlt": "Foto do Perfil",
+      "noBio": "Ainda não há biografia. Clique em \"Editar\" para adicionar uma!",
+      "editBio": "Editar Biografia",
+      "bioPlaceholder": "Digite sua biografia aqui",
+      "save": "Salvar",
+      "cancel": "Cancelar"
+    },
+    "activity": {
+      "title": "Atividade Recente",
+      "none": "Nenhuma atividade recente.",
+      "updatedOn": "Atualizado em {date}",
+      "viewAllBlocks": "Ver Todos os Blocos"
+    },
+    "streak": {
+      "title": "Sequência de Escrita",
+      "line": "{days} dias seguidos! Continue assim!"
+    },
+    "starredRooms": {
+      "title": "Salas Favoritas",
+      "none": "Você ainda não favoritou nenhuma sala. Comece a explorar para encontrar suas favoritas!",
+      "viewAll": "Ver Todas as Salas Favoritas",
+      "unnamedRoom": "Sala sem Nome"
+    },
+    "stats": {
+      "title": "Suas Estatísticas",
+      "totalBlocks": "Total de Blocos Criados",
+      "collaborations": "Colaborações",
+      "votesGiven": "Votos Dados",
+      "daysActive": "Dias Ativos",
+      "viewDetailed": "Ver Estatísticas Detalhadas 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Falha ao enviar a foto do perfil. Tente novamente.",
+      "uploadUnexpected": "Ocorreu um erro inesperado. Tente novamente.",
+      "bioUpdateFailed": "Erro ao atualizar a biografia. Tente novamente."
+    }
+  }
+}

--- a/i18n/pt/detailedStats.json
+++ b/i18n/pt/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Estatísticas Detalhadas",
+      "description": "Um detalhamento da sua atividade no Daily Page."
+    },
+    "nav": {
+      "backToDashboard": "← Voltar ao Painel"
+    },
+    "header": {
+      "title": "📊 Visão Geral das Suas Estatísticas 📊"
+    },
+    "cards": {
+      "totalBlocks": "Total de Blocos Criados 📝",
+      "collaborations": "Colaborações 🤝",
+      "votesGiven": "Votos Dados 👍",
+      "daysActive": "Dias Ativos 📆"
+    },
+    "chart": {
+      "datasetLabel": "Suas Estatísticas",
+      "labels": {
+        "blocksCreated": "Blocos Criados",
+        "collaborations": "Colaborações",
+        "votesGiven": "Votos Dados",
+        "daysActive": "Dias Ativos"
+      }
+    }
+  }
+}

--- a/i18n/pt/errors.json
+++ b/i18n/pt/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ops! Algo deu errado.",
+      "message": "Ocorreu um erro inesperado. Tente novamente mais tarde.",
+      "home": "Voltar ao Início"
+    },
+    "notFound": {
+      "title": "404 - Página Não Encontrada",
+      "metaTitle": "Página Não Encontrada",
+      "message": "Desculpe, não conseguimos encontrar a página que você estava procurando.",
+      "homePrefix": "Você pode voltar para",
+      "homeLink": "a página inicial",
+      "roomsPrefix": "ou conferir o",
+      "roomsLink": "diretório de salas."
+    }
+  }
+}

--- a/i18n/pt/flagModal.json
+++ b/i18n/pt/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Denunciar Conteúdo Inapropriado",
+    "fields": {
+      "reason": {
+        "label": "Motivo",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Ofensivo (linguagem de ódio ou insultos)",
+          "inappropriate": "Inapropriado (nudez, conteúdo gráfico etc.)",
+          "other": "Outro"
+        }
+      },
+      "details": {
+        "label": "Detalhes (opcional)",
+        "placeholder": "Descreva o que você viu..."
+      }
+    },
+    "buttons": {
+      "submit": "Enviar Denúncia",
+      "cancel": "Cancelar"
+    },
+    "toasts": {
+      "success": "Denúncia enviada — obrigado!",
+      "failed": "Falha ao enviar denúncia."
+    }
+  }
+}

--- a/i18n/pt/forgotPassword.json
+++ b/i18n/pt/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Redefinir Senha",
+      "description": "Solicite um link de redefinição para sua conta do Daily Page."
+    },
+    "header": {
+      "title": "Esqueceu sua Senha?",
+      "subtitle": "Digite seu email e enviaremos um link de redefinição."
+    },
+    "form": {
+      "email": {
+        "label": "Endereço de Email",
+        "placeholder": "Digite seu email"
+      },
+      "submit": "Solicitar Redefinição de Senha"
+    },
+    "feedback": {
+      "successGeneric": "Se esse email existir, um link de redefinição foi enviado.",
+      "missingEmail": "O email é obrigatório.",
+      "genericError": "Algo deu errado. Tente novamente.",
+      "unexpectedError": "Ocorreu um erro inesperado. Tente novamente."
+    },
+    "email": {
+      "subject": "Redefina sua senha do Daily Page",
+      "heading": "Solicitação de Redefinição de Senha",
+      "headingWithName": "Solicitação de Redefinição de Senha, {username}",
+      "body": "Clique no link abaixo para redefinir sua senha.",
+      "cta": "Redefinir Minha Senha",
+      "expires": "Este link expira em {hours} hora(s).",
+      "ignore": "Se você não solicitou uma redefinição de senha, pode ignorar este email com segurança."
+    }
+  }
+}

--- a/i18n/pt/home.json
+++ b/i18n/pt/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Principais Blocos nas últimas 24 Horas",
+      "description": "Daily Page é um site minimalista e independente de escrita onde qualquer pessoa pode publicar pensamentos criativos, memórias ou experimentos, um bloco por vez. Explore novas ideias, entre em salas e contribua com sua voz."
+    },
+    "hero": {
+      "eyebrow": "Um lugar tranquilo para escrever, ler e voltar",
+      "title": "Boas-vindas ao Daily Page!",
+      "subtitle": "Explore os blocos mais populares das últimas 24 horas.",
+      "ctaPrefix": "Sentindo inspiração?",
+      "cta": "Entre em uma sala",
+      "ctaSuffix": "e crie seu próprio bloco!"
+    },
+    "stats": {
+      "blocks": "Blocos",
+      "rooms": "Salas",
+      "tags": "Tags",
+      "collabsToday": "Colaborações Hoje"
+    },
+    "activity": {
+      "title": "Ao vivo no Daily Page",
+      "subtitle": "Conversas e reações frescas, tudo num só olhar.",
+      "fallbackActor": "Alguém",
+      "inRoom": "em",
+      "comments": {
+        "title": "Comentários recentes",
+        "more": "Pesquisar discussões",
+        "commentVerb": "comentou em",
+        "replyVerb": "respondeu em",
+        "empty": "Ainda não há comentários recentes. A próxima conversa pode começar com o seu bloco."
+      },
+      "reactions": {
+        "title": "Reações recentes",
+        "more": "Navegar pelos blocos principais",
+        "empty": "Ainda não há reações recentes. Um bom post pode acordar isso rapidamente.",
+        "types": {
+          "heart": "curtiu",
+          "leaf": "reagiu com uma folha a",
+          "wow": "reagiu com uau a",
+          "laugh": "riu de"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Sala em Destaque",
+      "roomInfoDays": "Atividade nos últimos {days} dias: {blocks} blocos, {votes} votos.",
+      "roomInfo24h": "Atividade nas últimas 24 horas: {blocks} blocos, {votes} votos.",
+      "checkItOut": "Confira",
+      "blockRibbon": "★ Bloco em Destaque",
+      "votes": "{n} votos",
+      "noContent": "(Nenhum conteúdo fornecido...)",
+      "viewBlock": "Ver Bloco"
+    },
+    "trendingTags": {
+      "title": "Tags em Alta",
+      "suffixDays": "(últimos {days} dias)",
+      "suffixAllTime": "(todos os tempos)",
+      "blocks": "{n} blocos",
+      "votes": "{n} votos",
+      "empty": "Ainda não há tags em alta. Seja o primeiro a marcar algo legal!"
+    },
+    "trendingBlocks": {
+      "title": "Blocos em Alta",
+      "suffixDays": "(últimos {days} dias)",
+      "createdBy": "Criado por:",
+      "in": "em",
+      "on": "em",
+      "unknownRoom": "Sala Desconhecida",
+      "empty24h": "Ainda não há blocos nas últimas 24 horas. Volte em breve, compa!"
+    }
+  }
+}

--- a/i18n/pt/layout.json
+++ b/i18n/pt/layout.json
@@ -1,0 +1,18 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Boas-vindas, Usuário!",
+    "logout": "Sair",
+    "login": "Entrar / Cadastrar-se",
+    "language": "Idioma",
+    "openMenu": "Abrir menu principal",
+    "closeMenu": "Fechar menu principal",
+    "privacy": "Política de Privacidade",
+    "uiFallbackNotice": "{requested} ainda não está traduzido. Mostrando {current} por enquanto.",
+    "copyButton": {
+      "copy": "Copiar",
+      "copied": "Copiado!"
+    },
+    "copyright": "© {year}"
+  }
+}

--- a/i18n/pt/modals.json
+++ b/i18n/pt/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Faça Login",
+      "message": "Você precisa estar logado para continuar.",
+      "messageWithAction": "Você precisa estar logado para {action}.",
+      "cta": "Entrar"
+    },
+    "actions": {
+      "voteOnBlock": "votar em um bloco",
+      "starRoom": "favoritar esta sala",
+      "reactToBlock": "reagir a este post",
+      "commentOnBlock": "comentar neste bloco",
+      "reportComment": "denunciar este comentário"
+    },
+    "errors": {
+      "starToggleFail": "Falha ao atualizar o status de favorito. Tente novamente."
+    }
+  }
+}

--- a/i18n/pt/nav.json
+++ b/i18n/pt/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Início",
+    "rooms": "Salas",
+    "tags": "Tags",
+    "archive": "Arquivo",
+    "search": "Buscar",
+    "bestOf": "Melhores",
+    "about": "Sobre",
+    "support": "Suporte",
+    "otherProjects": "Outros Projetos",
+    "auth": {
+      "welcomePrefix": "Boas-vindas, ",
+      "welcomeFallbackUser": "você",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Painel"
+  }
+}

--- a/i18n/pt/notifications.json
+++ b/i18n/pt/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Notificações",
+      "openMenu": "Abrir notificações",
+      "loading": "Carregando notificações...",
+      "error": "Não foi possível carregar as notificações agora.",
+      "empty": "Ainda não há notificações.",
+      "markRead": "Marcar como lida",
+      "fallbackActor": "Alguém",
+      "fallbackBlockTitle": "seu bloco",
+      "item": {
+        "blockComment": "{actorUsername} comentou no seu bloco \"{blockTitle}\".",
+        "commentReply": "{actorUsername} respondeu ao seu comentário em \"{blockTitle}\".",
+        "unknown": "Notificação"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Novo comentário em \"{blockTitle}\"",
+        "heading": "Novo comentário no seu bloco",
+        "headingWithName": "Olá {username},",
+        "body": "<strong>{actorUsername}</strong> comentou no seu bloco <strong>{blockTitle}</strong>.",
+        "cta": "Ver a conversa no Daily Page",
+        "fallbackActor": "Alguém",
+        "fallbackBlockTitle": "seu bloco"
+      },
+      "commentReply": {
+        "subject": "Nova resposta em \"{blockTitle}\"",
+        "heading": "Nova resposta ao seu comentário",
+        "headingWithName": "Olá {username},",
+        "body": "<strong>{actorUsername}</strong> respondeu ao seu comentário em <strong>{blockTitle}</strong>.",
+        "cta": "Ver a conversa no Daily Page",
+        "fallbackActor": "Alguém",
+        "fallbackBlockTitle": "seu bloco"
+      }
+    }
+  }
+}

--- a/i18n/pt/privacy.json
+++ b/i18n/pt/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Política de Privacidade",
+      "description": "Como o Daily Page coleta, usa e protege seus dados, em linguagem simples."
+    },
+    "title": "Política de Privacidade",
+    "lastUpdated": "Última atualização: {date}",
+    "intro": {
+      "h2": "Introdução",
+      "p1": "Daily Page (\"nós\", \"nos\" ou \"nosso\") opera o site dailypage.org (doravante referido como o \"Serviço\").",
+      "p2": "Esta página informa você sobre nossas políticas relacionadas à coleta, uso e divulgação de dados pessoais quando você usa nosso Serviço."
+    },
+    "collection": {
+      "h2": "Coleta e Uso de Informações",
+      "p": "Coletamos dados pessoais mínimos para melhorar e fornecer nosso Serviço. Isso inclui endereços de email para gerenciamento de conta e conteúdo enviado voluntariamente pelos usuários."
+    },
+    "usage": {
+      "h2": "Uso de Dados",
+      "p": "Os dados coletados são usados apenas para autenticação de conta, moderação de conteúdo e melhoria da experiência do usuário."
+    },
+    "storage": {
+      "h2": "Armazenamento e Segurança de Dados",
+      "p": "Seus dados são armazenados com segurança e nunca são compartilhados ou vendidos a terceiros sem consentimento explícito, exceto quando exigido por lei."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "Usamos cookies apenas para gerenciamento de sessão e melhoria da experiência do usuário. Você pode desativar cookies nas configurações do seu navegador."
+    },
+    "rights": {
+      "h2": "Seus Direitos",
+      "p": "Você pode solicitar a exclusão ou modificação dos seus dados pessoais a qualquer momento entrando em contato conosco."
+    },
+    "changes": {
+      "h2": "Alterações nesta Política de Privacidade",
+      "p": "Podemos atualizar nossa Política de Privacidade periodicamente. As alterações serão publicadas nesta página."
+    },
+    "contact": {
+      "h2": "Fale Conosco",
+      "p": "Para perguntas sobre esta Política de Privacidade, entre em contato conosco em:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/pt/profile.json
+++ b/i18n/pt/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Perfil de {username}",
+      "descriptionUser": "Veja a atividade recente, salas favoritas e estatísticas de {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Foto do perfil",
+      "noBio": "(Nenhuma biografia disponível.)"
+    },
+    "activity": {
+      "title": "Atividade Recente",
+      "updatedOn": "Atualizado em {date}",
+      "none": "Nenhuma atividade recente.",
+      "viewAllBlocks": "Ver Todos os Blocos"
+    },
+    "starredRooms": {
+      "title": "Salas Favoritas",
+      "none": "Ainda não há salas favoritadas.",
+      "unnamedRoom": "Sala sem Nome"
+    },
+    "stats": {
+      "title": "Estatísticas do Usuário",
+      "totalBlocks": "Total de Blocos Criados",
+      "collaborations": "Colaborações",
+      "daysActive": "Dias Ativos"
+    }
+  }
+}

--- a/i18n/pt/random.json
+++ b/i18n/pt/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Outros Projetos",
+      "description": "Explore diário de beisebol, experimentos aleatórios de escrita e outros projetos paralelos do Daily Page."
+    },
+    "title": "Outros Projetos",
+    "tagline": "Um cantinho aconchegante para experimentos e aventuras paralelas.",
+    "links": {
+      "baseball": "📖 Diário de Beisebol",
+      "randomWriter": "🎲 Escritor Aleatório"
+    },
+    "cta": {
+      "backToRooms": "Voltar às Salas Principais"
+    }
+  }
+}

--- a/i18n/pt/randomWriter.json
+++ b/i18n/pt/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Escritor Aleatório",
+      "description": "Gere um fluxo infinito de pseudotexto aleatório para diversão, inspiração ou caos."
+    },
+    "title": "Escritor Aleatório",
+    "buttons": {
+      "clear": "Limpar",
+      "stop": "Parar de escrever",
+      "start": "Começar a escrever"
+    }
+  }
+}

--- a/i18n/pt/reactions.json
+++ b/i18n/pt/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} reações: {count}",
+    "loginToReact": "Entre para reagir",
+    "countsLabel": "Reações"
+  }
+}

--- a/i18n/pt/readMore.json
+++ b/i18n/pt/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Mais...",
+    "aria": "Ler bloco completo: {title}"
+  }
+}

--- a/i18n/pt/resetPassword.json
+++ b/i18n/pt/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Redefinir Sua Senha",
+      "description": "Defina uma nova senha para sua conta."
+    },
+    "header": {
+      "title": "Redefinir Sua Senha",
+      "subtitle": "Escolha uma nova senha para recuperar o acesso."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Nova Senha",
+        "placeholder": "Digite a nova senha"
+      },
+      "submit": "Definir Nova Senha"
+    },
+    "feedback": {
+      "missingToken": "Token ausente ou inválido.",
+      "missingFields": "Token e nova senha são obrigatórios.",
+      "invalidOrExpired": "Token inválido ou expirado.",
+      "success": "Senha atualizada com sucesso!",
+      "genericError": "Algo deu errado. Tente novamente.",
+      "unexpectedError": "Ocorreu um erro inesperado. Tente novamente."
+    }
+  }
+}

--- a/i18n/pt/roomDashboard.json
+++ b/i18n/pt/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Explore blocos recentes e em andamento em {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Explorar:",
+      "allBlocks": "🗂️ Todos os blocos",
+      "browseByDate": "🗓️ Por data",
+      "bestOf": "🏅 Melhores",
+      "searchInRoom": "🔎 Buscar"
+    },
+    "actions": {
+      "createBlock": "Criar um Bloco",
+      "starTitle": "Favoritar esta sala",
+      "unstarTitle": "Remover esta sala dos favoritos"
+    },
+    "tabs": {
+      "locked": "Blocos Bloqueados",
+      "inProgress": "Blocos em Andamento"
+    },
+    "sections": {
+      "lockedHeader": "Blocos bloqueados",
+      "inProgressHeader": "Blocos em andamento"
+    },
+    "editorial": {
+      "heading": "Guias em destaque",
+      "description": "Comece aqui com os guias em destaque selecionados para esta sala.",
+      "roleNames": {
+        "pillar": "Guia principal",
+        "companion": "Guia de leitura",
+        "texture": "Guia de contexto"
+      }
+    },
+    "empty": {
+      "noDescription": "Nenhuma descrição disponível.",
+      "noLocked": "Ainda não há blocos bloqueados! Os blocos são bloqueados automaticamente após 1 hora de inatividade.",
+      "noInProgress": "Ainda não há blocos em andamento! Hora de começar um.",
+      "noBlocks": "Ainda não há blocos! Crie o primeiro e deixe sua marca. 😎"
+    }
+  }
+}

--- a/i18n/pt/roomsDirectory.json
+++ b/i18n/pt/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Diretório de Salas",
+      "description": "Cada sala é uma porta para um mundo diferente. Entre, compartilhe sua história e junte-se a outras pessoas para construir algo bonito."
+    },
+    "eyebrow": "Encontre seu canto",
+    "heading": "Diretório de Salas",
+    "intro": "Comece pelas salas que parecem vivas agora ou vagueie por tópico até algo clicar. Cada sala é um prompt de escrita, fandom ou obsessão compartilhada diferente esperando pela sua voz.",
+    "empty": "Nenhuma sala está disponível no momento. Volte mais tarde!",
+    "jumpToActive": "Ver salas ativas",
+    "jumpToTopics": "Navegar por tópico",
+    "statsLabel": "Destaques do diretório de salas",
+    "liveNow": "Ao vivo agora",
+    "recentlyActive": "Recentemente Ativas",
+    "recentlyActiveSubtitle": "A forma mais rápida de encontrar uma sala com pessoas agora.",
+    "browseByTopic": "Navegar por tópico",
+    "topicSubtitle": "Abra um tópico para explorar suas salas.",
+    "roomCount": "{count} salas",
+    "stats": {
+      "rooms": "salas para explorar",
+      "topics": "grupos de tópicos",
+      "active": "escolhas ativas"
+    },
+    "activeUsers": "Usuários Ativos: {count}",
+    "visitRoom": "Visitar Sala",
+    "close": "Fechar",
+    "noTitle": "Nenhum Título Disponível",
+    "noDescription": "Nenhuma Descrição Disponível"
+  }
+}

--- a/i18n/pt/search.json
+++ b/i18n/pt/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Buscar",
+      "description": "Buscar blocos públicos."
+    },
+    "title": "Buscar",
+    "placeholder": "Buscar blocos...",
+    "hint": "Digite pelo menos 2 caracteres para buscar.",
+    "noResults": "Nenhum resultado encontrado.",
+    "untitled": "Sem título",
+    "votesTitle": "Votos",
+    "pageLabel": "Página",
+    "filters": {
+      "inRoom": "Na sala"
+    },
+    "buttons": {
+      "search": "Buscar",
+      "prev": "Anterior",
+      "next": "Próximo"
+    }
+  }
+}

--- a/i18n/pt/signup.json
+++ b/i18n/pt/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Criar uma Conta",
+      "description": "Cadastre-se no Daily Page para acessar todos os recursos."
+    },
+    "header": {
+      "title": "Crie Sua Conta",
+      "subtitle": "Entre no Daily Page para começar a criar e compartilhar sua escrita diária!"
+    },
+    "form": {
+      "email": {
+        "label": "Email",
+        "placeholder": "Digite seu email"
+      },
+      "username": {
+        "label": "Nome de usuário",
+        "placeholder": "Digite seu nome de usuário"
+      },
+      "password": {
+        "label": "Senha",
+        "placeholder": "Digite uma senha"
+      },
+      "submit": "Cadastrar-se",
+      "feedback": {
+        "success": "Formulário enviado com sucesso!",
+        "successCreatedVerify": "Conta criada com sucesso! Verifique seu email para confirmar sua conta.",
+        "genericError": "Falha ao criar conta. Tente novamente.",
+        "unexpectedError": "Ocorreu um erro inesperado. Tente novamente."
+      }
+    }
+  }
+}

--- a/i18n/pt/starredRooms.json
+++ b/i18n/pt/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Todas as Salas Favoritas",
+      "description": "Uma lista de todas as salas que você favoritou."
+    },
+    "nav": {
+      "backToDashboard": "← Voltar ao Painel"
+    },
+    "header": {
+      "title": "🌟 Todas as Suas Salas Favoritas 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Sala sem Nome",
+      "noDescription": "Sem descrição."
+    },
+    "empty": {
+      "message": "Você ainda não favoritou nenhuma sala!"
+    }
+  }
+}

--- a/i18n/pt/support.json
+++ b/i18n/pt/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Suporte",
+      "description": "Como entrar em contato, relatar problemas, solicitar recursos ou salas e apoiar financeiramente o Daily Page."
+    },
+    "contact": {
+      "h1": "★ Gostaria de fazer uma pergunta, relatar um problema ou solicitar um recurso.",
+      "p1": {
+        "before": "Se preferir usar o GitHub, confira",
+        "link": "as issues deste projeto",
+        "after": "e acrescente sua voz. Pull requests também são bem-vindos, claro."
+      },
+      "p2": {
+        "before": "Como alternativa,",
+        "link": "envie um email",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Gostaria de apoiar este projeto com uma contribuição.",
+      "p1": {
+        "before": "Agradeço desde já por financiar este projeto. Envie pagamentos com segurança pelo",
+        "paypal": "PayPal",
+        "middle": "ou, se preferir,",
+        "amazon": "peça algumas sacolas dos brinquedos que estou vendendo na Amazon",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Gostaria de solicitar uma nova sala.",
+      "form": {
+        "nameLabel": "Nome da Sala",
+        "topicLabel": "Tópico (opcional)",
+        "descriptionLabel": "Descrição",
+        "submit": "Enviar Solicitação",
+        "success": "Solicitação enviada com sucesso!",
+        "errorGeneric": "Falha ao enviar solicitação. Tente novamente.",
+        "errorUnexpected": "Ocorreu um erro inesperado. Tente novamente."
+      }
+    }
+  }
+}

--- a/i18n/pt/tags.json
+++ b/i18n/pt/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Visão Geral das Tags",
+      "description": "Navegue por todas as tags usadas no Daily Page, com filtros rápidos por período."
+    },
+    "title": "Visão Geral das Tags",
+    "intro": "Explore todas as tags usadas no Daily Page.",
+    "tagCloudTitle": "Nuvem de Tags",
+    "timeframe": {
+      "last24h": "Últimas 24 Horas",
+      "last7d": "Últimos 7 Dias",
+      "last30d": "Últimos 30 Dias",
+      "all": "Todos os Tempos"
+    },
+    "error": {
+      "loading": "Erro ao carregar a visão geral das tags"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Blocos marcados com"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Total de blocos com",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Criado por:",
+        "inRoom": "em",
+        "unknownRoom": "Sala Desconhecida",
+        "onDate": "em"
+      },
+      "chart": {
+        "label": "Blocos Criados ao Longo do Tempo"
+      },
+      "empty": {
+        "message": "Ainda não há blocos com esta tag. Talvez você deva criar o primeiro? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Erro ao carregar a página da tag"
+      }
+    }
+  }
+}

--- a/i18n/pt/translation.json
+++ b/i18n/pt/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Traduzido de",
+    "see": "ver",
+    "originalBlock": "bloco original"
+  }
+}

--- a/i18n/pt/userBlocks.json
+++ b/i18n/pt/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Seus Blocos",
+      "description": "Navegue e ordene todos os blocos que você criou ou em que colaborou."
+    },
+    "header": {
+      "dashboardLink": "Seu Painel",
+      "profileLink": "Perfil de {username}",
+      "allBlocks": "Todos os Blocos"
+    },
+    "empty": "Ainda não há blocos.",
+    "pagination": {
+      "prev": "← Anterior",
+      "next": "Próximo →"
+    },
+    "titleUser": "Blocos de {username}"
+  }
+}

--- a/i18n/pt/verifyEmail.json
+++ b/i18n/pt/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Verificar Email",
+      "description": "Verifique seu endereço de email no Daily Page."
+    },
+    "header": {
+      "title": "Verificando seu email..."
+    },
+    "status": {
+      "checking": "Verificando token, aguarde...",
+      "missingToken": "Token de verificação ausente ou inválido.",
+      "genericFailure": "Falha na verificação.",
+      "unexpectedError": "Ocorreu um erro inesperado.",
+      "success": "Sua conta foi verificada com sucesso!",
+      "invalidOrExpired": "Token de verificação inválido ou expirado."
+    },
+    "verificationMsg": {
+      "subject": "Verifique sua conta do Daily Page ✨",
+      "heading": "Boas-vindas ao Daily Page, {username}!",
+      "body": "Verifique seu email clicando abaixo:",
+      "cta": "Verificar Endereço de Email",
+      "expires": "Este link expira em {hours} horas."
+    }
+  }
+}

--- a/i18n/pt/voteControls.json
+++ b/i18n/pt/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Voto positivo",
+    "downvote": "Voto negativo",
+    "errors": {
+      "failed": "Falha ao salvar seu voto."
+    }
+  }
+}

--- a/server/db/notificationService.js
+++ b/server/db/notificationService.js
@@ -91,7 +91,7 @@ async function sendCommentNotificationEmail({
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
   const uiLang = block.lang || 'en';
   const blockUrl = `${baseUrl}/${uiLang}${canonicalCommentPath(block, comment._id || comment.id)}`;
-  const emailLang = ['en', 'es', 'fr', 'ru', 'id', 'de'].includes(block.lang) ? block.lang : 'en';
+  const emailLang = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt'].includes(block.lang) ? block.lang : 'en';
 
   const { subject, html } = await buildCommentNotificationEmail({
     uiLang: emailLang,

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -13,7 +13,7 @@ import {
 } from '../db/blockService.js';
 import { getTotalRooms } from '../db/roomService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -59,4 +59,6 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'ru' }).catch(console.error), 2_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'id' }).catch(console.error), 3_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'de' }).catch(console.error), 3_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'it' }).catch(console.error), 4_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'pt' }).catch(console.error), 4_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary
- Add complete Portuguese (`pt`) UI translations under `i18n/pt`
- Register `pt` as a fully supported UI locale
- Enable Portuguese comment notification emails, hreflang alternates, and home cache warming

## Validation
- Confirmed all locale JSON parses correctly
- Confirmed `i18n/pt` matches `i18n/en` file-for-file and key-for-key
- Confirmed placeholders are preserved across Portuguese translations
- Ran `git diff --check`

## Notes
- Did not touch DB-backed room name/description translations
- Broader non-i18n hard-coded UI/server strings remain for a separate cleanup
- Jasmine currently fails before running specs due to missing `lib/broadcast` imported by `spec/broadcastSpec.js`