### PR TITLE
Flatten room dashboard block tabs

### DIFF
--- a/public/css/blocks-tabs.css
+++ b/public/css/blocks-tabs.css
@@ -5,38 +5,36 @@
 .tab-links {
   list-style: none;
   padding: 0;
-  margin: 0 0 20px 0;
+  margin: 0 0 16px 0;
   display: flex;
-  border-bottom: 1px solid #ddd;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .tab-links li {
-  margin-right: 5px;
+  margin: 0;
 }
 
 .tab-links li a {
   display: block;
-  padding: 10px 15px;
-  background: #f7f7f7;
+  padding: 8px 14px;
+  background: var(--secondary-bg);
   color: #555;
   text-decoration: none;
-  border: 1px solid #ddd;
-  border-bottom: none;
-  border-radius: 4px 4px 0 0;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-weight: 600;
+  line-height: 1.2;
 }
 
 .tab-links li.active a {
-  background: #fff;
-  color: #000;
-  border-color: #ddd;
+  background: #eaf4ff;
+  color: #004187;
+  border-color: #b8d9ff;
 }
 
 .tab-content > div {
   display: none;
-  padding: 15px;
-  border: 1px solid #ddd;
-  border-radius: 0 4px 4px 4px;
-  background: #fff;
 }
 
 .tab-content > div.active {


### PR DESCRIPTION
## Summary

- Removes the extra bordered/padded tab panel around room dashboard block lists
- Keeps the locked/in-progress tab selector behavior intact
- Restyles the tab selector as wrapped pill controls so narrow viewports have more usable list width

## Verification

- Started the app locally on port 3001
- Checked the Physics room dashboard with both locked and in-progress posts
- Confirmed the updated tab CSS is served and the block list no longer has the extra outer panel padding/border