### PR TITLE
Prevent stale backup restores from overwriting collaborative edits

### DIFF
--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -241,7 +241,7 @@ class Broadcast {
 
   onConnection(connection) {
     this.controller.updateRootUrl(connection.peer);
-    this.controller.unhideEditor();
+    this.controller.unhideEditorWhenReady();
     this.addToInConns(connection);
   }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -23,6 +23,8 @@ class Controller {
     this.blockId = blockId;
     this.lastLocalInsertTime = new Date().getTime();
     this.isLocked = false;
+    this.isReadyForLocalEdits = false;
+    this.backupHydrationRequestId = 0;
     this.makeOwnName(doc);
     this.setTimedActions();
 
@@ -33,6 +35,7 @@ class Controller {
     this.editor = editor;
     this.editor.controller = this;
     this.editor.bindChangeEvent();
+    this.editor.setReadOnly(true);
 
     this.vector = new VersionVector(this.siteId);
     this.crdt = new CRDT(this);
@@ -182,6 +185,12 @@ class Controller {
     doc.getElementById('block-page').classList.remove('hide');
   }
 
+  unhideEditorWhenReady(doc = document) {
+    if (this.isReadyForLocalEdits) {
+      this.unhideEditor(doc);
+    }
+  }
+
   hideEditor(doc = document) {
     doc.getElementById('block-page').classList.add('hide')
   }
@@ -278,7 +287,7 @@ class Controller {
       return;
     }
 
-    BackendHelper.syncBlockContent(this.blockId, this.editor.currentContents())
+    BackendHelper.syncBlockContent(this.blockId, this.editor.getText())
       .then()
       .catch((error) => {
         console.log('Error occurred during attempt to save doc.');
@@ -504,7 +513,7 @@ class Controller {
       const possibleTargets = result.filter(id => id !== this.myPeerId());
 
       if (possibleTargets.length === 0) {
-        this.unhideEditor();
+        this.unhideEditorWhenReady();
         this.useBackupContent();
         this.broadcast.peer.on('connection', conn => this.setTargetPeerId(conn.peer));
       } else {
@@ -519,6 +528,7 @@ class Controller {
 
   handleSync(syncObj, doc = document, win = window) {
     if (syncObj.peerId != this.targetPeerId) { this.setTargetPeerId(syncObj.peerId); }
+    this.backupHydrationRequestId++;
 
     syncObj.network.forEach(obj => this.addToNetwork(obj.peerId, obj.siteId, doc));
 
@@ -526,9 +536,15 @@ class Controller {
       this.populateCRDT(syncObj.initialStruct);
       this.populateVersionVector(syncObj.initialVersions);
     }
-    this.unhideEditor(doc);
+    this.markEditorReady(doc);
 
     this.syncCompleted(syncObj.peerId);
+  }
+
+  markEditorReady(doc = document) {
+    this.isReadyForLocalEdits = true;
+    this.editor.setReadOnly(false);
+    this.unhideEditor(doc);
   }
 
   syncCompleted(peerId) {
@@ -603,11 +619,13 @@ class Controller {
   }
 
   localDelete(startPos, endPos) {
+    if (!this.isReadyForLocalEdits) return;
     if (this.isLocked) return;
     this.crdt.handleLocalDelete(startPos, endPos);
   }
 
   localInsert(chars, startPos) {
+    if (!this.isReadyForLocalEdits) return;
     if (this.isLocked) return;
     if (!chars || chars.length === 0) return;
     for (let i = 0; i < chars.length; i++) {
@@ -630,13 +648,24 @@ class Controller {
     if (!this.crdt.isEmpty()) {
       return;
     }
+    const requestId = ++this.backupHydrationRequestId;
     this.hideEditor();
     BackendHelper.getBlock(this.blockId).then(result => {
-      if (this.crdt.isEmpty()) {
-        this.localInsert(result.block.content, { line: 0, ch: 0 });
+      if (requestId === this.backupHydrationRequestId && this.crdt.isEmpty()) {
+        this.isReadyForLocalEdits = true;
+        this.localInsert(result.block.content || '', { line: 0, ch: 0 });
         this.editor.replaceText(this.crdt.toText());
+        this.markEditorReady();
       }
-      this.unhideEditor();
+    }).catch((error) => {
+      console.log('Error occurred during attempt to hydrate doc from backup.');
+      console.log(error);
+      if (requestId === this.backupHydrationRequestId && this.crdt.isEmpty()) {
+        this.isReadyForLocalEdits = true;
+        this.localInsert(this.editor.getText() || '', { line: 0, ch: 0 });
+        this.editor.replaceText(this.crdt.toText());
+        this.markEditorReady();
+      }
     });
   }
 

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -191,6 +191,14 @@ class Editor {
     });
   }
 
+  setReadOnly(isReadOnly) {
+    this.mde.codemirror.setOption('readOnly', isReadOnly ? 'nocursor' : false);
+  }
+
+  getText() {
+    return this.mde.value();
+  }
+
   clearImagePreviews() {
     // Clear stored markers rather than querying the DOM
     this.imageMarks.forEach(marker => marker.clear());

--- a/spec/controllerSpec.js
+++ b/spec/controllerSpec.js
@@ -3,6 +3,7 @@ import { v4 } from 'uuid';
 import Controller from '../lib/controller';
 import Char from '../lib/char';
 import Identifier from '../lib/identifier';
+import BackendHelper from '../lib/backendHelper';
 
 describe("Controller", () => {
   const mockPeer = {
@@ -37,7 +38,9 @@ describe("Controller", () => {
     insertText: function () { },
     deleteText: function () { },
     removeCursor: function () { },
-    bindButtons: function () { }
+    bindButtons: function () { },
+    setReadOnly: function () { },
+    getText: function () { }
   };
 
   const host = "https://localhost:3000";
@@ -568,6 +571,72 @@ describe("Controller", () => {
       expect(controller.addToNetwork).toHaveBeenCalledWith('1', '3', mockDoc);
       expect(controller.addToNetwork).toHaveBeenCalledWith('2', '4', mockDoc);
       expect(controller.addToNetwork).toHaveBeenCalledWith('3', '5', mockDoc);
+    });
+  });
+
+  describe("backup hydration", () => {
+    let mockWin, mockDoc, controller, resolveBackup;
+
+    const syncObj = {
+      initialStruct: [[{
+        position: [{ digit: 3, siteId: 4 }],
+        counter: 1,
+        siteId: 5,
+        value: "a"
+      }]],
+      initialVersions: [],
+      peerId: '7',
+      siteId: '10',
+      network: []
+    };
+
+    beforeEach(() => {
+      spyOn(Controller.prototype, 'setTimedActions');
+      mockWin = new JSDOM(`<!DOCTYPE html><div id='block-page'></div><p id="peerId"></p><p class="copy-container"></p>`).window;
+      mockDoc = mockWin.document;
+      controller = new Controller(
+        'target-peer',
+        'room-id',
+        'block-id',
+        host,
+        mockPeer,
+        mockBroadcast,
+        mockEditor,
+        mockDoc,
+        mockWin
+      );
+      controller.broadcast.peer = mockPeer;
+
+      spyOn(BackendHelper, 'getBlock').and.returnValue(new Promise(resolve => {
+        resolveBackup = resolve;
+      }));
+    });
+
+    it("does not apply a delayed DB backup after peer sync initializes the CRDT", async () => {
+      spyOn(controller, "localInsert").and.callThrough();
+      spyOn(controller.editor, "replaceText");
+
+      controller.useBackupContent();
+      controller.handleSync(syncObj, mockDoc, mockWin);
+
+      resolveBackup({ block: { content: "stale backup" } });
+      await Promise.resolve();
+
+      expect(controller.localInsert).not.toHaveBeenCalled();
+      expect(controller.editor.replaceText).toHaveBeenCalledTimes(1);
+      expect(controller.crdt.toText()).toEqual("a");
+    });
+
+    it("backs up the source editor value instead of rendered CodeMirror DOM", async () => {
+      spyOn(controller, "checkBlockStatus").and.returnValue(Promise.resolve(false));
+      spyOn(controller, "firstPeerId").and.returnValue(mockPeer.id);
+      spyOn(controller, "myPeerId").and.returnValue(mockPeer.id);
+      spyOn(controller.editor, "getText").and.returnValue("source markdown");
+      spyOn(BackendHelper, "syncBlockContent").and.returnValue(Promise.resolve());
+
+      await controller.backupChanges();
+
+      expect(BackendHelper.syncBlockContent).toHaveBeenCalledWith('block-id', "source markdown");
     });
   });
 

--- a/spec/editorSpec.js
+++ b/spec/editorSpec.js
@@ -4,6 +4,7 @@ import Editor from '../lib/editor';
 
 describe("Editor", () => {
   const mockMDE = {
+    value: function() {},
     codemirror: {
       setOption: function() {}
     }
@@ -16,6 +17,25 @@ describe("Editor", () => {
   describe("constructor", () => {
     it("sets the mde passed in to the.mde", () => {
       expect(editor.mde).toEqual(mockMDE);
+    });
+  });
+
+  describe("editing state helpers", () => {
+    it("sets CodeMirror readOnly while waiting for hydration", () => {
+      spyOn(editor.mde.codemirror, "setOption");
+      editor.setReadOnly(true);
+      expect(editor.mde.codemirror.setOption).toHaveBeenCalledWith('readOnly', 'nocursor');
+    });
+
+    it("restores CodeMirror editability after hydration", () => {
+      spyOn(editor.mde.codemirror, "setOption");
+      editor.setReadOnly(false);
+      expect(editor.mde.codemirror.setOption).toHaveBeenCalledWith('readOnly', false);
+    });
+
+    it("returns the source editor value for persistence", () => {
+      spyOn(editor.mde, "value").and.returnValue("source markdown");
+      expect(editor.getText()).toEqual("source markdown");
     });
   });
 


### PR DESCRIPTION
## Summary

This fixes a data-loss risk in the CRDT block editor where delayed DB backup hydration could race with peer sync or local editor activity.

The editor now stays read-only until CRDT state is initialized from either peer sync or DB backup, and delayed backup responses are ignored if peer sync has already initialized the document.

## Changes

- Gate local insert/delete handling until editor hydration is complete.
- Keep CodeMirror read-only during initial CRDT hydration.
- Ignore stale DB backup hydration responses after peer sync wins the race.
- Avoid un-hiding the editor from connection events before the document is ready.
- Save block content from the EasyMDE source value instead of rendered CodeMirror DOM.
- Add regression coverage for stale backup hydration and source-value persistence.

## Verification

- Manually tested collaborative editing with multiple local editing instances on the same block.
- Ran `npm run build` successfully.

## Notes

Automated tests are currently blocked by existing repo test harness/lint configuration issues:
- `npm test` fails during the repo-wide ESLint pretest step.
- Focused Jasmine specs are blocked by existing Node 24 ESM extensionless import resolution.