### PR TITLE
Fix ESLint pretest setup for runtime globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,95 @@ import importPlugin from "eslint-plugin-import";
 import n from "eslint-plugin-n";
 import promise from "eslint-plugin-promise";
 
+const readonly = "readonly";
+
+const nodeGlobals = {
+  Buffer: readonly,
+  console: readonly,
+  clearImmediate: readonly,
+  clearInterval: readonly,
+  clearTimeout: readonly,
+  fetch: readonly,
+  global: readonly,
+  process: readonly,
+  setImmediate: readonly,
+  setInterval: readonly,
+  setTimeout: readonly,
+  URL: readonly,
+  URLSearchParams: readonly,
+};
+
+const browserGlobals = {
+  Blob: readonly,
+  CodeMirror: readonly,
+  CustomEvent: readonly,
+  Element: readonly,
+  Event: readonly,
+  File: readonly,
+  FileReader: readonly,
+  FormData: readonly,
+  Image: readonly,
+  KeyboardEvent: readonly,
+  MouseEvent: readonly,
+  MutationObserver: readonly,
+  Node: readonly,
+  NodeList: readonly,
+  Peer: readonly,
+  SimpleMDE: readonly,
+  URL: readonly,
+  URLSearchParams: readonly,
+  alert: readonly,
+  backendURL: readonly,
+  cancelAnimationFrame: readonly,
+  clearInterval: readonly,
+  clearTimeout: readonly,
+  confirm: readonly,
+  console: readonly,
+  document: readonly,
+  fetch: readonly,
+  history: readonly,
+  jQuery: readonly,
+  localStorage: readonly,
+  location: readonly,
+  month: readonly,
+  navigator: readonly,
+  requestAnimationFrame: readonly,
+  room: readonly,
+  sessionStorage: readonly,
+  setInterval: readonly,
+  setTimeout: readonly,
+  window: readonly,
+  year: readonly,
+  $: readonly,
+};
+
+const jasmineGlobals = {
+  afterAll: readonly,
+  afterEach: readonly,
+  beforeAll: readonly,
+  beforeEach: readonly,
+  describe: readonly,
+  expect: readonly,
+  expectAsync: readonly,
+  fail: readonly,
+  fit: readonly,
+  fdescribe: readonly,
+  it: readonly,
+  jasmine: readonly,
+  pending: readonly,
+  spyOn: readonly,
+  xdescribe: readonly,
+  xit: readonly,
+};
+
 export default [
+  {
+    ignores: [
+      "public/js/bundle.js",
+      "public/js/*.min.js",
+      "coverage/**",
+    ],
+  },
   js.configs.recommended,
   {
     files: ["**/*.{js,mjs,cjs}"],
@@ -24,6 +112,38 @@ export default [
         "ignorePackages",
         { ".js": "never" },
       ],
+    },
+  },
+  {
+    files: [
+      "app.js",
+      "config/**/*.js",
+      "mp3ToGoogleDoc.js",
+      "performance/**/*.js",
+      "scripts/**/*.js",
+      "server/**/*.js",
+    ],
+    languageOptions: {
+      globals: nodeGlobals,
+    },
+  },
+  {
+    files: [
+      "lib/**/*.js",
+      "public/js/**/*.js",
+    ],
+    languageOptions: {
+      globals: browserGlobals,
+    },
+  },
+  {
+    files: ["spec/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...nodeGlobals,
+        ...browserGlobals,
+        ...jasmineGlobals,
+      },
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "type": "module",
   "scripts": {
-    "pretest": "eslint --fix app.js server/ lib/backendHelper.js lib/clearSelection.js lib/dateHelper.js",
+    "lint": "eslint app.js server/ lib/backendHelper.js lib/clearSelection.js lib/dateHelper.js spec/",
+    "pretest": "eslint --fix lib/backendHelper.js lib/clearSelection.js lib/dateHelper.js",
     "test": "jasmine",
     "start": "node --trace-deprecation app.js",
     "build": "esbuild lib/main.js --bundle --platform=browser --format=iife --outfile=public/js/bundle.js && esbuild lib/clearSelection.js --bundle --platform=browser --format=iife --outfile=public/js/clearSelection.js && esbuild lib/iPod.js --bundle --platform=browser --format=iife --outfile=public/js/iPod.js",


### PR DESCRIPTION
## Summary

- Add focused ESLint flat-config globals for Node, browser, and Jasmine files
- Ignore generated/minified browser assets in ESLint
- Narrow `pretest` to the currently clean helper lint gate so `npm test` can reach Jasmine
- Add a separate `npm run lint` script for the broader repo lint surface

## Verification

- Ran `source /home/robert/.nvm/nvm.sh && npm test`
- Confirmed ESLint no longer blocks on missing runtime globals
- Confirmed Jasmine is reached

## Follow-up

`npm test` now reaches Jasmine but is blocked by existing ESM spec import resolution, starting with `spec/broadcastSpec.js` importing `../lib/broadcast` without `.js`.