### PR TITLE
Fix remote cursor labels in collaborative editor

### DIFF
--- a/lib/remoteCursor.js
+++ b/lib/remoteCursor.js
@@ -12,7 +12,6 @@ export default class RemoteCursor {
     this.createCursor(color);
     this.createFlag(color, name);
 
-    this.cursor.appendChild(this.flag);
     this.set(position);
   }
 
@@ -28,24 +27,39 @@ export default class RemoteCursor {
   createFlag(color, name) {
     const cursorName = document.createTextNode(name);
 
+    this.flagLine = document.createElement('div');
+    this.flagLine.classList.add('remote-cursor-flag-line');
+
     this.flag = document.createElement('span');
     this.flag.classList.add('flag');
     this.flag.style.backgroundColor = color;
-    this.flag.appendChild(cursorName)
+    this.flag.appendChild(cursorName);
+    this.flagLine.appendChild(this.flag);
   }
 
   set(position) {
     this.detach();
 
     const coords = this.mde.codemirror.cursorCoords(position, 'local');
-    this.cursor.style.left = (coords.left >= 0 ? coords.left : 0) + 'px';
-    this.mde.codemirror.getDoc().setBookmark(position, { widget: this.cursor });
+    const left = coords.left >= 0 ? coords.left : 0;
+    this.cursor.style.left = left + 'px';
+    this.flagLine.style.marginLeft = left + 'px';
+    this.bookmark = this.mde.codemirror.getDoc().setBookmark(position, { widget: this.cursor });
+    this.lineWidget = this.mde.codemirror.addLineWidget(position.line, this.flagLine, { above: true });
     this.lastPosition = position;
   }
 
   detach() {
-    if (this.cursor.parentElement) {
-        this.cursor.parentElement.remove();
+    if (this.bookmark) {
+      this.bookmark.clear();
+      this.bookmark = null;
+    } else if (this.cursor.parentElement) {
+      this.cursor.parentElement.remove();
+    }
+
+    if (this.lineWidget) {
+      this.lineWidget.clear();
+      this.lineWidget = null;
     }
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1000,14 +1000,24 @@ Cursors
   width: 2px;
   position: absolute;
   top: 0px;
+  z-index: 2;
+  pointer-events: none;
 }
 
-.flag {
-  top: -10px;
+.remote-cursor-flag-line {
+  height: 15px;
+  pointer-events: none;
+  position: relative;
+}
+
+.remote-cursor-flag-line .flag {
+  top: 0;
   font-size: 12px;
   left: 0px;
   position: absolute;
   line-height: 15px;
+  padding: 0 2px;
+  white-space: nowrap;
 }
 
 /********************


### PR DESCRIPTION
## Summary

Fixes remote collaborator cursor labels in the CRDT editor so they no longer overlap post text or get clipped at the top of the editor.

The remote cursor label is now rendered as a CodeMirror line widget above the cursor’s line, while the cursor bar remains anchored at the actual cursor position. This lets CodeMirror reserve space for the label instead of relying on absolute positioning over the document text.

## Changes

- Render remote cursor names in a dedicated CodeMirror line widget
- Keep the remote cursor bar positioned at the actual cursor location
- Clear both the cursor bookmark and label widget when cursors move
- Tighten label spacing so the tag sits cleanly against the cursor

## Testing

- Ran `npm test`
- Confirmed 264 specs pass with 0 failures
- Manually verified remote cursor labels no longer clip or overlap editor text