### PR TITLE
Keep footer anchored on short pages

### DIFF
--- a/public/css/footer.css
+++ b/public/css/footer.css
@@ -1,6 +1,7 @@
 /* Footer */
 
 .footer {
+  flex-shrink: 0;
   padding: 20px;
   margin-top: 50px;
   background-color: #f2f2f2;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -69,11 +69,19 @@ General
   --z-popover: 930;    /* language switcher + its dropdown */
 }
 
+html {
+  min-height: 100%;
+}
+
 body {
   font-family: "Rubik-Light";
   background-color: #ffffff;
   margin: 0;
   overflow-x: hidden;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
 }
 
 html[dir="rtl"] body {
@@ -99,6 +107,7 @@ html[dir="rtl"] .fi {
 }
 
 .with-margins {
+  flex: 1 0 auto;
   margin: 0 auto;
   width: 85%;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

- Make the shared page body a full-height vertical flex layout
- Let the main content area expand to fill spare viewport space
- Prevent the footer from shrinking so it stays at the bottom on short views

## Testing

- Verified manually on the search page
- Not run: automated tests, CSS-only layout change