### PR TITLE
Fix public user posts page title after posts rename

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -449,7 +449,7 @@ router.get(
       res.render('users/blocks', {
         title: isOwnProfile
           ? t('userBlocks.meta.title')
-          : t('userBlocks.meta.titleUser', { username }),
+          : t('userBlocks.titleUser', { username }),
         description: t('userBlocks.meta.description'),
         username,
         blocks,


### PR DESCRIPTION
## Summary

- Fixes the public user posts page title after the block-to-post copy rename.
- Updates the route to use the existing `userBlocks.titleUser` translation key instead of the missing `userBlocks.meta.titleUser` key.

## Verification

- Confirmed all i18n JSON files parse successfully.
- Confirmed static route/view translation keys resolve in English.
- Ran `npm test`: 264 specs, 0 failures.