### PR TITLE
Allow locked post edits by logged-in creators

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -308,7 +308,11 @@ class Controller {
       const data = await res.json();
       const block = data.block || data;
 
-      if (block.status === 'locked') {
+      const canManageLockedBlock =
+        typeof this.win !== 'undefined' &&
+        Boolean(this.win.canManageBlock);
+
+      if (block.status === 'locked' && !canManageLockedBlock) {
         this.isLocked = true;
         this.disableEditor();
 

--- a/server/api/v1/blocks.js
+++ b/server/api/v1/blocks.js
@@ -21,6 +21,11 @@ import optionalAuth from '../../middleware/optionalAuth.js';
 import { refreshAuthToken } from '../../utils/jwtHelper.js';
 import { normalizeEditorialInput } from '../../db/editorial.js';
 import { generateAnonymousId } from '../../utils/anonymousId.js';
+import {
+  canEditBlockContent,
+  canManageBlock,
+  parseEditTokens
+} from '../../utils/block.js';
 
 const roomScopedRouter = Router({ mergeParams: true });
 const globalRouter = Router();
@@ -107,9 +112,7 @@ const useBlockAPI = (app) => {
     }
 
 
-    const existingTokens = req.cookies.edit_tokens
-      ? JSON.parse(req.cookies.edit_tokens)
-      : [];
+    const existingTokens = parseEditTokens(req.cookies.edit_tokens);
 
     let normalizedEditorial;
     try {
@@ -282,8 +285,8 @@ const useBlockAPI = (app) => {
     }
   });
 
-  // 📌 Update the **content** of a block (Anyone can do this!)
-  globalRouter.post('/:block_id/content', async (req, res) => {
+  // 📌 Update the **content** of a block
+  globalRouter.post('/:block_id/content', optionalAuth, async (req, res) => {
     const { block_id } = req.params;
     const { content } = req.body;
 
@@ -291,6 +294,10 @@ const useBlockAPI = (app) => {
       const block = await getBlockById(block_id);
       if (!block) {
         return res.status(404).json({ error: 'Block not found.' });
+      }
+
+      if (!canEditBlockContent(req.user, block)) {
+        return res.status(403).json({ error: 'You are not authorized to update this block.' });
       }
 
       await updateBlock(block_id, { content });
@@ -313,11 +320,9 @@ const useBlockAPI = (app) => {
       }
 
       // Check ownership before allowing edits
-      const editTokens = req.cookies.edit_tokens ? JSON.parse(req.cookies.edit_tokens) : [];
-      const isCreator = block.creator === req.user?.username;
-      const hasEditToken = editTokens.includes(block.editToken);
+      const editTokens = parseEditTokens(req.cookies.edit_tokens);
 
-      if (!isCreator && !hasEditToken) {
+      if (!canManageBlock(req.user, block, editTokens)) {
         return res.status(403).json({ error: 'You are not authorized to update this block.' });
       }
 
@@ -373,11 +378,9 @@ const useBlockAPI = (app) => {
         return res.status(404).json({ error: 'Block not found.' });
       }
 
-      const editTokens = req.cookies.edit_tokens ? JSON.parse(req.cookies.edit_tokens) : [];
-      const isCreator = block.creator === req.user?.username;
-      const hasEditToken = editTokens.includes(block.editToken);
+      const editTokens = parseEditTokens(req.cookies.edit_tokens);
 
-      if (!isCreator && !hasEditToken) {
+      if (!canManageBlock(req.user, block, editTokens)) {
         return res.status(403).json({ error: 'You are not authorized to delete this block.' });
       }
 

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -16,7 +16,7 @@ import { renderMarkdownContent } from '../utils/markdownHelper.js';
 import optionalAuth from '../middleware/optionalAuth.js';
 import { resolveBlockLangParam } from '../middleware/resolveBlockLangParam.js';
 import { addI18n } from '../services/i18n.js';
-import { canManageBlock } from '../utils/block.js';
+import { canManageBlock, parseEditTokens } from '../utils/block.js';
 import { canonicalBlockPath } from '../utils/canonical.js';
 
 const router = express.Router();
@@ -60,7 +60,7 @@ router.get(
       const deepLinkCommentId = normalizeCommentId(req.query.commentId);
 
       const block = await getBlockById(block_id);
-      const editTokens = req.cookies.edit_tokens ? JSON.parse(req.cookies.edit_tokens) : [];
+      const editTokens = parseEditTokens(req.cookies.edit_tokens);
 
       if (!block || block.roomId !== room_id) {
         return res.status(404).render('error', {

--- a/server/routes/blocks.js
+++ b/server/routes/blocks.js
@@ -10,7 +10,7 @@ import { getPeerIDs } from '../db/sessionService.js';
 import { addI18n } from '../services/i18n.js';
 import { getUiLang } from '../services/localeContext.js';
 import { generateAnonymousId } from '../utils/anonymousId.js';
-import { canManageBlock } from '../utils/block.js';
+import { canManageBlock, parseEditTokens } from '../utils/block.js';
 import { canonicalBlockEditPath } from '../utils/canonical.js';
 import { renderMarkdownContent } from '../utils/markdownHelper.js';
 
@@ -68,9 +68,7 @@ router.get(
     const { t } = res.locals;
     const user = req.user;
 
-    const editTokens = req.cookies.edit_tokens
-      ? JSON.parse(req.cookies.edit_tokens)
-      : [];
+    const editTokens = parseEditTokens(req.cookies.edit_tokens);
 
     try {
       const block = await getBlockById(block_id);
@@ -96,6 +94,11 @@ router.get(
       }
 
       const peerIDs = await getPeerIDs(block_id);
+      const canManage = canManageBlock(user, block, editTokens);
+
+      if (block.status === 'locked' && !canManage) {
+        return res.redirect(`/rooms/${room_id}/blocks/${block_id}`);
+      }
 
       if (peerIDs.length >= 6) {
         return res.render('fullBlock', {
@@ -134,7 +137,7 @@ router.get(
         turnCredential: config.turnCredential,
         peerIDs,
         initialTargetPeerId,
-        canManageBlock: canManageBlock(user, block, editTokens),
+        canManageBlock: canManage,
         backendURL: backendBaseUrl,
 
         // Make the split explicit:

--- a/server/utils/block.js
+++ b/server/utils/block.js
@@ -1,10 +1,46 @@
 import { renderMarkdownPreview } from "./markdownHelper.js"
 import { titleOnlyMeta } from './unfinished.js';
 
+function idsMatch(left, right) {
+  return Boolean(left && right && String(left) === String(right));
+}
+
+export function parseEditTokens(rawTokens) {
+  if (!rawTokens) return [];
+
+  try {
+    const tokens = JSON.parse(rawTokens);
+    return Array.isArray(tokens) ? tokens : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isLoggedInBlockCreator(user, block) {
+  if (!user || !block) return false;
+  if (idsMatch(user.id, block.userId)) return true;
+
+  return !block.userId &&
+    block.creator &&
+    block.creator !== 'anonymous' &&
+    user.username === block.creator;
+}
+
 export function canManageBlock(user, block, editTokens) {
-  const isCreator = user && user.username === block.creator;
-  const hasEditToken = editTokens.includes(block.editToken);
+  const isCreator = isLoggedInBlockCreator(user, block);
+  const hasEditToken = Array.isArray(editTokens) && editTokens.includes(block.editToken);
+
+  if (block?.status === 'locked') {
+    return isCreator;
+  }
+
   return isCreator || hasEditToken;
+}
+
+export function canEditBlockContent(user, block) {
+  if (!block) return false;
+  if (block.status === 'locked') return isLoggedInBlockCreator(user, block);
+  return true;
 }
 
 export function toBlockPreviewDTO(block, {

--- a/spec/blockPermissionsSpec.js
+++ b/spec/blockPermissionsSpec.js
@@ -1,0 +1,53 @@
+import {
+  canEditBlockContent,
+  canManageBlock,
+  isLoggedInBlockCreator,
+  parseEditTokens
+} from '../server/utils/block.js';
+
+describe('block editing permissions', () => {
+  const user = { id: 'user-1', username: 'alice' };
+
+  it('allows the logged-in creator to manage a locked block by persistent user id', () => {
+    const block = {
+      userId: 'user-1',
+      creator: 'alice',
+      editToken: 'token-1',
+      status: 'locked'
+    };
+
+    expect(isLoggedInBlockCreator(user, block)).toBeTrue();
+    expect(canManageBlock(user, block, [])).toBeTrue();
+    expect(canEditBlockContent(user, block)).toBeTrue();
+  });
+
+  it('does not let an edit token manage a locked block', () => {
+    const block = {
+      userId: null,
+      creator: 'anonymous',
+      editToken: 'token-1',
+      status: 'locked'
+    };
+
+    expect(canManageBlock(null, block, ['token-1'])).toBeFalse();
+    expect(canEditBlockContent(null, block)).toBeFalse();
+  });
+
+  it('keeps in-progress block content open for live collaboration', () => {
+    const block = {
+      userId: 'user-1',
+      creator: 'alice',
+      editToken: 'token-1',
+      status: 'in-progress'
+    };
+
+    expect(canEditBlockContent(null, block)).toBeTrue();
+    expect(canManageBlock(null, block, ['token-1'])).toBeTrue();
+  });
+
+  it('ignores malformed edit token cookies', () => {
+    expect(parseEditTokens('not-json')).toEqual([]);
+    expect(parseEditTokens('{"token": "token-1"}')).toEqual([]);
+    expect(parseEditTokens('["token-1"]')).toEqual(['token-1']);
+  });
+});


### PR DESCRIPTION
## Summary

- Allow logged-in post creators to keep editing their own posts after the post is locked
- Stop edit-token/cookie access from granting management permissions once a post is locked
- Prevent non-owners from opening locked posts in the editor
- Keep in-progress posts open to the existing live collaboration model
- Add focused permission coverage for locked vs in-progress edit behavior

## Testing

- `npm test`
- `npx eslint server/utils/block.js server/routes/blocks.js server/routes/blockView.js server/api/v1/blocks.js lib/controller.js spec/blockPermissionsSpec.js`
- `npm run build`

## Notes

Full `npm run lint` is currently blocked by unrelated pre-existing lint errors outside this change.