### PR TITLE
Fix Jasmine setup for Node 24 ESM

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -110,7 +110,7 @@ export default [
       "import/extensions": [
         "error",
         "ignorePackages",
-        { ".js": "never" },
+        { ".js": "always" },
       ],
     },
   },

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -1,4 +1,4 @@
-import BackendHelper from './backendHelper';
+import BackendHelper from './backendHelper.js';
 
 class Broadcast {
   constructor() {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,15 +1,15 @@
-import BackendHelper from './backendHelper';
-import DateHelper from './dateHelper';
-import CRDT from './crdt';
-import Char from './char';
-import Identifier from './identifier';
-import VersionVector from './versionVector';
-import Version from './version';
+import BackendHelper from './backendHelper.js';
+import DateHelper from './dateHelper.js';
+import CRDT from './crdt.js';
+import Char from './char.js';
+import Identifier from './identifier.js';
+import VersionVector from './versionVector.js';
+import Version from './version.js';
 import { v4 } from 'uuid';
-import { generateItemFromHash } from './hashAlgo';
-import CSS_COLORS from './cssColors';
-import { getCursorNameForSite } from './cursorHelper';
-import { getUiLang } from './langContext';
+import { generateItemFromHash } from './hashAlgo.js';
+import CSS_COLORS from './cssColors.js';
+import { getCursorNameForSite } from './cursorHelper.js';
+import { getUiLang } from './langContext.js';
 
 class Controller {
   constructor(targetPeerId, roomId, blockId, host, peer, broadcast, editor, doc = document, win = window) {

--- a/lib/crdt.js
+++ b/lib/crdt.js
@@ -1,5 +1,5 @@
-import Identifier from './identifier';
-import Char from './char';
+import Identifier from './identifier.js';
+import Char from './char.js';
 
 class CRDT {
   constructor(controller, base=32, boundary=10, strategy='random') {

--- a/lib/crdtLinear.js
+++ b/lib/crdtLinear.js
@@ -1,5 +1,5 @@
-import Identifier from './identifier';
-import Char from './char';
+import Identifier from './identifier.js';
+import Char from './char.js';
 
 class CRDT {
   constructor(controller, base=32, boundary=10, strategy='random', mult=2) {

--- a/lib/cursorHelper.js
+++ b/lib/cursorHelper.js
@@ -1,7 +1,7 @@
 // lib/cursorHelper.js
-import { ANIMALS } from './cursorNames';
-import { generateItemFromHash } from './hashAlgo';
-import { getUiLang } from './langContext';
+import { ANIMALS } from './cursorNames.js';
+import { generateItemFromHash } from './hashAlgo.js';
+import { getUiLang } from './langContext.js';
 
 export function getCursorNameForSite(siteId) {
   const lang = getUiLang();

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,9 +1,9 @@
-import RequestHelper from './requestHelper';
-import RemoteCursor from './remoteCursor';
+import RequestHelper from './requestHelper.js';
+import RemoteCursor from './remoteCursor.js';
 import {
   alreadyPingedToday,
   streakPing
-} from './streakHelper';
+} from './streakHelper.js';
 
 class Editor {
   constructor(mde) {

--- a/lib/iPod.js
+++ b/lib/iPod.js
@@ -1,7 +1,7 @@
 import "core-js/stable";
 import * as Bluebird from 'bluebird';
-import BackendHelper from './backendHelper';
-import EncodeHelper from './encodeHelper';
+import BackendHelper from './backendHelper.js';
+import EncodeHelper from './encodeHelper.js';
 
 $(document).ready(async () => {
   let v; let up = 0; let down = 0; let i = 0; let

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,8 @@
 import EasyMDE from 'easymde'
 
-import Controller from './controller';
-import Broadcast from './broadcast';
-import Editor from './editor';
+import Controller from './controller.js';
+import Broadcast from './broadcast.js';
+import Editor from './editor.js';
 
 let peerId = initialTargetPeerId;
 if (!peerId) {

--- a/lib/remoteCursor.js
+++ b/lib/remoteCursor.js
@@ -1,6 +1,6 @@
-import CSS_COLORS from './cssColors';
-import { generateItemFromHash } from './hashAlgo';
-import { getCursorNameForSite } from './cursorHelper';
+import CSS_COLORS from './cssColors.js';
+import { generateItemFromHash } from './hashAlgo.js';
+import { getCursorNameForSite } from './cursorHelper.js';
 
 export default class RemoteCursor {
   constructor(mde, siteId, position) {

--- a/lib/streakHelper.js
+++ b/lib/streakHelper.js
@@ -1,5 +1,7 @@
 // top-level variable to hold the date we last pinged
-let streakPingDate = localStorage.getItem('streakPingDate') || null;
+let streakPingDate = typeof localStorage === 'undefined'
+  ? null
+  : localStorage.getItem('streakPingDate') || null;
 
 // Utility to check if “today” is the same day we last sent a ping
 export function alreadyPingedToday() {
@@ -12,12 +14,14 @@ export function alreadyPingedToday() {
 // Utility to store “today” so we won't send again
 export function markPingSentForToday() {
   const todayUTC = new Date().toISOString().slice(0, 10);
-  localStorage.setItem('streakPingDate', todayUTC);
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('streakPingDate', todayUTC);
+  }
   streakPingDate = todayUTC;
 }
 
 export function streakPing() {
-  if (!userId) return;
+  if (typeof userId === 'undefined' || !userId) return;
 
   fetch(`/api/v1/users/${userId}/streakPing`, {
     method: 'POST'

--- a/lib/userBot.js
+++ b/lib/userBot.js
@@ -1,8 +1,8 @@
-import CRDT from './crdt';
-import VersionVector from './versionVector';
+import CRDT from './crdt.js';
+import VersionVector from './versionVector.js';
 import Peer from 'peerjs';
-import Identifier from './identifier';
-import Char from './char';
+import Identifier from './identifier.js';
+import Char from './char.js';
 
 class UserBot {
   constructor(peerId, targetPeerId, script, mde) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
-import Char from './char';
-import CRDT from './crdt';
+import Char from './char.js';
+import CRDT from './crdt.js';
 import { v4 } from 'uuid';
 
 export function mockController() {

--- a/lib/utilLinear.js
+++ b/lib/utilLinear.js
@@ -1,5 +1,5 @@
-import Char from './char';
-import CRDT from './crdtLinear';
+import Char from './char.js';
+import CRDT from './crdtLinear.js';
 import { v4 } from 'uuid';
 
 function mockController() {

--- a/lib/versionVector.js
+++ b/lib/versionVector.js
@@ -1,4 +1,4 @@
-import Version from './version';
+import Version from './version.js';
 
 // vector/list of versions of sites in the distributed system
 // keeps track of the latest operation received from each site (i.e. version)

--- a/spec/broadcastSpec.js
+++ b/spec/broadcastSpec.js
@@ -1,4 +1,4 @@
-import Broadcast from '../lib/broadcast';
+import Broadcast from '../lib/broadcast.js';
 import { v4 } from 'uuid';
 import { JSDOM } from 'jsdom';
 

--- a/spec/charSpec.js
+++ b/spec/charSpec.js
@@ -1,5 +1,5 @@
-import Char from '../lib/char';
-import Identifier from "../lib/identifier";
+import Char from '../lib/char.js';
+import Identifier from "../lib/identifier.js";
 
 describe("Char", () => {
   describe("compareTo", () => {

--- a/spec/controllerSpec.js
+++ b/spec/controllerSpec.js
@@ -1,9 +1,9 @@
 import { JSDOM } from 'jsdom';
 import { v4 } from 'uuid';
-import Controller from '../lib/controller';
-import Char from '../lib/char';
-import Identifier from '../lib/identifier';
-import BackendHelper from '../lib/backendHelper';
+import Controller from '../lib/controller.js';
+import Char from '../lib/char.js';
+import Identifier from '../lib/identifier.js';
+import BackendHelper from '../lib/backendHelper.js';
 
 describe("Controller", () => {
   const mockPeer = {

--- a/spec/crdtLinearSpec.js
+++ b/spec/crdtLinearSpec.js
@@ -1,7 +1,7 @@
-import CRDT from '../lib/crdtLinear';
-import Char from '../lib/char';
-import Identifier from '../lib/identifier';
-import VersionVector from '../lib/versionVector';
+import CRDT from '../lib/crdtLinear.js';
+import Char from '../lib/char.js';
+import Identifier from '../lib/identifier.js';
+import VersionVector from '../lib/versionVector.js';
 
 describe("CRDT", () => {
   const siteId = Math.floor(Math.random() * 1000);

--- a/spec/crdtSpec.js
+++ b/spec/crdtSpec.js
@@ -1,7 +1,7 @@
-import CRDT from '../lib/crdt';
-import Char from '../lib/char';
-import Identifier from '../lib/identifier';
-import VersionVector from '../lib/versionVector';
+import CRDT from '../lib/crdt.js';
+import Char from '../lib/char.js';
+import Identifier from '../lib/identifier.js';
+import VersionVector from '../lib/versionVector.js';
 
 describe("CRDT", () => {
   const siteId = Math.floor(Math.random() * 1000);

--- a/spec/editorSpec.js
+++ b/spec/editorSpec.js
@@ -1,6 +1,4 @@
-import { JSDOM } from 'jsdom';
-
-import Editor from '../lib/editor';
+import Editor from '../lib/editor.js';
 
 describe("Editor", () => {
   const mockMDE = {
@@ -37,48 +35,6 @@ describe("Editor", () => {
       spyOn(editor.mde, "value").and.returnValue("source markdown");
       expect(editor.getText()).toEqual("source markdown");
     });
-  });
-
-  describe("bindChangeEvent", () => {
-    // it("is triggered by a change in the codemirror", () => {
-    //   spyOn(editor.mde.codemirror, "on");
-    //   editor.mde.codemirror.trigger("change");
-    //   expect(editor.mde.codemirror.on).toHaveBeenCalled();
-    // });
-    //
-    // it("changes the character text to a new line", () => {
-    //
-    // });
-    //
-    // it("calls controller.handleInsert when change was an insert", () => {
-    //
-    // });
-    //
-    // it("calls controller.handleDelete when change was a deletion", () => {
-    //
-    // });
-  });
-
-  describe("updateView", () => {
-    beforeEach(() => {
-      const dom = new JSDOM(`<!DOCTYPE html><textarea></textarea>`);
-    });
-
-    // it("adds text to the view", () => {
-    //   const editor = new Editor(null);
-    //   const newText = "I am here."
-    //   editor.updateView(newText);
-    //
-    //   expect(editor.mde.value()).toEqual(newText);
-    // });
-    //
-    // it("removes text from the view", () => {
-    //
-    // });
-    //
-    // it("retains the cursor position", () => {
-    //
-    // });
   });
 
   describe("findLinearIdx", () => {

--- a/spec/identifierSpec.js
+++ b/spec/identifierSpec.js
@@ -1,4 +1,4 @@
-import Identifier from '../lib/identifier';
+import Identifier from '../lib/identifier.js';
 
 describe("Identifier", () => {
   describe("compareTo", () => {

--- a/spec/sortedArraySpec.js
+++ b/spec/sortedArraySpec.js
@@ -1,4 +1,4 @@
-import SortedArray from '../lib/sortedArray';
+import SortedArray from '../lib/sortedArray.js';
 
 describe('SortedArray', () => {
   describe('get', () => {

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -4,9 +4,11 @@
     "**/*[sS]pec.js"
   ],
   "helpers": [
-    "helpers/**/*.js",
-    "../node_modules/babel-register/lib/node.js"
+    "helpers/**/*.js"
   ],
-  "stopSpecOnExpectationFailure": false,
-  "random": false
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "forbidDuplicateNames": false,
+    "random": false
+  }
 }

--- a/spec/versionSpec.js
+++ b/spec/versionSpec.js
@@ -1,4 +1,4 @@
-import Version from '../lib/version';
+import Version from '../lib/version.js';
 
 describe('Version', () => {
   let siteId, version;

--- a/spec/versionVectorSpec.js
+++ b/spec/versionVectorSpec.js
@@ -1,4 +1,4 @@
-import VersionVector from "../lib/VersionVector";
+import VersionVector from "../lib/versionVector.js";
 
 describe("VersionVector", () => {
   describe('constructor', () => {


### PR DESCRIPTION
## Summary

Updates the Jasmine test setup so specs can be loaded and executed under Node 24 with native ESM.

## Changes

- Removed the stale Babel register helper from Jasmine config.
- Moved Jasmine runtime options under `env` for Jasmine 6 compatibility.
- Disabled duplicate suite-name enforcement to match the existing spec structure.
- Added explicit `.js` extensions to relative imports used by specs and tested lib modules.
- Updated ESLint import extension expectations to preserve native ESM-compatible imports.
- Guarded browser-only globals in `streakHelper` so Node can import editor-related modules.
- Removed empty placeholder `describe` blocks that Jasmine 6 rejects.

## Verification

- Ran `npx jasmine spec/controllerSpec.js spec/editorSpec.js`.
  - Jasmine now resolves modules and executes specs.
  - Remaining failures are localized `controllerSpec` test setup issues.
- Ran `npm test`.
  - Full suite now loads and runs.
  - Remaining failures are existing/localized spec issues, including `controllerSpec` and `broadcastSpec`.

## Notes

This PR focuses on restoring Jasmine runner compatibility for Node 24 / ESM. Follow-up work can address the now-visible spec failures separately.