### PR TITLE
Fix iOS preview fade after closing image lightbox

### DIFF
--- a/public/css/block-common.css
+++ b/public/css/block-common.css
@@ -36,6 +36,8 @@ a.block-title {
   max-width: min(100%, 22rem);
   max-height: 15rem;
   margin: 0.75rem auto;
+  position: relative;
+  z-index: 0;
 }
 
 .block-content img:focus-visible,

--- a/public/css/blocks-dashboard.css
+++ b/public/css/blocks-dashboard.css
@@ -32,6 +32,7 @@ ul {
 
 .content-preview {
   line-height: 1.4;
+  isolation: isolate;
   overflow: hidden;
   position: relative;
   white-space: normal;
@@ -52,7 +53,23 @@ ul {
   height: 50px;
   background: linear-gradient(transparent, #fff);
   pointer-events: none;
+  z-index: 2;
   transition: opacity 0.3s ease;
+}
+
+@supports (-webkit-mask-image: linear-gradient(#000, transparent)) or (mask-image: linear-gradient(#000, transparent)) {
+  .content-preview.fade-footer {
+    -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 50px), transparent);
+    mask-image: linear-gradient(to bottom, #000 calc(100% - 50px), transparent);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+  }
+
+  .content-preview.fade-footer::after {
+    display: none;
+  }
 }
 
 .block-footer {

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -346,6 +346,7 @@
   max-height: 200px;
   overflow: hidden;
   margin-top: 1rem;
+  isolation: isolate;
   position: relative;
 }
 
@@ -358,6 +359,22 @@
   height: 40px;
   background: linear-gradient(transparent, #fffbea);
   pointer-events: none;
+  z-index: 2;
+}
+
+@supports (-webkit-mask-image: linear-gradient(#000, transparent)) or (mask-image: linear-gradient(#000, transparent)) {
+  .featured-content-preview {
+    -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 40px), transparent);
+    mask-image: linear-gradient(to bottom, #000 calc(100% - 40px), transparent);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+  }
+
+  .featured-content-preview::after {
+    display: none;
+  }
 }
 
 .featured-section {


### PR DESCRIPTION
## Summary
- Fixes an iOS Safari rendering issue where preview fade shading could become discontinuous after opening and closing the image lightbox
- Uses mask-based fades for block previews when supported, avoiding WebKit layer ordering glitches with image content
- Keeps the existing pseudo-element gradient as a fallback for browsers without mask support

## Testing
- Reproduced and verified the fix on iPhone against a local dev instance
- `npm run build`