### PR TITLE
Keep homepage cache warm with stale-while-revalidate refreshes

### DIFF
--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -10,11 +10,13 @@ const TTL = {
   trendingTags: 120 * 1000,        // 2 min
   totalTags: 10 * 60 * 1000,       // 10 min
   featuredRoom: 60 * 1000,         // 60s
+  featuredBlock: 60 * 1000,        // 60s
   topBlocks: 60 * 1000             // 60s
 };
 
 // optional: spread expirations so you don't get synchronized misses
 const JITTER = 10 * 1000; // up to 10s extra
+const HOME_STALE_TTL = 30 * 60 * 1000;
 
 export const PUBLIC_BLOCK_VISIBILITY_MATCH = Object.freeze({
   $or: [
@@ -105,7 +107,7 @@ export async function getGlobalBlockStats() {
       return { totalBlocks, collaborationsToday: collaborationsLast24Hours };
     },
     [],
-    { ttlMs: TTL.globalBlockStats, jitterMs: JITTER }
+    { ttlMs: TTL.globalBlockStats, jitterMs: JITTER, staleTtlMs: HOME_STALE_TTL }
   );
 }
 
@@ -118,7 +120,7 @@ export async function getTotalTags() {
       { $count: 'totalTags' }
     ]);
     return result?.[0]?.totalTags ?? 0;
-  }, [], { ttlMs: TTL.totalTags, jitterMs: JITTER });
+  }, [], { ttlMs: TTL.totalTags, jitterMs: JITTER, staleTtlMs: HOME_STALE_TTL });
 }
 
 export async function getAllTagsWithCounts(timeframe = 'all') {
@@ -215,20 +217,27 @@ export async function getTagTrendData(tagName, defaultDays = 30, opts = {}) {
 export async function getFeaturedBlockWithFallback(options = {}) {
   const { preferredLang = 'en' } = options;
 
-  // “Featured” becomes: random block from last year (prefer lang if possible)
-  const { block, period } = await getRandomBlockFromLastYear({ preferredLang });
+  return await cache.get(
+    `featured-block-with-fallback-${preferredLang}`,
+    async () => {
+      // “Featured” becomes: random block from last year (prefer lang if possible)
+      const { block, period } = await getRandomBlockFromLastYear({ preferredLang });
 
-  // If absolutely nothing exists (very early dev), fall back to old logic
-  if (!block) {
-    const { blocks, period: p2 } = await getTopBlocksWithFallback({
-      lockedOnly: false,
-      limit: 1,
-      preferredLang,
-    });
-    return { featuredBlock: blocks[0] || null, period: p2 };
-  }
+      // If absolutely nothing exists (very early dev), fall back to old logic
+      if (!block) {
+        const { blocks, period: p2 } = await getTopBlocksWithFallback({
+          lockedOnly: false,
+          limit: 1,
+          preferredLang,
+        });
+        return { featuredBlock: blocks[0] || null, period: p2 };
+      }
 
-  return { featuredBlock: block, period };
+      return { featuredBlock: block, period };
+    },
+    [],
+    { ttlMs: TTL.featuredBlock, jitterMs: JITTER, staleTtlMs: HOME_STALE_TTL }
+  );
 }
 
 export async function getRandomBlockFromLastYear(options = {}) {
@@ -414,7 +423,7 @@ export async function getTopBlocksWithFallback(options = {}) {
         });
       },
       [],
-      { ttlMs: TTL.topBlocks, jitterMs: JITTER }
+      { ttlMs: TTL.topBlocks, jitterMs: JITTER, staleTtlMs: HOME_STALE_TTL }
     );
 
     if (Array.isArray(bandBlocks) && bandBlocks.length > 0) {
@@ -552,7 +561,7 @@ export async function getTrendingTagsWithFallback(options = {}) {
       cacheKey,
       async () => Block.aggregate(makePipeline(startDate, endDate, BAND_FETCH)).exec(),
       [],
-      { ttlMs: TTL.trendingTags, jitterMs: JITTER }
+      { ttlMs: TTL.trendingTags, jitterMs: JITTER, staleTtlMs: HOME_STALE_TTL }
     );
 
     if (Array.isArray(bandTags) && bandTags.length > 0) {

--- a/server/db/homeActivityService.js
+++ b/server/db/homeActivityService.js
@@ -7,6 +7,7 @@ import User from './models/User.js';
 import { publiclyVisibleBlockMatch } from './blockService.js';
 import { toRoomI18nDTO } from './roomService.js';
 import { canonicalCommentPath } from '../utils/canonical.js';
+import * as cache from '../services/cache.js';
 
 const REACTION_EMOJI_BY_TYPE = {
   heart: '❤️',
@@ -14,6 +15,9 @@ const REACTION_EMOJI_BY_TYPE = {
   wow: '😮',
   laugh: '😂'
 };
+
+const ACTIVITY_TTL = 30 * 1000;
+const ACTIVITY_STALE_TTL = 10 * 60 * 1000;
 
 function clampLimit(limit, fallback = 5, max = 8) {
   return Math.max(1, Math.min(Number(limit) || fallback, max));
@@ -114,6 +118,15 @@ function serializeRoom(roomMap, roomId) {
 
 export async function getRecentCommentActivity({ limit = 5, lang = 'en' } = {}) {
   const safeLimit = clampLimit(limit);
+  return await cache.get(
+    `recent-comment-activity-${safeLimit}-${lang}`,
+    () => getRecentCommentActivityFresh({ safeLimit, lang }),
+    [],
+    { ttlMs: ACTIVITY_TTL, staleTtlMs: ACTIVITY_STALE_TTL }
+  );
+}
+
+async function getRecentCommentActivityFresh({ safeLimit, lang }) {
   const rawComments = await BlockComment.find({
     status: 'visible',
     deletedAt: null
@@ -171,6 +184,15 @@ export async function getRecentCommentActivity({ limit = 5, lang = 'en' } = {}) 
 
 export async function getRecentReactionActivity({ limit = 5, lang = 'en' } = {}) {
   const safeLimit = clampLimit(limit);
+  return await cache.get(
+    `recent-reaction-activity-${safeLimit}-${lang}`,
+    () => getRecentReactionActivityFresh({ safeLimit, lang }),
+    [],
+    { ttlMs: ACTIVITY_TTL, staleTtlMs: ACTIVITY_STALE_TTL }
+  );
+}
+
+async function getRecentReactionActivityFresh({ safeLimit, lang }) {
   const rawReactions = await BlockReaction.find({})
     .sort({ createdAt: -1, _id: -1 })
     .limit(safeLimit * 8)

--- a/server/db/roomService.js
+++ b/server/db/roomService.js
@@ -1,6 +1,9 @@
 import Room from './models/Room.js';
+import * as cache from '../services/cache.js';
 
 let cachedTopicsByLang = new Map();
+
+const ROOM_STALE_TTL = 30 * 60 * 1000;
 
 function resolveRoomField(room, field, lang) {
   const map = room?.[`${field}_i18n`];
@@ -37,10 +40,17 @@ export function toRoomI18nDTO(room, lang) {
  */
 export async function getRoomMetadata(roomId, lang = null) {
   try {
-    const doc = await Room.findOne({ _id: roomId });
-    const obj = doc?.toObject();
-    if (!obj) return null;
-    return lang ? toRoomI18nDTO(obj, lang) : obj;
+    return await cache.get(
+      `room-metadata-${roomId}-${lang || 'raw'}`,
+      async () => {
+        const doc = await Room.findOne({ _id: roomId });
+        const obj = doc?.toObject();
+        if (!obj) return null;
+        return lang ? toRoomI18nDTO(obj, lang) : obj;
+      },
+      [],
+      { ttlMs: 10 * 60 * 1000, staleTtlMs: ROOM_STALE_TTL }
+    );
   } catch (error) {
     console.error(`Error fetching room metadata for ID: ${roomId}`, error.message);
     throw error;
@@ -61,7 +71,12 @@ export async function getAllRooms(lang = null) {
 }
 
 export async function getTotalRooms() {
-  return await Room.countDocuments({});
+  return await cache.get(
+    'total-rooms',
+    () => Room.countDocuments({}),
+    [],
+    { ttlMs: 10 * 60 * 1000, staleTtlMs: ROOM_STALE_TTL }
+  );
 }
 
 /**

--- a/server/services/cache.js
+++ b/server/services/cache.js
@@ -1,40 +1,65 @@
 import cache from 'memory-cache';
 
 const DEFAULT_TTL_MS = 2 * 1000;
+const ENTRY_VERSION = 1;
 
 // Prevent stampedes: if multiple requests ask for same key while it's missing,
 // only run refresh() once and share the same Promise.
 const inFlight = new Map();
+
+function isManagedEntry(entry) {
+  return entry && entry.__dailyPageCacheEntry === ENTRY_VERSION;
+}
+
+function readOptions(timeOrOpts) {
+  if (typeof timeOrOpts === 'number') {
+    return { ttlMs: timeOrOpts, jitterMs: 0, staleTtlMs: 0 };
+  }
+
+  return {
+    ttlMs: timeOrOpts?.ttlMs ?? DEFAULT_TTL_MS,
+    jitterMs: timeOrOpts?.jitterMs ?? 0,
+    staleTtlMs: timeOrOpts?.staleTtlMs ?? 0,
+  };
+}
+
+function calculateTtl(ttlMs, jitterMs) {
+  return ttlMs + (jitterMs ? Math.floor(Math.random() * jitterMs) : 0);
+}
 
 /**
  * cache.get(key, refresh, args?, timeOrOpts?)
  *
  * Backward compatible:
  * - If timeOrOpts is a number -> treated as ttlMs (like before)
- * - If timeOrOpts is an object -> { ttlMs, jitterMs }
+ * - If timeOrOpts is an object -> { ttlMs, jitterMs, staleTtlMs }
+ *
+ * staleTtlMs enables stale-while-revalidate. Fresh values return immediately.
+ * Expired-but-stale values also return immediately while one background
+ * refresh updates the cache for the next request.
  */
 export async function get(key, refresh, args = [], timeOrOpts = DEFAULT_TTL_MS) {
-  const ttlMs =
-    typeof timeOrOpts === 'number'
-      ? timeOrOpts
-      : (timeOrOpts?.ttlMs ?? DEFAULT_TTL_MS);
-
-  const jitterMs =
-    typeof timeOrOpts === 'object'
-      ? (timeOrOpts?.jitterMs ?? 0)
-      : 0;
-
-  const finalTtlMs =
-    ttlMs + (jitterMs ? Math.floor(Math.random() * jitterMs) : 0);
+  const { ttlMs, jitterMs, staleTtlMs } = readOptions(timeOrOpts);
+  const finalTtlMs = calculateTtl(ttlMs, jitterMs);
 
   const existing = cache.get(key);
-  if (existing !== null) return existing;
+  if (existing !== null) {
+    if (!isManagedEntry(existing)) return existing;
+
+    if (Date.now() < existing.expiresAt) return existing.value;
+
+    if (!inFlight.has(key)) {
+      refreshInBackground(key, refresh, args, finalTtlMs, staleTtlMs);
+    }
+
+    return existing.value;
+  }
 
   if (inFlight.has(key)) return inFlight.get(key);
 
   const p = (async () => {
     const value = await refresh(...args);
-    cache.put(key, value, finalTtlMs);
+    putValue(key, value, finalTtlMs, staleTtlMs);
     return value;
   })().finally(() => {
     inFlight.delete(key);
@@ -42,6 +67,39 @@ export async function get(key, refresh, args = [], timeOrOpts = DEFAULT_TTL_MS) 
 
   inFlight.set(key, p);
   return p;
+}
+
+function putValue(key, value, ttlMs, staleTtlMs) {
+  if (!staleTtlMs) {
+    cache.put(key, value, ttlMs);
+    return;
+  }
+
+  cache.put(
+    key,
+    {
+      __dailyPageCacheEntry: ENTRY_VERSION,
+      value,
+      expiresAt: Date.now() + ttlMs,
+    },
+    ttlMs + staleTtlMs
+  );
+}
+
+function refreshInBackground(key, refresh, args, ttlMs, staleTtlMs) {
+  const p = (async () => {
+    const value = await refresh(...args);
+    putValue(key, value, ttlMs, staleTtlMs);
+    return value;
+  })()
+    .catch((error) => {
+      console.error(`Background cache refresh failed for ${key}:`, error);
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, p);
 }
 
 // Optional helpers (handy later)
@@ -52,4 +110,3 @@ export function del(key) {
 export function clear() {
   cache.clear();
 }
-

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -10,20 +10,28 @@ import {
   getGlobalBlockStats,
   getTotalTags,
   getFeaturedRoomWithFallback,
+  getFeaturedBlockWithFallback,
 } from '../db/blockService.js';
 import { getTotalRooms } from '../db/roomService.js';
+import {
+  getRecentCommentActivity,
+  getRecentReactionActivity
+} from '../db/homeActivityService.js';
 
 const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
   await Promise.allSettled([
+    getFeaturedBlockWithFallback({ preferredLang }),
     getTrendingTagsWithFallback({ limit: 10, sortBy: 'totalBlocks' }),
     getFeaturedRoomWithFallback(),
     getGlobalBlockStats(),
     getTotalTags(),
     getTotalRooms(),
     getTopBlocksWithFallback({ lockedOnly: false, limit: 20, preferredLang }),
+    getRecentCommentActivity({ limit: 5, lang: preferredLang }),
+    getRecentReactionActivity({ limit: 5, lang: preferredLang }),
   ]);
 }
 

--- a/spec/cacheSpec.js
+++ b/spec/cacheSpec.js
@@ -1,0 +1,49 @@
+import * as cache from '../server/services/cache.js';
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('cache service', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('serves stale values while refreshing expired entries in the background', async () => {
+    let calls = 0;
+    const refresh = async () => {
+      calls += 1;
+      await delay(20);
+      return calls;
+    };
+
+    expect(await cache.get('swr-key', refresh, [], { ttlMs: 5, staleTtlMs: 200 })).toBe(1);
+
+    await delay(10);
+
+    expect(await cache.get('swr-key', refresh, [], { ttlMs: 5, staleTtlMs: 200 })).toBe(1);
+    expect(calls).toBe(2);
+
+    await delay(30);
+
+    expect(await cache.get('swr-key', refresh, [], { ttlMs: 50, staleTtlMs: 200 })).toBe(2);
+  });
+
+  it('shares one refresh promise on cold misses', async () => {
+    let calls = 0;
+    const refresh = async () => {
+      calls += 1;
+      await delay(5);
+      return 'value';
+    };
+
+    const [first, second] = await Promise.all([
+      cache.get('cold-key', refresh, [], { ttlMs: 50, staleTtlMs: 200 }),
+      cache.get('cold-key', refresh, [], { ttlMs: 50, staleTtlMs: 200 })
+    ]);
+
+    expect(first).toBe('value');
+    expect(second).toBe('value');
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

This adds stale-while-revalidate behavior to the shared cache helper and applies it to the data that powers the homepage.

Instead of blocking a homepage request whenever a cached value expires, stale-enabled entries can now return the last known value immediately while a single background refresh updates the cache for future requests.

## Changes

- Add `staleTtlMs` support to `server/services/cache.js`
- Cache homepage featured block lookups
- Allow homepage block stats, top blocks, trending tags, and tag counts to serve stale values while refreshing
- Add stale cache behavior for recent comment/reaction activity
- Add stale cache behavior for room metadata and room counts
- Expand the cron homepage warmer to include:
  - featured blocks
  - recent comments
  - recent reactions
- Add focused specs for stale-while-revalidate cache behavior

## Verification

- `npx eslint server/services/cache.js server/db/blockService.js server/db/roomService.js server/db/homeActivityService.js server/services/cron.js spec/cacheSpec.js`
- `npx jasmine spec/cacheSpec.js`

Note: the full `npm run lint` still reports existing unrelated lint issues outside this change.