### PR TITLE
Restore recently active rooms using post activity

### DIFF
--- a/public/css/rooms.css
+++ b/public/css/rooms.css
@@ -386,13 +386,13 @@ html[data-theme="dark"] {
 }
 
 .room-activity.is-visible,
-.room-tile.recently-active .room-activity {
+.room-tile.recently-active .room-activity:not(:empty) {
   display: inline-flex;
   opacity: 1;
   visibility: visible;
 }
 
-.room-tile.recently-active .room-activity,
+.room-tile.recently-active .room-activity:not(:empty),
 .room-activity.is-visible {
   background: rgba(202, 107, 44, 0.14);
   color: var(--rooms-accent-deep);
@@ -598,7 +598,7 @@ html[data-theme="dark"] .room-activity {
   background: rgba(159, 184, 255, 0.08);
 }
 
-html[data-theme="dark"] .room-tile.recently-active .room-activity,
+html[data-theme="dark"] .room-tile.recently-active .room-activity:not(:empty),
 html[data-theme="dark"] .room-activity.is-visible {
   background: var(--rooms-accent-soft);
   color: var(--rooms-accent-text);

--- a/server/db/schemas/BlockSchema.js
+++ b/server/db/schemas/BlockSchema.js
@@ -112,6 +112,7 @@ blockSchema.index({ groupId: 1, lang: 1 }, { unique: true });
 
 blockSchema.index({ creator: 1, createdAt: -1 });
 blockSchema.index({ collaborators: 1, createdAt: -1 });
+blockSchema.index({ updatedAt: -1, roomId: 1 });
 
 // Text search index for MVP search
 // Notes:

--- a/server/db/sessionService.js
+++ b/server/db/sessionService.js
@@ -1,7 +1,10 @@
 import Session from './models/Session.js';
 import Room from './models/Room.js';
+import Block from './models/Block.js';
+import { publiclyVisibleBlockMatch } from './blockService.js';
 
 export const PEER_TTL_MS = 5 * 60 * 1000;
+export const RECENT_ROOM_ACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;
 
 let recentlyActiveCache = null;
 let recentlyActiveCacheExpiration = 0;
@@ -145,53 +148,96 @@ export async function removePeer(peerId, blockId) {
   );
 }
 
+export function rankRoomActivity(recentBlockActivity = [], sessions = [], now = new Date()) {
+  const roomActivity = new Map();
+
+  for (const activity of recentBlockActivity) {
+    if (!activity?._id) continue;
+
+    roomActivity.set(String(activity._id), {
+      activePeers: new Set(),
+      recentPosts: activity.recentPosts || 0,
+      lastActivityAt: activity.lastActivityAt || null
+    });
+  }
+
+  for (const session of sessions) {
+    if (!session.roomId) continue;
+
+    const roomId = String(session.roomId);
+    const activity = roomActivity.get(roomId) || {
+      activePeers: new Set(),
+      recentPosts: 0,
+      lastActivityAt: null
+    };
+    const { activePeers } = splitPeersByFreshness(session.peers, now);
+
+    for (const [peerId, timestamp] of Object.entries(activePeers)) {
+      activity.activePeers.add(peerId);
+      if (!activity.lastActivityAt || new Date(timestamp) > new Date(activity.lastActivityAt)) {
+        activity.lastActivityAt = timestamp;
+      }
+    }
+
+    if (activity.activePeers.size || activity.recentPosts) {
+      roomActivity.set(roomId, activity);
+    }
+  }
+
+  return [...roomActivity.entries()]
+    .map(([roomId, activity]) => ({
+      roomId,
+      activeUsers: activity.activePeers.size,
+      recentPosts: activity.recentPosts,
+      lastActivityAt: activity.lastActivityAt
+    }))
+    .sort((a, b) => (
+      b.activeUsers - a.activeUsers ||
+      new Date(b.lastActivityAt || 0) - new Date(a.lastActivityAt || 0) ||
+      b.recentPosts - a.recentPosts
+    ));
+}
+
 /**
- * Gets X number of "recently active" rooms, meaning rooms with the most peers across their blocks.
+ * Gets recently active rooms using fresh editor sessions and recent public post updates.
  */
 export async function getRecentlyActiveRooms(limit = 5) {
   const now = Date.now();
-  
-  if (recentlyActiveCache && now < recentlyActiveCacheExpiration) {
-    return recentlyActiveCache;
+
+  if (
+    recentlyActiveCache?.limit === limit &&
+    now < recentlyActiveCacheExpiration
+  ) {
+    return recentlyActiveCache.rooms;
   }
 
   try {
-    // Get all active block sessions (blocks with peers)
-    const sessions = await Session.find({ peers: { $exists: true, $ne: {} } }).lean();
-
-    // Group by room
-    const roomActivity = {};
-    for (const session of sessions) {
-      if (!session.roomId) continue; // Skip if no room ID is recorded
-      
-      if (!roomActivity[session.roomId]) {
-        roomActivity[session.roomId] = new Set();
-      }
-
-      const { activePeers } = splitPeersByFreshness(session.peers);
-      const activePeerIds = Object.keys(activePeers);
-      if (!activePeerIds.length) continue;
-
-      activePeerIds.forEach(peer => roomActivity[session.roomId].add(peer));
-    }
-
-    // Convert to array and sort by most active users
-    const sortedRooms = Object.entries(roomActivity)
-      .map(([roomId, peers]) => ({ roomId, activeUsers: peers.size }))
-      .sort((a, b) => b.activeUsers - a.activeUsers)
-      .slice(0, limit);
-
-    // Fetch room info for the top rooms
-    const promises = sortedRooms.map(async ({ roomId, activeUsers }) => {
-      const room = await Room.findOne({ _id: roomId }).lean();
-      return room ? { ...room, activeUsers } : null;
-    });
-
-    const results = await Promise.all(promises);
-    const final = results.filter(Boolean);
+    const cutoff = new Date(now - RECENT_ROOM_ACTIVITY_MS);
+    const [recentBlockActivity, sessions] = await Promise.all([
+      Block.aggregate([
+        { $match: publiclyVisibleBlockMatch({ updatedAt: { $gte: cutoff } }) },
+        {
+          $group: {
+            _id: '$roomId',
+            recentPosts: { $sum: 1 },
+            lastActivityAt: { $max: '$updatedAt' }
+          }
+        }
+      ]),
+      Session.find({ peers: { $exists: true, $ne: {} } }).lean()
+    ]);
+    const rankedRooms = rankRoomActivity(recentBlockActivity, sessions, new Date(now)).slice(0, limit);
+    const rooms = await Room.find({ _id: { $in: rankedRooms.map(room => room.roomId) } }).lean();
+    const roomsById = new Map(rooms.map(room => [String(room._id), room]));
+    const final = rankedRooms
+      .map(activity => {
+        const room = roomsById.get(activity.roomId);
+        return room ? { ...room, ...activity } : null;
+      })
+      .filter(Boolean);
 
     // Cache the final data for 60 seconds
-    recentlyActiveCache = final;
+    recentlyActiveCache = { limit, rooms: final };
     recentlyActiveCacheExpiration = now + 60 * 1000;
 
     return final;

--- a/spec/sessionServiceSpec.js
+++ b/spec/sessionServiceSpec.js
@@ -1,0 +1,71 @@
+import { rankRoomActivity } from '../server/db/sessionService.js';
+
+describe('rankRoomActivity', () => {
+  const now = new Date('2026-06-07T12:00:00.000Z');
+
+  it('surfaces rooms with recently updated posts even without live peers', () => {
+    const activity = rankRoomActivity([
+      {
+        _id: 'poetry',
+        recentPosts: 2,
+        lastActivityAt: new Date('2026-06-07T10:00:00.000Z')
+      }
+    ], [], now);
+
+    expect(activity).toEqual([
+      {
+        roomId: 'poetry',
+        activeUsers: 0,
+        recentPosts: 2,
+        lastActivityAt: new Date('2026-06-07T10:00:00.000Z')
+      }
+    ]);
+  });
+
+  it('prioritizes live rooms and counts each active peer once across blocks', () => {
+    const activity = rankRoomActivity([
+      {
+        _id: 'poetry',
+        recentPosts: 3,
+        lastActivityAt: new Date('2026-06-07T11:59:00.000Z')
+      }
+    ], [
+      {
+        roomId: 'history',
+        peers: {
+          'peer-1': new Date('2026-06-07T11:58:00.000Z'),
+          'peer-expired': new Date('2026-06-07T11:00:00.000Z')
+        }
+      },
+      {
+        roomId: 'history',
+        peers: {
+          'peer-1': new Date('2026-06-07T11:59:00.000Z'),
+          'peer-2': new Date('2026-06-07T11:57:00.000Z')
+        }
+      }
+    ], now);
+
+    expect(activity.map(room => room.roomId)).toEqual(['history', 'poetry']);
+    expect(activity[0].activeUsers).toBe(2);
+    expect(activity[0].recentPosts).toBe(0);
+    expect(activity[0].lastActivityAt).toEqual(new Date('2026-06-07T11:59:00.000Z'));
+  });
+
+  it('orders non-live rooms by their latest post activity', () => {
+    const activity = rankRoomActivity([
+      {
+        _id: 'older-busy-room',
+        recentPosts: 10,
+        lastActivityAt: new Date('2026-06-06T12:00:00.000Z')
+      },
+      {
+        _id: 'newer-room',
+        recentPosts: 1,
+        lastActivityAt: new Date('2026-06-07T08:00:00.000Z')
+      }
+    ], [], now);
+
+    expect(activity.map(room => room.roomId)).toEqual(['newer-room', 'older-busy-room']);
+  });
+});

--- a/views/rooms.pug
+++ b/views/rooms.pug
@@ -43,11 +43,9 @@ block content
     else
       if recentlyActiveRooms && recentlyActiveRooms.length > 0
         .topic-section.recently-active#recently-active
-          .section-label= t('roomsDirectory.liveNow')
           h2.topic-header(data-topic=t('roomsDirectory.recentlyActive') data-recently-active='true')
             .topic-header__main
               span.topic-title= t('roomsDirectory.recentlyActive')
-              span.topic-subtitle= t('roomsDirectory.recentlyActiveSubtitle')
             .topic-header__meta
               span.topic-count= t('roomsDirectory.roomCount', { count: recentlyActiveRooms.length })
               span.expand-icon
@@ -59,12 +57,15 @@ block content
                 data-room-description=(room.displayDescription || room.description)
                 data-room-link=uiPath(`/rooms/${room._id}`)
                 data-room-active-users=(room.activeUsers || 0)
-                data-room-active-users-loaded='true'
+                data-room-active-users-loaded=(room.activeUsers ? 'true' : 'false')
               )
                 a.room-link(href=uiPath(`/rooms/${room._id}`) title=(room.displayName || room.name))
                   .room-card-head
                     span.room-title= room.displayName || room.name
-                    span.room-activity= t('roomsDirectory.activeUsers', { count: room.activeUsers || 0 })
+                    if room.activeUsers > 0
+                      span.room-activity= t('roomsDirectory.activeUsers', { count: room.activeUsers })
+                    else
+                      span.room-activity
                   span.room-description= room.displayDescription || room.description
                   span.room-cta
                     span.room-cta__label= t('roomsDirectory.visitRoom')


### PR DESCRIPTION
## Summary

- Surface rooms containing public posts created or edited within the last seven days
- Preserve live editor heartbeat counts and prioritize rooms with active editors
- Rank other recently active rooms by their latest post update
- Add an index supporting recent room activity queries
- Hide empty active-user pills until presence data is loaded
- Add focused tests for room activity ranking

## Context

The room directory previously defined recently active rooms exclusively through live editor sessions. Since peer heartbeats expire after five minutes, the section usually disappeared even when rooms had received recent posts or edits.

This change uses existing block `updatedAt` timestamps as a low-overhead activity signal while retaining heartbeat data for live active-user counts.

## Testing

- `npm test` — 279 specs, 0 failures
- Changed JavaScript files pass ESLint
- `views/rooms.pug` compiles successfully