### PR TITLE
Fix tag entry flow on post tag inputs

### DIFF
--- a/public/js/create-block-tags.js
+++ b/public/js/create-block-tags.js
@@ -33,6 +33,42 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  function focusNewTagInput() {
+    document.getElementById('new-tag')?.focus();
+  }
+
+  function addTag() {
+    const newTagInput = document.getElementById('new-tag');
+    const newTag = newTagInput?.value.trim();
+    if (!newTag) {
+      focusNewTagInput();
+      return;
+    }
+
+    const newPill = document.createElement('span');
+    newPill.classList.add('tag-pill');
+    newPill.textContent = newTag;
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.classList.add('tag-remove');
+    removeBtn.setAttribute('data-tag', newTag);
+    // Leading space preserved as before
+    removeBtn.textContent = ' ' + t('blockTags.buttons.removeTag');
+    newPill.appendChild(removeBtn);
+
+    const tagAdd = document.querySelector('.tag-add');
+    if (tagAdd) {
+      tagContainer.insertBefore(newPill, tagAdd);
+    } else {
+      tagContainer.appendChild(newPill);
+    }
+
+    newTagInput.value = '';
+    updateHiddenTags();
+    focusNewTagInput();
+  }
+
   tagContainer.addEventListener('click', (e) => {
     if (e.target && e.target.classList.contains('tag-remove')) {
       e.preventDefault();
@@ -46,32 +82,15 @@ document.addEventListener('DOMContentLoaded', () => {
   if (addTagBtn) {
     addTagBtn.addEventListener('click', (e) => {
       e.preventDefault();
-      const newTagInput = document.getElementById('new-tag');
-      const newTag = newTagInput.value.trim();
-      if (!newTag) return;
-
-      const newPill = document.createElement('span');
-      newPill.classList.add('tag-pill');
-      newPill.textContent = newTag;
-
-      const removeBtn = document.createElement('button');
-      removeBtn.classList.add('tag-remove');
-      removeBtn.setAttribute('data-tag', newTag);
-      // Leading space preserved as before
-      removeBtn.textContent = ' ' + t('blockTags.buttons.removeTag');
-      newPill.appendChild(removeBtn);
-
-      const tagAdd = document.querySelector('.tag-add');
-      if (tagAdd) {
-        tagContainer.insertBefore(newPill, tagAdd);
-      } else {
-        tagContainer.appendChild(newPill);
-      }
-
-      newTagInput.value = '';
-      updateHiddenTags();
+      addTag();
     });
   }
+
+  document.getElementById('new-tag')?.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    addTag();
+  });
 
   // inits
   updateTagHeader();

--- a/public/js/edit-tags.js
+++ b/public/js/edit-tags.js
@@ -34,6 +34,46 @@ document.addEventListener('DOMContentLoaded', () => {
         : safeLabel('blockTags.header.noTags', 'No tags');
   }
 
+  function focusNewTagInput() {
+    document.getElementById('new-tag')?.focus();
+  }
+
+  function addTag() {
+    const newTagInput = document.getElementById('new-tag');
+    const newTag = newTagInput?.value.trim();
+    if (!newTag) {
+      focusNewTagInput();
+      return;
+    }
+
+    const newPill = document.createElement('span');
+    newPill.classList.add('tag-pill');
+    newPill.textContent = newTag;
+
+    // Only add remove button when manager UI exists
+    if (canManageTags) {
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.classList.add('tag-remove');
+      removeBtn.setAttribute('data-tag', newTag);
+
+      // preserve leading space behavior
+      const rm = safeLabel('blockTags.buttons.removeTag', 'x');
+      removeBtn.textContent = ' ' + rm;
+
+      newPill.appendChild(removeBtn);
+    }
+
+    const tagAdd = document.querySelector('.tag-add');
+    if (tagAdd) tagContainer.insertBefore(newPill, tagAdd);
+    else tagContainer.appendChild(newPill);
+
+    newTagInput.value = '';
+    updateTagHeader();
+    updateTagsOnBackend();
+    focusNewTagInput();
+  }
+
   tagContainer.addEventListener('click', (e) => {
     if (e.target && e.target.classList.contains('tag-remove')) {
       const pill = e.target.parentElement;
@@ -44,37 +84,17 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   if (addTagBtn) {
-    addTagBtn.addEventListener('click', () => {
-      const newTagInput = document.getElementById('new-tag');
-      const newTag = newTagInput?.value.trim();
-      if (!newTag) return;
-
-      const newPill = document.createElement('span');
-      newPill.classList.add('tag-pill');
-      newPill.textContent = newTag;
-
-      // Only add remove button when manager UI exists
-      if (canManageTags) {
-        const removeBtn = document.createElement('button');
-        removeBtn.classList.add('tag-remove');
-        removeBtn.setAttribute('data-tag', newTag);
-
-        // preserve leading space behavior
-        const rm = safeLabel('blockTags.buttons.removeTag', 'x');
-        removeBtn.textContent = ' ' + rm;
-
-        newPill.appendChild(removeBtn);
-      }
-
-      const tagAdd = document.querySelector('.tag-add');
-      if (tagAdd) tagContainer.insertBefore(newPill, tagAdd);
-      else tagContainer.appendChild(newPill);
-
-      newTagInput.value = '';
-      updateTagHeader();
-      updateTagsOnBackend();
+    addTagBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      addTag();
     });
   }
+
+  document.getElementById('new-tag')?.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    addTag();
+  });
 
   function updateTagsOnBackend() {
     if (typeof block_id === 'undefined') {

--- a/views/partials/_tag_section.pug
+++ b/views/partials/_tag_section.pug
@@ -6,17 +6,17 @@ mixin tagSection(tags, canManageBlock)
         span.tag-pill
           a(href=uiPath(`/tags/${encodeURIComponent(tag)}`)) #{tag}
           if canManageBlock
-            button.tag-remove(data-tag=tag) x
+            button.tag-remove(type='button' data-tag=tag) x
       if canManageBlock
         span.tag-add
           input#new-tag(type='text' placeholder=t('blockTags.input.placeholder'))
-          button#add-tag-btn= t('blockTags.input.addButton')
+          button#add-tag-btn(type='button')= t('blockTags.input.addButton')
   else
     if canManageBlock
       p.block-tags-header= t('blockTags.header.noTags')
       div#tag-container
         span.tag-add
           input#new-tag(type='text' placeholder=t('blockTags.input.placeholder'))
-          button#add-tag-btn= t('blockTags.input.addButton')
+          button#add-tag-btn(type='button')= t('blockTags.input.addButton')
     else
       p.block-tags-header


### PR DESCRIPTION
## Summary

Fixes the tag input flow so users can confirm a tag with Enter and continue adding tags smoothly.

## Changes

- Adds Enter-key handling for tag inputs on create-post and edit-post flows.
- Keeps focus on the tag input after adding a tag via Enter or the Add button.
- Marks tag add/remove buttons as `type="button"` so they do not accidentally submit the create-post form.
- Applies the behavior consistently through the shared tag partial and both tag scripts.

## Testing

- Manually verified tag adding on the create-post page.
- Ran `node --check` for:
  - `public/js/create-block-tags.js`
  - `public/js/edit-tags.js`
- Ran jsdom smoke checks for Enter and button-based tag creation/focus behavior.
- `npm run lint` still fails due to pre-existing unrelated lint issues outside this change.