### PR TITLE
Fix editor occupancy and collaborator attribution

### DIFF
--- a/lib/backendHelper.js
+++ b/lib/backendHelper.js
@@ -20,6 +20,15 @@ class BackendHelper {
   }
 
   /**
+   * Marks the current editor as a collaborator after a real local edit.
+   * @param {string} blockId - The block ID.
+   * @returns {Promise<void>}
+   */
+  static async markBlockCollaborator(blockId) {
+    return BackendHelper._sendJSON(`api/v1/blocks/${blockId}/collaborators`, 'POST');
+  }
+
+  /**
    * Updates the block **metadata** (title, description, tags).
    * Requires authentication or an edit token.
    * @param {string} blockId - The block ID.
@@ -69,8 +78,8 @@ class BackendHelper {
    * @param {string} peerId - The peer's unique identifier.
    * @returns {Promise<void>}
    */
-  static async removePeer(blockId, peerId) {
-    return BackendHelper._sendJSON(`api/v1/blocks/${blockId}/peers/${peerId}`, 'DELETE');
+  static async removePeer(blockId, peerId, options = {}) {
+    return BackendHelper._sendJSON(`api/v1/blocks/${blockId}/peers/${peerId}`, 'DELETE', null, options);
   }
 
   /** 🌍 Helper Methods **/
@@ -98,14 +107,15 @@ class BackendHelper {
    * @param {Object} [body] - Request body (optional for DELETE).
    * @returns {Promise<void>}
    */
-  static async _sendJSON(endpoint, method, body = null) {
+  static async _sendJSON(endpoint, method, body = null, options = {}) {
     try {
-      const options = {
+      const fetchOptions = {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: body ? JSON.stringify(body) : null
+        body: body ? JSON.stringify(body) : null,
+        keepalive: options.keepalive === true
       };
-      const response = await fetch(`${backendURL}/${endpoint}`, options);
+      const response = await fetch(`${backendURL}/${endpoint}`, fetchOptions);
       if (!response.ok) throw new Error(`Failed to ${method} ${endpoint}`);
     } catch (error) {
       console.error(`❌ BackendHelper Error: ${error.message}`);

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -63,7 +63,7 @@ class Broadcast {
 
   onOpen(targetPeerId) {
     this.peer.on('open', id => {
-      this.controller.addPeer(id);
+      this.controller.startPeerPresence(id);
       this.onPeerConnection();
       this.onError();
       this.onDisconnect();

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -11,6 +11,8 @@ import CSS_COLORS from './cssColors.js';
 import { getCursorNameForSite } from './cursorHelper.js';
 import { getUiLang } from './langContext.js';
 
+/* global showToast */
+
 class Controller {
   constructor(targetPeerId, roomId, blockId, host, peer, broadcast, editor, doc = document, win = window) {
     this.siteId = v4();
@@ -24,6 +26,12 @@ class Controller {
     this.roomId = roomId;
     this.blockId = blockId;
     this.lastLocalInsertTime = new Date().getTime();
+    this.hasLocalUserEdits = false;
+    this.hasMarkedCollaborator = false;
+    this.isMarkingCollaborator = false;
+    this.peerPresenceId = null;
+    this.peerPresenceIntervalId = null;
+    this.removePeerPresenceOnExit = null;
     this.isLocked = false;
     this.isReadyForLocalEdits = false;
     this.backupHydrationRequestId = 0;
@@ -126,6 +134,53 @@ class Controller {
     BackendHelper.addPeer(this.blockId, id, this.roomId);
   }
 
+  startPeerPresence(id, win = this.win) {
+    this.peerPresenceId = id;
+    this.addPeer(id);
+
+    if (this.peerPresenceIntervalId) {
+      win.clearInterval(this.peerPresenceIntervalId);
+    }
+
+    this.peerPresenceIntervalId = win.setInterval(() => {
+      this.addPeer(id);
+    }, 60000);
+
+    if (this.removePeerPresenceOnExit) {
+      win.removeEventListener('pagehide', this.removePeerPresenceOnExit);
+      win.removeEventListener('beforeunload', this.removePeerPresenceOnExit);
+    }
+
+    this.removePeerPresenceOnExit = () => {
+      if (this.peerPresenceIntervalId) {
+        win.clearInterval(this.peerPresenceIntervalId);
+        this.peerPresenceIntervalId = null;
+      }
+      BackendHelper.removePeer(this.blockId, id, { keepalive: true }).catch(() => {});
+    };
+
+    win.addEventListener('pagehide', this.removePeerPresenceOnExit);
+    win.addEventListener('beforeunload', this.removePeerPresenceOnExit);
+  }
+
+  markLocalUserEdit() {
+    this.hasLocalUserEdits = true;
+    if (this.hasMarkedCollaborator || this.isMarkingCollaborator) return;
+
+    this.isMarkingCollaborator = true;
+    BackendHelper.markBlockCollaborator(this.blockId)
+      .then(() => {
+        this.hasMarkedCollaborator = true;
+      })
+      .catch((error) => {
+        console.log('Error occurred during attempt to mark block collaborator.');
+        console.log(error);
+      })
+      .finally(() => {
+        this.isMarkingCollaborator = false;
+      });
+  }
+
   setTargetPeerId(id) {
     this.targetPeerId = id;
   }
@@ -137,7 +192,6 @@ class Controller {
   }
 
   redirectInactive(doc = this.doc, win = this.win) {
-    const currentDate = DateHelper.currentDate();
     let lastTime = new Date().getTime();
 
     function dismissWithKeyPress(event) {
@@ -329,7 +383,7 @@ class Controller {
     })[0].peerId;
   }
 
-  myPeerId(doc = this.doc) {
+  myPeerId() {
     return this.broadcast.peer.id;
   }
 
@@ -404,7 +458,7 @@ class Controller {
     return doc.getElementById(peerId);
   }
 
-  beingCalled(callObj, doc = this.doc) {
+  beingCalled(callObj) {
     const peerFlag = this.getPeerElemById(callObj.peer);
 
     this.addBeingCalledClass(callObj.peer);
@@ -527,7 +581,7 @@ class Controller {
     });
   }
 
-  handleSync(syncObj, doc = this.doc, win = this.win) {
+  handleSync(syncObj, doc = this.doc) {
     if (syncObj.peerId != this.targetPeerId) { this.setTargetPeerId(syncObj.peerId); }
     this.backupHydrationRequestId++;
 

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -169,6 +169,8 @@ class Editor {
         streakPing();
       }
 
+      this.controller.markLocalUserEdit();
+
       switch (changeObj.origin) {
         case 'redo':
         case 'undo':

--- a/server/api/v1/blocks.js
+++ b/server/api/v1/blocks.js
@@ -20,6 +20,7 @@ import { updateUserStreak } from '../../db/userService.js';
 import optionalAuth from '../../middleware/optionalAuth.js';
 import { refreshAuthToken } from '../../utils/jwtHelper.js';
 import { normalizeEditorialInput } from '../../db/editorial.js';
+import { generateAnonymousId } from '../../utils/anonymousId.js';
 
 const roomScopedRouter = Router({ mergeParams: true });
 const globalRouter = Router();
@@ -248,6 +249,38 @@ const useBlockAPI = (app) => {
   });
 
   /** 🌍 Single Block Endpoints (Now inside Global Router) **/
+
+  globalRouter.post('/:block_id/collaborators', optionalAuth, async (req, res) => {
+    const { block_id } = req.params;
+
+    try {
+      const block = await getBlockById(block_id);
+      if (!block) {
+        return res.status(404).json({ error: 'Block not found.' });
+      }
+
+      const collaboratorId = req.user
+        ? req.user.username
+        : (req.cookies.anonymousId || generateAnonymousId());
+
+      if (!req.user && !req.cookies.anonymousId) {
+        res.cookie('anonymousId', collaboratorId, {
+          maxAge: 24 * 60 * 60 * 1000
+        });
+      }
+
+      if (collaboratorId !== block.creator) {
+        await updateBlock(block_id, {
+          $addToSet: { collaborators: collaboratorId }
+        });
+      }
+
+      res.status(200).json({ message: 'Block collaborator updated successfully.' });
+    } catch (error) {
+      console.error('Error updating block collaborator:', error.message);
+      res.status(500).json({ error: 'Failed to update block collaborator.' });
+    }
+  });
 
   // 📌 Update the **content** of a block (Anyone can do this!)
   globalRouter.post('/:block_id/content', async (req, res) => {

--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -1008,7 +1008,7 @@ export const saveVote = async (blockId, userId, action) => {
 // Update a block by ID
 export async function updateBlock(blockId, updates) {
   return await Block.findByIdAndUpdate(blockId, updates, {
-    new: true,
+    returnDocument: 'after',
     runValidators: true,
     context: 'query'
   });

--- a/server/db/flagService.js
+++ b/server/db/flagService.js
@@ -13,5 +13,5 @@ export async function getFlagsByBlock(blockId) {
 
 // (Optional) Update flag status
 export async function updateFlagStatus(flagId, status) {
-  return Flag.findByIdAndUpdate(flagId, { status }, { new: true });
+  return Flag.findByIdAndUpdate(flagId, { status }, { returnDocument: 'after' });
 }

--- a/server/db/sessionService.js
+++ b/server/db/sessionService.js
@@ -1,8 +1,49 @@
 import Session from './models/Session.js';
 import Room from './models/Room.js';
 
+export const PEER_TTL_MS = 5 * 60 * 1000;
+
 let recentlyActiveCache = null;
 let recentlyActiveCacheExpiration = 0;
+
+function isFreshPeer(timestamp, now = new Date()) {
+  return now - new Date(timestamp) <= PEER_TTL_MS;
+}
+
+function splitPeersByFreshness(peers = {}, now = new Date()) {
+  const activePeers = {};
+  const expiredPeerIds = [];
+
+  for (const [peerId, timestamp] of Object.entries(peers || {})) {
+    if (isFreshPeer(timestamp, now)) {
+      activePeers[peerId] = timestamp;
+    } else {
+      expiredPeerIds.push(peerId);
+    }
+  }
+
+  return { activePeers, expiredPeerIds };
+}
+
+async function pruneExpiredPeersForSession(session, now = new Date()) {
+  if (!session) return {};
+
+  const { activePeers, expiredPeerIds } = splitPeersByFreshness(session.peers, now);
+  if (!expiredPeerIds.length) return activePeers;
+
+  if (Object.keys(activePeers).length > 0) {
+    const unsetFields = expiredPeerIds.reduce((fields, peerId) => {
+      fields[`peers.${peerId}`] = '';
+      return fields;
+    }, {});
+
+    await Session.updateOne({ _id: session._id }, { $unset: unsetFields });
+  } else {
+    await Session.deleteOne({ _id: session._id });
+  }
+
+  return activePeers;
+}
 
 /**
  * Return the peer IDs for a given block (or all blocks).
@@ -12,9 +53,11 @@ let recentlyActiveCacheExpiration = 0;
  */
 export async function getPeerIDs(blockId = null, withTime = false) {
   if (blockId) {
-    let session = await Session.findOne({ _id: blockId });
-    if (!session) return {};
-    return withTime ? session.peers : Object.keys(session.peers || {});
+    const session = await Session.findOne({ _id: blockId });
+    if (!session) return withTime ? {} : [];
+
+    const activePeers = await pruneExpiredPeersForSession(session);
+    return withTime ? activePeers : Object.keys(activePeers);
   }
 
   // Fetch all sessions (blocks) if no specific block is requested
@@ -22,7 +65,8 @@ export async function getPeerIDs(blockId = null, withTime = false) {
   const result = {};
 
   for (const session of sessions) {
-    result[session._id] = withTime ? session.peers : Object.keys(session.peers || {});
+    const activePeers = await pruneExpiredPeersForSession(session);
+    result[session._id] = withTime ? activePeers : Object.keys(activePeers);
   }
   return result;
 }
@@ -31,7 +75,6 @@ export async function getPeerIDs(blockId = null, withTime = false) {
  * Removes expired peers and deletes sessions for blocks older than 24 hours.
  */
 export async function cleanUpExpiredSessions() {
-  const maxPeerAge = 24 * 60 * 60 * 1000; // 24 hours
   const now = new Date();
 
   // Grab all session docs
@@ -42,11 +85,7 @@ export async function cleanUpExpiredSessions() {
   for (const session of sessions) {
     const updatedPeers = {};
 
-    for (const [peer, timestamp] of Object.entries(session.peers || {})) {
-      if (now - new Date(timestamp) <= maxPeerAge) {
-        updatedPeers[peer] = timestamp;
-      }
-    }
+    Object.assign(updatedPeers, splitPeersByFreshness(session.peers, now).activePeers);
 
     if (Object.keys(updatedPeers).length > 0) {
       // Session still has active peers, so update it
@@ -129,7 +168,11 @@ export async function getRecentlyActiveRooms(limit = 5) {
         roomActivity[session.roomId] = new Set();
       }
 
-      Object.keys(session.peers).forEach(peer => roomActivity[session.roomId].add(peer));
+      const { activePeers } = splitPeersByFreshness(session.peers);
+      const activePeerIds = Object.keys(activePeers);
+      if (!activePeerIds.length) continue;
+
+      activePeerIds.forEach(peer => roomActivity[session.roomId].add(peer));
     }
 
     // Convert to array and sort by most active users
@@ -168,7 +211,8 @@ export async function getActiveUsers(roomId) {
     
     const uniqueUsers = new Set();
     sessions.forEach(session => {
-      Object.keys(session.peers || {}).forEach(peer => uniqueUsers.add(peer));
+      const { activePeers } = splitPeersByFreshness(session.peers);
+      Object.keys(activePeers).forEach(peer => uniqueUsers.add(peer));
     });
 
     return uniqueUsers.size;

--- a/server/db/userService.js
+++ b/server/db/userService.js
@@ -32,7 +32,7 @@ export async function updateUserProfile(userId, updates) {
       ...updates,
       updatedAt: new Date(),
     },
-    { new: true } // return the updated doc
+    { returnDocument: 'after' }
   );
 
   // If there's no matching user, updatedUser will be null

--- a/server/routes/blocks.js
+++ b/server/routes/blocks.js
@@ -89,15 +89,10 @@ router.get(
         ? user.username
         : (req.cookies.anonymousId || generateAnonymousId());
 
-      if (!block.collaborators.includes(collaboratorId)) {
-        block.collaborators.push(collaboratorId);
-        await block.save();
-
-        if (!user && !req.cookies.anonymousId) {
-          res.cookie('anonymousId', collaboratorId, {
-            maxAge: 24 * 60 * 60 * 1000
-          });
-        }
+      if (!user && !req.cookies.anonymousId) {
+        res.cookie('anonymousId', collaboratorId, {
+          maxAge: 24 * 60 * 60 * 1000
+        });
       }
 
       const peerIDs = await getPeerIDs(block_id);

--- a/spec/controllerSpec.js
+++ b/spec/controllerSpec.js
@@ -594,6 +594,39 @@ describe("Controller", () => {
 
       expect(BackendHelper.syncBlockContent).toHaveBeenCalledWith('block-id', "source markdown");
     });
+
+    it("marks the collaborator separately from content backup after a local edit", async () => {
+      spyOn(controller, "checkBlockStatus").and.returnValue(Promise.resolve(false));
+      spyOn(controller, "firstPeerId").and.returnValue(mockPeer.id);
+      spyOn(controller, "myPeerId").and.returnValue(mockPeer.id);
+      spyOn(controller.editor, "getText").and.returnValue("changed markdown");
+      spyOn(BackendHelper, "syncBlockContent").and.returnValue(Promise.resolve());
+      spyOn(BackendHelper, "markBlockCollaborator").and.returnValue(Promise.resolve());
+
+      controller.markLocalUserEdit();
+      await Promise.resolve();
+      await controller.backupChanges();
+      await Promise.resolve();
+
+      expect(BackendHelper.markBlockCollaborator).toHaveBeenCalledWith('block-id');
+      expect(BackendHelper.syncBlockContent).toHaveBeenCalledWith('block-id', "changed markdown");
+      expect(controller.hasMarkedCollaborator).toBeTrue();
+    });
+
+    it("marks the collaborator even when this peer is not responsible for backups", async () => {
+      spyOn(controller, "checkBlockStatus").and.returnValue(Promise.resolve(false));
+      spyOn(controller, "firstPeerId").and.returnValue('another-peer');
+      spyOn(controller, "myPeerId").and.returnValue(mockPeer.id);
+      spyOn(BackendHelper, "syncBlockContent").and.returnValue(Promise.resolve());
+      spyOn(BackendHelper, "markBlockCollaborator").and.returnValue(Promise.resolve());
+
+      controller.markLocalUserEdit();
+      await Promise.resolve();
+      await controller.backupChanges();
+
+      expect(BackendHelper.markBlockCollaborator).toHaveBeenCalledWith('block-id');
+      expect(BackendHelper.syncBlockContent).not.toHaveBeenCalled();
+    });
   });
 
   describe('syncCompleted', () => {


### PR DESCRIPTION
## Summary

- Treat edit-room occupancy as fresh live peer presence instead of stale session records.
- Add editor presence heartbeats and best-effort peer removal on page exit.
- Stop adding collaborators merely from visiting the edit page.
- Add collaborators only after a real local edit, independent of which peer performs content backups.
- Keep original creators out of the `collaborators` array since creator attribution is already stored separately.
- Replace deprecated Mongoose `new: true` update options with `returnDocument: 'after'`.

## Testing

- Ran `npm test`: 270 specs, 0 failures.
- Ran targeted ESLint on touched files.
- Ran `npm run build`.
- Verified live editing behavior manually with multiple peers.