### PR TITLE
Add compact block image previews with lightbox

### DIFF
--- a/public/css/archive.css
+++ b/public/css/archive.css
@@ -49,12 +49,6 @@
   margin-bottom: 0.5rem;
 }
 
-.block-content img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
 .block-content p {
   margin: 5px 0;
 }

--- a/public/css/block-common.css
+++ b/public/css/block-common.css
@@ -16,6 +16,116 @@ a.block-title {
   word-break: break-word;
 }
 
+.block-content img,
+.content-preview img,
+.featured-content-preview img {
+  display: block;
+  width: auto;
+  max-width: min(100%, 34rem);
+  height: auto;
+  max-height: 26rem;
+  margin: 1rem auto;
+  object-fit: contain;
+  border-radius: 6px;
+  background: #f7f8fa;
+  cursor: zoom-in;
+}
+
+.content-preview img,
+.featured-content-preview img {
+  max-width: min(100%, 22rem);
+  max-height: 15rem;
+  margin: 0.75rem auto;
+}
+
+.block-content img:focus-visible,
+.content-preview img:focus-visible,
+.featured-content-preview img:focus-visible {
+  outline: 3px solid rgba(0, 123, 255, 0.45);
+  outline-offset: 3px;
+}
+
+.block-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  box-sizing: border-box;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.82);
+}
+
+.block-image-lightbox *,
+.block-image-lightbox *::before,
+.block-image-lightbox *::after {
+  box-sizing: border-box;
+}
+
+.block-image-lightbox[hidden] {
+  display: none;
+}
+
+.block-image-lightbox__frame {
+  position: relative;
+  display: grid;
+  place-items: center;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.block-image-lightbox__image {
+  display: block;
+  max-width: min(100%, 1200px);
+  max-height: 90vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 8px;
+  background: #111;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.block-image-lightbox__close {
+  position: absolute;
+  top: -0.75rem;
+  right: -0.75rem;
+  display: inline-grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  padding: 0;
+  border-radius: 999px;
+  background: rgba(20, 20, 20, 0.92);
+  color: #fff;
+  cursor: pointer;
+}
+
+.block-image-lightbox__close::before,
+.block-image-lightbox__close::after {
+  content: "";
+  position: absolute;
+  width: 1.55rem;
+  height: 0.14rem;
+  border-radius: 999px;
+  background: currentColor;
+  transform-origin: center;
+}
+
+.block-image-lightbox__close::before {
+  transform: rotate(45deg);
+}
+
+.block-image-lightbox__close::after {
+  transform: rotate(-45deg);
+}
+
+.block-image-lightbox__close:hover,
+.block-image-lightbox__close:focus-visible {
+  background: #000;
+}
+
 /* Badge itself */
 .badge.badge-draft {
   display: inline-flex;
@@ -44,5 +154,28 @@ a.block-title {
     width: auto;
     max-width: 100%;
     margin-right: auto;
+  }
+}
+
+@media (max-width: 600px) {
+  .block-content img,
+  .content-preview img,
+  .featured-content-preview img {
+    max-width: 100%;
+    max-height: 55vh;
+  }
+
+  .content-preview img,
+  .featured-content-preview img {
+    max-height: 14rem;
+  }
+
+  .block-image-lightbox {
+    padding: 0.75rem;
+  }
+
+  .block-image-lightbox__close {
+    top: 0.5rem;
+    right: 0.5rem;
   }
 }

--- a/public/css/block-view.css
+++ b/public/css/block-view.css
@@ -182,12 +182,6 @@ hr {
   color: #0056b3;
 }
 
-.block-content img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
 .block-content p, .block-content ul *, .block-content ol * {
   white-space: unset;
 }

--- a/public/css/blocks-dashboard.css
+++ b/public/css/blocks-dashboard.css
@@ -88,13 +88,6 @@ ul {
   }
 }
 
-.content-preview img,
-.featured-content-preview img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-}
-
 .block-title {
   font-size: 27px;
   font-weight: bold;

--- a/public/js/block-images.js
+++ b/public/js/block-images.js
@@ -1,0 +1,100 @@
+/* global document, window */
+
+(function () {
+  const imageSelector = '.block-content img, .content-preview img, .featured-content-preview img';
+  let lightbox;
+  let lightboxImage;
+  let closeButton;
+  let previouslyFocused;
+
+  const label = (key, fallback) => {
+    const translated = window.i18nT?.(key);
+    return translated && translated !== key ? translated : fallback;
+  };
+
+  const ensureLightbox = () => {
+    if (lightbox) return;
+
+    lightbox = document.createElement('div');
+    lightbox.className = 'block-image-lightbox';
+    lightbox.hidden = true;
+    lightbox.setAttribute('role', 'dialog');
+    lightbox.setAttribute('aria-modal', 'true');
+    lightbox.setAttribute('aria-label', label('layout.blockImages.preview', 'Image preview'));
+
+    const frame = document.createElement('div');
+    frame.className = 'block-image-lightbox__frame';
+
+    closeButton = document.createElement('button');
+    closeButton.className = 'block-image-lightbox__close';
+    closeButton.type = 'button';
+    closeButton.setAttribute('aria-label', label('layout.blockImages.close', 'Close image preview'));
+
+    lightboxImage = document.createElement('img');
+    lightboxImage.className = 'block-image-lightbox__image';
+    lightboxImage.alt = '';
+
+    frame.append(closeButton, lightboxImage);
+    lightbox.append(frame);
+    document.body.append(lightbox);
+
+    closeButton.addEventListener('click', closeLightbox);
+    lightbox.addEventListener('click', event => {
+      if (event.target === lightbox) closeLightbox();
+    });
+  };
+
+  const closeLightbox = () => {
+    if (!lightbox || lightbox.hidden) return;
+
+    lightbox.hidden = true;
+    document.body.style.removeProperty('overflow');
+    lightboxImage.removeAttribute('src');
+
+    if (previouslyFocused && document.contains(previouslyFocused)) {
+      previouslyFocused.focus();
+    }
+    previouslyFocused = null;
+  };
+
+  const openLightbox = img => {
+    ensureLightbox();
+
+    previouslyFocused = document.activeElement;
+    lightboxImage.src = img.currentSrc || img.src;
+    lightboxImage.alt = img.alt || '';
+    lightbox.hidden = false;
+    document.body.style.overflow = 'hidden';
+    closeButton.focus();
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll(imageSelector).forEach(img => {
+      img.tabIndex = img.tabIndex >= 0 ? img.tabIndex : 0;
+      img.setAttribute('role', 'button');
+      if (!img.getAttribute('aria-label')) {
+        img.setAttribute('aria-label', label('layout.blockImages.open', 'Open image preview'));
+      }
+    });
+  });
+
+  document.addEventListener('click', event => {
+    const img = event.target.closest(imageSelector);
+    if (!img) return;
+
+    event.preventDefault();
+    openLightbox(img);
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      closeLightbox();
+      return;
+    }
+
+    if ((event.key === 'Enter' || event.key === ' ') && event.target.matches(imageSelector)) {
+      event.preventDefault();
+      openLightbox(event.target);
+    }
+  });
+}());

--- a/views/partials/_common_scripts.pug
+++ b/views/partials/_common_scripts.pug
@@ -4,6 +4,7 @@ script(src="/js/notifications.js")
 script(src="/js/ui-lang-menu.js")
 script(src="/js/details-autoclose.js")
 script(src="/js/uiLangFallbackBanner.js")
+script(src="/js/block-images.js")
 
 script.
   window.MathJax = {


### PR DESCRIPTION
## Summary
- Adds shared compact sizing for rendered block images across block pages, homepage previews, archive/list contexts, and tag views
- Adds a click/tap lightbox so users can opt in to viewing images larger
- Supports keyboard access with focusable images, Enter/Space to open, and Escape to close
- Replaces scattered full-width image rules with shared block image styling

## Testing
- `npx eslint public/js/block-images.js`
- `node --check public/js/block-images.js`
- `npm run build`

## Note
- `npx jasmine` is currently blocked by a pre-existing Node ESM import issue in `spec/broadcastSpec.js`