### PR TITLE
Add full Turkish UI localization

### DIFF
--- a/i18n/tr/about.json
+++ b/i18n/tr/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Hakkında",
+      "description": "Daily Page nedir, nasıl çalışır ve neden webin daha yavaş, daha nazik bir köşesi olarak oluşturuldu."
+    },
+    "title": "Daily Page Hakkında",
+    "tagline": "Yemeğinizi değil zihninizi besleyin.",
+    "mission": {
+      "h2": "Misyon",
+      "p1": "Okuyucu merakıyla körüklenen bağımsız bir yazı laboratuvarı oturma odamda başladı.",
+      "p2": "Beyninizi çürütmek için değil, beslemek için inşa edildi: Yavaşça, isterseniz isimsiz olarak yazabileceğiniz ve kimseyi etkileme konusunda asla endişelenmeyeceğiniz bir yer."
+    },
+    "how": {
+      "h2": "Nasıl Çalışır?",
+      "features": {
+        "rooms": {
+          "label": "Odalar",
+          "text": "konu silolarıdır (\"alt reddit, ancak daha dostça\" düşünün)."
+        },
+        "blocks": {
+          "label": "Gönderiler",
+          "text": "işbirliğine dayalı yazma alanlarıdır; herkes (\"anonim\" bile olsa) bir tane oluşturabilir, kilitlenene kadar düzenleyebilir ve diğerlerine oy verebilir."
+        },
+        "privacy": {
+          "label": "Gizlilik ve Paylaşım",
+          "text": "herkese açık gönderilerin odanın akışında yayınlanacağı anlamına gelir. Listelenmemiş taslaklar kilitlenene kadar gizlenir ancak arkadaşlarınızı davet etmek için bir paylaşım bağlantısı alırsınız."
+        },
+        "markdown": {
+          "label": "Markdown ve Medya",
+          "text": "Markdown ile yazmanıza, görseller eklemenize ve Google Dokümanlar'daki gibi birlikte düzenlemenize olanak tanır."
+        },
+        "trends": {
+          "label": "Trendler ve Etiketler",
+          "text": "Gönderinizi etiketlemenize, etiket trendlerini takip etmenize ve en iyi içerikleri keşfetmenize (7 gün / 30 gün / tüm zamanlar) olanak tanır."
+        },
+        "streaks": {
+          "label": "Yazma Serileri",
+          "text": "Günlük yazma serinizi canlı tutun; her gün ortaya çıkmanız için en iyi teşvikiniz."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Buraya Nasıl Geldik?",
+      "p1": "2018'de \"bugünün sayfası\" için tarihe dayalı bir wiki oluşturdum ve birkaç iç gözlem yazarının bunu düşüncelerini aktaracak bir çıkış noktasına dönüştürmesini izledim. Hiçbir zaman çok büyük olmadı ama bir tohum ekti.",
+      "p2": "Şimdilik ileri saralım ve Daily Page birçok odaya yayılan tohumdur; içedönükler, idealistler ve daha yavaş bir tempo isteyen herkes için sessiz bir sosyal ağ."
+    },
+    "next": {
+      "h2": "Sırada Ne Var?",
+      "p1": "Daha yeni başlıyoruz: daha zengin yerleştirmeler, daha derin kullanıcı istatistikleri, itibar skor tabloları ve düşünceli yaratımları ödüllendirmenin daha fazla yolu.",
+      "p2": "Bu küçük bağımsız deneyin parçası olduğunuz için teşekkür ederiz."
+    },
+    "cta": {
+      "rooms": "Odaları Keşfedin",
+      "signup": "Topluluğa Katılın"
+    }
+  }
+}

--- a/i18n/tr/accountSecurity.json
+++ b/i18n/tr/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Hesap Güvenliği",
+      "description": "Daily Page şifrenizi ve iki faktörlü kimlik doğrulamanızı yönetin."
+    },
+    "backToDashboard": "Kontrol paneline geri dön",
+    "heading": "Hesap Güvenliği",
+    "subheading": "Hesabınızı güçlü bir şifre ve kimlik doğrulama uygulamasıyla koruyun.",
+    "password": {
+      "title": "Şifre değiştir",
+      "description": "En az 8 karakterden oluşan benzersiz bir şifre kullanın.",
+      "current": {
+        "label": "Mevcut Şifre"
+      },
+      "new": {
+        "label": "Yeni Şifre"
+      },
+      "submit": "Şifreyi Güncelle"
+    },
+    "twoFactor": {
+      "title": "İki Faktörlü Kimlik Doğrulama",
+      "statusOn": "Etkinleştirilmiş",
+      "statusOff": "Kapalı",
+      "description": "Oturum açtığınızda şifrenizden sonra kimlik doğrulama uygulamasından tek kullanımlık bir kod ekleyin.",
+      "currentPassword": {
+        "label": "Mevcut Şifre"
+      },
+      "startSetup": "Authenticator Uygulamasını Ayarlama",
+      "qrAlt": "Kimlik doğrulayıcı uygulaması QR kodu",
+      "manualKey": "Manuel kurulum tuşu",
+      "code": {
+        "label": "6 haneli kod"
+      },
+      "enable": "2FA'yı etkinleştir",
+      "disableCode": {
+        "label": "Kimlik doğrulayıcı kodu"
+      },
+      "disable": "2FA'yı devre dışı bırak"
+    },
+    "recoveryCodes": {
+      "title": "Kurtarma kodlarınızı kaydedin",
+      "description": "Kimlik doğrulayıcı uygulamanıza erişiminizi kaybederseniz oturum açmak için bu tek kullanımlık kodlardan birini kullanın.",
+      "regenerateDescription": "Önceki seti kaybettiyseniz yeni bir kurtarma kodu seti oluşturun. Bu, eski kurtarma kodlarını geçersiz kılar.",
+      "regenerate": "Yeni Kurtarma Kodları Oluşturun",
+      "warning": "Bunları güvenli bir yerde saklayın. Bir daha gösterilmeyecekler."
+    },
+    "feedback": {
+      "passwordChanged": "Şifreniz güncellendi.",
+      "setupReady": "QR kodunu tarayın ve kurulumu tamamlamak için 6 haneli kodu girin.",
+      "twoFactorEnabled": "İki faktörlü kimlik doğrulama artık etkindir.",
+      "twoFactorDisabled": "İki faktörlü kimlik doğrulama artık devre dışı.",
+      "recoveryCodesRegenerated": "Kurtarma kodlarınız yeniden oluşturuldu. Şimdi yeni kodları kaydedin.",
+      "missingFields": "Lütfen gerekli tüm alanları doldurun.",
+      "missingCurrentPassword": "Devam etmek için mevcut şifrenizi girin.",
+      "passwordTooShort": "Yeni şifreniz en az 8 karakter olmalıdır.",
+      "invalidCurrentPassword": "Mevcut şifre eşleşmedi.",
+      "missingCode": "Kimlik doğrulayıcı uygulamanızdan 6 haneli kodu girin.",
+      "invalidCode": "O kod işe yaramadı. Lütfen tekrar deneyin.",
+      "noPendingSetup": "Kodu girmeden önce kurulumu yeniden başlatın.",
+      "setupExpired": "Bu kurulum oturumunun süresi doldu. Yeni bir QR kodu almak için kurulumu tekrar başlatın.",
+      "twoFactorNotEnabled": "Bu hesap için iki faktörlü kimlik doğrulama etkin değil.",
+      "genericError": "Bir şeyler ters gitti. Lütfen tekrar deneyin.",
+      "unexpectedError": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+    }
+  }
+}

--- a/i18n/tr/anonymousUser.json
+++ b/i18n/tr/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "İsimsiz Gezgin",
+      "description": "Profil yok. Geçmiş yok. Sadece titreşimler."
+    },
+    "ascii": {
+      "ariaLabel": "Alıntılarla tuhaf yaratığın ASCII sanatı"
+    },
+    "header": {
+      "title": "Anonim"
+    },
+    "body": {
+      "line1": "Boşluğa düştün. Burada görülecek hiçbir şey yok.",
+      "line2": "sadece hikayesi olmayan gezgin bir ruh."
+    },
+    "buttons": {
+      "home": "← Eve dönüş",
+      "signup": "Bir kimlik oluşturun"
+    }
+  }
+}

--- a/i18n/tr/archive.json
+++ b/i18n/tr/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arşiv",
+      "description": "Arşivin tamamını aya göre keşfedin.",
+      "titleRoom": "Daily Page — Arşiv · {roomName}",
+      "descriptionRoom": "{roomName} odasındaki geçmiş yazılarınızı ay ay keşfedin. Başkalarının bu alanda zaman içinde neler paylaştığını görmek için herhangi bir tarihe atlayın."
+    },
+    "nav": {
+      "prev": "Öncesi",
+      "next": "Sonraki"
+    },
+    "title": "📚 Arşivlere Göz Atın",
+    "titleRoom": "📚 {roomName} — Arşivler",
+    "roomViewing": "{roomName} odasının arşivi görüntüleniyor",
+    "viewRoomLink": "Odayı görüntüle",
+    "noContent": "Henüz içerik mevcut değil.",
+    "backToRoom": "← Oda Kontrol Paneline geri dön",
+    "calendar": {
+      "meta": {
+        "description": "Hızlı düşüncelerden derin düşüncelere kadar {month} {year}'de yayınlanan tüm yaratıcı gönderileri görüntüleyin. Nelerin paylaşıldığını keşfetmek için herhangi bir tarihi tıklayın.",
+        "descriptionRoom": "{month} {year} sırasında {roomName}'deki yaratıcı etkinliği görüntüleyin. O gün paylaşılan gönderileri keşfetmek için bir tarih seçin."
+      },
+      "title": "📆 {month} {year} arşivi",
+      "prevLabel": "{month} {year} arşivi",
+      "nextLabel": "{month} {year} arşivi"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "{date} arşivi",
+        "titleRoom": "{roomName} — {date} arşivi",
+        "descriptionSite": "Sessiz notlardan vahşi itiraflara kadar {date}'de yazılan gönderileri keşfedin.",
+        "descriptionRoom": "{date}'de, {roomName} odasındaki yazarlar izlerini bıraktı; o gün paylaşılan düşünceler, fikirler ve ifadeler arasında ilerleyin."
+      },
+      "heading": "{date} arşivi",
+      "empty": "Bu tarihe ait içerik bulunamadı.",
+      "labels": {
+        "createdBy": "Oluşturan:",
+        "in": "içinde",
+        "on": "{datetime} tarihinde",
+        "unknownRoom": "Bilinmeyen Oda"
+      },
+      "nav": {
+        "prevDay": "Önceki gün",
+        "nextDay": "Ertesi gün"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Tüm Gönderiler",
+        "descriptionRoom": "{roomName} odasında şimdiye kadar yayınlanmış her gönderiye göz atın. Geçmişini keşfetmek için tarihe, başlığa veya oylara göre sıralayın."
+      },
+      "header": {
+        "allBlocks": "— Tüm Gönderiler"
+      },
+      "sort": {
+        "label": "Göre sırala",
+        "options": {
+          "date": "Tarih",
+          "title": "Başlık",
+          "votes": "Oylar"
+        },
+        "submit": "Git"
+      }
+    },
+    "pagination": {
+      "prev": "← Önceki",
+      "next": "Sonraki →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "{time} için Daily Page'ler"
+      },
+      "empty": "Bu süre zarfında herhangi bir sayfa bulamadık."
+    }
+  }
+}

--- a/i18n/tr/auth.json
+++ b/i18n/tr/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Oturum aç",
+        "description": "Yazma yolculuğunuza devam etmek için Daily Page hesabınızda oturum açın."
+      },
+      "heading": "Tekrar hoşgeldiniz!",
+      "subheading": "Günlük yazılarınızı paylaşmaya devam etmek için hesabınıza giriş yapın.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Kullanıcı adı veya E-posta",
+          "placeholder": "Kullanıcı adınızı veya e-posta adresinizi girin"
+        },
+        "password": {
+          "label": "Şifre",
+          "placeholder": "Şifrenizi girin"
+        },
+        "totpCode": {
+          "label": "Kimlik doğrulayıcı veya kurtarma kodu",
+          "placeholder": "Kodu girin"
+        }
+      },
+      "actions": {
+        "submit": "Giriş Yap"
+      },
+      "feedback": {
+        "success": "Giriş başarılı! Yönlendiriliyor...",
+        "twoFactorRequired": "Kimlik doğrulayıcı uygulamanızdan 6 haneli kodu girin veya bir kurtarma kodu kullanın.",
+        "twoFactorFailed": "O kod işe yaramadı. Lütfen tekrar deneyin.",
+        "failedGeneric": "Giriş başarısız oldu. Lütfen tekrar deneyin.",
+        "unexpected": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+      },
+      "links": {
+        "forgotPassword": "Şifrenizi mi unuttunuz?",
+        "noAccount": "Henüz bir hesabınız yok mu?",
+        "signupHere": "Buradan kaydolun!"
+      }
+    }
+  }
+}

--- a/i18n/tr/bestOf.json
+++ b/i18n/tr/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Daily Page'nin en iyisi",
+      "description": "Daily Page'de en sevilen gönderiler; komik, dürüst, şiirsel ya da sadece tuhaf. Geçtiğimiz gün, hafta, ay ve sonrasında neyin öne çıktığını görün.",
+      "titleRoom": "{roomName}'nin en iyisi",
+      "descriptionRoom": "{roomName} odasından öne çıkan gönderileri keşfedin; okuyucuların son 24 saat, 7 gün, 30 gün ve tüm zamanlarda en çok sevdikleri gönderiler."
+    },
+    "heading": "🏆Daily Page'nin en iyileri",
+    "headingRoomPrefix": "🏆 En iyileri",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 Saat",
+      "7d": "🚀 7 Gün",
+      "30d": "🌕 30 Gün",
+      "all": "👑 Tüm Zamanlar"
+    },
+    "labels": {
+      "createdBy": "Oluşturan:",
+      "inRoom": "içinde",
+      "onDate": "{date} tarihinde",
+      "unknownRoom": "Bilinmeyen Oda",
+      "noBlocks": "Hiçbir gönderi bulunamadı.",
+      "viewRoom": "Odayı görüntüle"
+    }
+  }
+}

--- a/i18n/tr/blockCommon.json
+++ b/i18n/tr/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Taslak"
+    },
+    "deleteModal": {
+      "title": "Gönderi Silinsin mi?",
+      "message": "Bu eylem geri alınamaz.",
+      "confirm": "Sil",
+      "cancel": "İptal",
+      "closeAriaLabel": "Kapat"
+    },
+    "toasts": {
+      "deleteSuccess": "Gönderi başarıyla silindi!",
+      "deleteFailed": "Gönderi silinemedi."
+    }
+  }
+}

--- a/i18n/tr/blockEditor.json
+++ b/i18n/tr/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Sen)"
+    },
+    "meta": {
+      "title": "Gönderiyi Düzenle - {blockTitle}",
+      "titleFallback": "Gönderiyi Düzenle"
+    },
+    "errors": {
+      "imageUrlRequired": "Lütfen bir resim URL'si girin.",
+      "notFound": "Gönderi bulunamadı veya bu odaya ait değil.",
+      "loadFailed": "Gönderi düzenleyici yüklenirken bir hata oluştu.",
+      "updateTitleFailed": "Başlık güncellenirken hata oluştu."
+    },
+    "roomInfo": {
+      "label": "Oda:"
+    },
+    "title": {
+      "placeholder": "Gönderi başlığını girin",
+      "editTooltip": "Başlığı Düzenle",
+      "lock": "Gönderiyi Kilitle",
+      "delete": "Gönderiyi Sil"
+    },
+    "description": {
+      "label": "Açıklama",
+      "editTooltip": "Açıklamayı Düzenle",
+      "placeholder": "Açıklamayı girin",
+      "noDescriptionOwner": "Henüz açıklama yok...",
+      "noDescriptionViewer": "Açıklama sağlanmadı...",
+      "save": "Kaydet",
+      "cancel": "İptal",
+      "expand": "Genişlet",
+      "collapse": "Daralt",
+      "updateError": "Açıklama güncellenirken hata oluştu."
+    },
+    "status": {
+      "lastBackup": "Son yedekleme: {datetime}",
+      "lastBackupUnknown": "Son yedekleme: Bilinmiyor"
+    },
+    "peers": {
+      "label": "Katılımcılar:"
+    },
+    "toasts": {
+      "blockLocked": "Bu gönderi kilitlendi!"
+    },
+    "editor": {
+      "placeholder": "Boş sayfa senin sesini bekliyor; korkusuzca yaz."
+    },
+    "loading": {
+      "label": "Yükleniyor",
+      "quote": "Bırakın dünya sizin için yansın. Prizma ışığını beyaz sıcak bir şekilde kağıda atın.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "5 dakikadır hiçbir şey yazmadın. Oturuma devam etmek için Tamam'ı tıklayın; aksi halde arşive yönlendirileceksiniz.",
+      "confirm": "TAMAM"
+    },
+    "sharing": {
+      "label": "Bağlantıyı Paylaşma",
+      "copyTooltip": "Panoya kopyala",
+      "copied": "Kopyalandı!"
+    },
+    "toolbar": {
+      "insertImage": "Resim Ekle",
+      "insertImageUrlPlaceholder": "Resim URL'sini girin",
+      "insertImageAltPlaceholder": "Alternatif metin (isteğe bağlı)",
+      "insertImageConfirm": "Onayla",
+      "insertImageCancel": "İptal"
+    },
+    "buttons": {
+      "downloadFile": "Dosyayı indir"
+    },
+    "lockModal": {
+      "messageLine1": "Bu gönderiyi kilitlemek istediğinizden emin misiniz?",
+      "messageLine2": "Bu, onu sonlandıracak ve daha fazla düzenleme yapılmasını önleyecektir.",
+      "confirm": "Kilit",
+      "cancel": "İptal",
+      "successToast": "Gönderi başarıyla kilitlendi.",
+      "errorToast": "Gönderi kilitlenirken hata oluştu."
+    },
+    "tags": {
+      "headerWithTags": "Etiketler:",
+      "headerNoTags": "Henüz etiket yok! Biraz ekleyin:",
+      "updateError": "Etiketler güncellenirken hata oluştu."
+    },
+    "fullBlock": {
+      "headingPrefix": "Üzgünüz; \"{blockTitle}\" gönderisi şu anda",
+      "headingStatus": "tamamen dolu.",
+      "retryPrefix": "Lütfen",
+      "retryLink": "farklı bir gönderi dene",
+      "retrySuffix": "ya da başka bir zaman geri gel.",
+      "consolationPrefix": "Beklerken okuyabilirsiniz:",
+      "consolationBestOf": "favori gönderilerimizden bazıları",
+      "consolationMiddle": "veya göz atmak için",
+      "consolationArchive": "arşiv."
+    }
+  }
+}

--- a/i18n/tr/blockList.json
+++ b/i18n/tr/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "her zaman",
+      "days": "son {n} günlerde",
+      "day": "son 24 saat içinde"
+    },
+    "createdBy": "Oluşturan:",
+    "on": "tarihinde"
+  }
+}

--- a/i18n/tr/blockTags.json
+++ b/i18n/tr/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Etiketler:",
+      "noTags": "Henüz etiket yok! Biraz ekleyin:"
+    },
+    "input": {
+      "placeholder": "Yeni etiket",
+      "addButton": "Ekle"
+    },
+    "buttons": {
+      "removeTag": "X"
+    }
+  }
+}

--- a/i18n/tr/blockView.json
+++ b/i18n/tr/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Gönderi - {blockTitle}",
+      "titleFallback": "Gönderi"
+    },
+    "labels": {
+      "room": "Oda",
+      "author": "Yazar",
+      "created": "Oluşturuldu",
+      "unknownAuthor": "Anonim",
+      "authorAvatarAlt": "{username}'in avatarı",
+      "viewAuthorProfile": "{username}'in profilini görüntüleyin",
+      "lang": "Çeviriler:",
+      "available": "mevcut"
+    },
+    "buttons": {
+      "edit": "Düzenle",
+      "deleteBlock": "Gönderiyi Sil",
+      "share": "Paylaş",
+      "flagContent": "İçeriği İşaretle"
+    },
+    "description": {
+      "label": "Açıklama",
+      "none": "Açıklama sağlanmadı...",
+      "expand": "Genişlet",
+      "collapse": "Daralt"
+    },
+    "editorial": {
+      "heading": "Okuma kılavuzu",
+      "roleLabel": "Okuma türü",
+      "clusterLabel": "Rehber",
+      "sequence": "Parça {sequence}",
+      "primaryPillarHeading": "Buradan başlayın",
+      "relatedHeading": "Okumaya devam et",
+      "clusterHeading": "Daha fazlası bu kılavuzda",
+      "expandSection": "{count} tane daha göster",
+      "collapseSection": "Daha az göster",
+      "roleNames": {
+        "pillar": "Temel kılavuz",
+        "companion": "Derin dalış",
+        "texture": "Arka plan"
+      }
+    },
+    "comments": {
+      "heading": "Yorumlar",
+      "count": "{count} yorum",
+      "empty": "Henüz kimse cevap vermedi. Konuşma başladığında yorumlar burada görünecek.",
+      "composer": {
+        "label": "Yorum ekle",
+        "placeholder": "Bir yorum yazın...",
+        "submit": "Yorum gönder",
+        "submitting": "Yayınlanıyor...",
+        "success": "Yorum yayınlandı.",
+        "error": "Yorumunuz şu anda yayınlanamıyor.",
+        "loginPrompt": "Sohbete katılmak için giriş yapın.",
+        "loginCta": "Yorum yapmak için giriş yapın",
+        "verifyPrompt": "Yorum göndermeden önce e-posta adresinizi doğrulayın.",
+        "verifyCta": "E-postayı doğrulayın"
+      },
+      "sort": {
+        "label": "Sırala",
+        "oldestFirst": "Önce en eski",
+        "newestFirst": "Önce en yeni"
+      },
+      "by": "Yazan",
+      "unknownAuthor": "Bilinmiyor",
+      "reply": {
+        "action": "Yanıtla",
+        "label": "Yanıt ekle",
+        "placeholder": "Bir cevap yazın...",
+        "submit": "Yanıt gönder",
+        "submitting": "Yayınlanıyor...",
+        "success": "Yanıt gönderildi.",
+        "error": "Yanıtınız şu anda gönderilemiyor.",
+        "cancel": "İptal",
+        "loginPrompt": "Cevaplamak için giriş yapın."
+      },
+      "manage": {
+        "edited": "Düzenlendi",
+        "editAction": "Düzenle",
+        "deleteAction": "Sil",
+        "deleteConfirm": "Bu yorum silinsin mi? Bu aynı zamanda altındaki yanıtları da kaldıracaktır.",
+        "deleteSuccess": "Yorum silindi.",
+        "deleteError": "Bu yorum şu anda silinemiyor.",
+        "forbidden": "Yalnızca kendi yorumlarınızı yönetebilirsiniz.",
+        "edit": {
+          "label": "Yorumu düzenle",
+          "save": "Kaydet",
+          "saving": "Kaydediliyor...",
+          "cancel": "İptal",
+          "success": "Yorum güncellendi.",
+          "error": "Bu yorum şu anda güncellenemiyor."
+        }
+      },
+      "report": {
+        "action": "Bildir",
+        "pending": "Raporlanıyor...",
+        "success": "Yorum bildirildi.",
+        "error": "Bu yorum şu anda raporlanamıyor.",
+        "ownError": "Kendi yorumunuzu bildiremezsiniz.",
+        "hidden": "Yorum rapordan sonra gizlendi.",
+        "reported": "Bildirildi"
+      },
+      "deepLink": {
+        "focused": "Bağlantılı yorum",
+        "unavailable": "Bağlantılı yorum artık mevcut değil."
+      },
+      "loadMore": "Daha fazla yorum yükle",
+      "loading": "Yükleniyor...",
+      "loadError": "Şu anda daha fazla yorum yüklenemiyor."
+    },
+    "share": {
+      "title": "Bu Gönderiyi Paylaş",
+      "shareOn": "Şurada paylaş:",
+      "nativeText": "Bu gönderiye göz atın: {title}",
+      "alt": {
+        "facebook": "Facebook logosu",
+        "reddit": "Reddit logosu",
+        "whatsapp": "WhatsApp logosu",
+        "twitter": "Twitter logosu"
+      }
+    },
+    "errors": {
+      "notFound": "Gönderi bulunamadı veya bu odaya ait değil.",
+      "loadFailed": "Gönderi görünümü yüklenirken hata oluştu."
+    }
+  }
+}

--- a/i18n/tr/createBlock.json
+++ b/i18n/tr/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Yeni Gönderi Oluştur — Daily Page",
+      "description": "İsteğe bağlı etiketler, dil ve görünürlükle yeni bir yaratıcı gönderiye başlayın."
+    },
+    "heading": "Yeni Gönderi Oluştur",
+    "roomInfo": {
+      "roomLabel": "Oda:",
+      "unavailable": "Oda bilgisi mevcut değil.",
+      "noDescription": "Açıklama mevcut değil."
+    },
+    "form": {
+      "title": {
+        "label": "Başlık:",
+        "placeholder": {
+          "full": "örneğin 'Başyapıtım', 'Şimdiye Kadarki En İyi Fikir', 'Meraklılar İçin İlgi Çekici Bir Başlık'",
+          "short": "örneğin 'Benim Başyapıtım'"
+        }
+      },
+      "description": {
+        "label": "Açıklama (isteğe bağlı):",
+        "placeholder": "Harika fikrinizi açıklayın… ya da doğaçlama yapın."
+      },
+      "initialContent": {
+        "label": "Başlangıç ​​İçeriği (isteğe bağlı):",
+        "help": "Buradan yazmaya başlayın veya görüntüleri ekleyebileceğiniz ve gerçek zamanlı olarak işbirliği yapabileceğiniz tam düzenleyici sayfasında devam etmek için \"Oluştur\"a basın.",
+        "placeholder": "Gönderinize buradan başlayın veya oluşturduktan sonra düzenlemeye devam edin…"
+      },
+      "visibility": {
+        "label": "Görünürlük:"
+      },
+      "submit": "Gönderi Oluştur"
+    },
+    "visibility": {
+      "public": {
+        "label": "Herkese Açık",
+        "title": "Herkes tarafından gerçek zamanlı olarak düzenlenebilir. Giriş yapmanıza gerek yok.",
+        "inline": "Herkes tarafından gerçek zamanlı olarak düzenlenebilir. Giriş yapmanıza gerek yok."
+      },
+      "unlisted": {
+        "label": "Liste Dışı Taslak",
+        "title": "Düzenlenebilirken genel taramadan gizlenir. Kilitlendikten sonra görünür.",
+        "inline": "Düzenlenebilirken genel taramadan gizlenir. Kilitlendikten sonra görünür.",
+        "tooltip": "Liste dışı taslaklar düzenlenebilir durumdayken genel taramadan gizlenir. Bağlantıya sahip olan herkes ortak çalışabilir ve gönderi kilitlendiğinde herkese açık hale gelir."
+      }
+    },
+    "advanced": {
+      "summary": "Gelişmiş seçenekler",
+      "lang": {
+        "label": "Dil:",
+        "options": {
+          "en": "İngilizce",
+          "es": "İspanyolca",
+          "fr": "Fransızca",
+          "ru": "Rusça",
+          "id": "Endonezce",
+          "de": "Almanca",
+          "it": "İtalyanca",
+          "pt": "Portekizce",
+          "zh": "Çince",
+          "ja": "Japonca",
+          "ko": "Korece",
+          "ar": "Arapça",
+          "hi": "Hintçe",
+          "tr": "Türkçe",
+          "nl": "Felemenkçe",
+          "sv": "İsveççe",
+          "no": "Norveççe",
+          "da": "Danca",
+          "fi": "Fince",
+          "pl": "Lehçe",
+          "cs": "Çekçe",
+          "el": "Yunanca",
+          "he": "İbranice",
+          "th": "Tayca",
+          "vi": "Vietnamca"
+        }
+      },
+      "translate": {
+        "label": "Mevcut gönderiyi çevir (URL veya ID):",
+        "placeholder": "Bir gönderi URL'si veya kimliği yapıştırın (isteğe bağlı)",
+        "invalid": "Bu geçerli bir gönderi URL'sine veya kimliğine benzemiyor.",
+        "fetchError": "Gönderi bilgileri getirilemedi."
+      }
+    },
+    "messages": {
+      "langExists": "Bu dil için bir çeviri zaten mevcut. Lütfen başka bir dil seçin.",
+      "genericError": "Bir şeyler ters gitti. Lütfen tekrar deneyin."
+    }
+  }
+}

--- a/i18n/tr/dashboard.json
+++ b/i18n/tr/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Kontrol Paneli",
+      "description": "Daily Page kontrol paneliniz ve hesaba genel bakış."
+    },
+    "profile": {
+      "profilePicAlt": "Profil Resmi",
+      "noBio": "Henüz biyografi yok. Bir tane eklemek için \"Düzenle\"yi tıklayın!",
+      "editBio": "Biyografiyi Düzenle",
+      "bioPlaceholder": "Biyografinizi buraya girin",
+      "save": "Kaydet",
+      "cancel": "İptal"
+    },
+    "activity": {
+      "title": "Son Etkinlik",
+      "none": "Yakın zamanda etkinlik yok.",
+      "updatedOn": "{date} tarihinde güncellendi",
+      "viewAllBlocks": "Tüm Gönderileri Görüntüle"
+    },
+    "drafts": {
+      "title": "Yazmaya Devam Et",
+      "none": "Açık durumda taslak yok.",
+      "updatedOn": "{date} tarihinde güncellendi",
+      "unlisted": "Liste dışı",
+      "viewAll": "Tüm Gönderileri Görüntüle"
+    },
+    "streak": {
+      "title": "Yazma Serisi",
+      "line": "{days} gün üst üste! Böyle devam!"
+    },
+    "starredRooms": {
+      "title": "Yıldızlı Odalar",
+      "none": "Henüz hiçbir odaya yıldız eklemediniz. Favorilerinizi bulmak için keşfetmeye başlayın!",
+      "viewAll": "Tüm Yıldızlı Odaları Görüntüle",
+      "unnamedRoom": "İsimsiz Oda"
+    },
+    "security": {
+      "title": "Hesap Güvenliği",
+      "summary": "Şifrenizi değiştirin ve iki faktörlü kimlik doğrulamayı yönetin.",
+      "manage": "Güvenliği Yönet"
+    },
+    "stats": {
+      "title": "İstatistikleriniz",
+      "totalBlocks": "Oluşturulan Toplam Gönderi",
+      "collaborations": "İşbirlikleri",
+      "votesGiven": "Verilen Oylar",
+      "daysActive": "Aktif Günler",
+      "viewDetailed": "Ayrıntılı İstatistikleri Görüntüle 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Profil resmi yüklenemedi. Lütfen tekrar deneyin.",
+      "uploadUnexpected": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin.",
+      "bioUpdateFailed": "Biyografi güncellenirken hata oluştu. Lütfen tekrar deneyin."
+    }
+  }
+}

--- a/i18n/tr/detailedStats.json
+++ b/i18n/tr/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Ayrıntılı İstatistikler",
+      "description": "Daily Page etkinliğinizin ayrıntılı dökümü."
+    },
+    "nav": {
+      "backToDashboard": "← Kontrol Paneli'e geri dön"
+    },
+    "header": {
+      "title": "📊 İstatistiklerinize Genel Bakış 📊"
+    },
+    "cards": {
+      "totalBlocks": "Oluşturulan Toplam Gönderi 📝",
+      "collaborations": "İşbirlikleri 🤝",
+      "votesGiven": "Verilen Oylar 👍",
+      "daysActive": "Aktif Günler 📆"
+    },
+    "chart": {
+      "datasetLabel": "İstatistikleriniz",
+      "labels": {
+        "blocksCreated": "Oluşturulan Gönderiler",
+        "collaborations": "İşbirlikleri",
+        "votesGiven": "Verilen Oylar",
+        "daysActive": "Aktif Günler"
+      }
+    }
+  }
+}

--- a/i18n/tr/errors.json
+++ b/i18n/tr/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Hata! Bir şeyler ters gitti.",
+      "message": "Beklenmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyin.",
+      "home": "Ana Sayfaya Geri Dön"
+    },
+    "notFound": {
+      "title": "404 - Sayfa Bulunamadı",
+      "metaTitle": "Sayfa Bulunamadı",
+      "message": "Üzgünüz, aradığınız sayfayı bulamadık.",
+      "homePrefix": "Şuraya geri dönebilirsiniz:",
+      "homeLink": "ana sayfa",
+      "roomsPrefix": "veya şuraya göz atın",
+      "roomsLink": "odalar dizini."
+    }
+  }
+}

--- a/i18n/tr/flagModal.json
+++ b/i18n/tr/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Uygunsuz İçeriği Bildirin",
+    "fields": {
+      "reason": {
+        "label": "Sebep",
+        "options": {
+          "spam": "İstenmeyen e-posta",
+          "offensive": "Saldırgan (nefret dolu dil veya hakaretler)",
+          "inappropriate": "Uygunsuz (çıplaklık, grafik içerik vb.)",
+          "other": "Diğer"
+        }
+      },
+      "details": {
+        "label": "Ayrıntılar (isteğe bağlı)",
+        "placeholder": "Ne gördüğünüzü anlatın…"
+      }
+    },
+    "buttons": {
+      "submit": "Raporu Gönder",
+      "cancel": "İptal"
+    },
+    "toasts": {
+      "success": "Rapor gönderildi; teşekkür ederiz!",
+      "failed": "Rapor gönderilemedi."
+    }
+  }
+}

--- a/i18n/tr/forgotPassword.json
+++ b/i18n/tr/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Şifreyi Sıfırla",
+      "description": "Daily Page hesabınız için bir sıfırlama bağlantısı isteyin."
+    },
+    "header": {
+      "title": "Şifrenizi mi unuttunuz?",
+      "subtitle": "E-postanızı girin, size bir sıfırlama bağlantısı göndereceğiz."
+    },
+    "form": {
+      "email": {
+        "label": "E-posta Adresi",
+        "placeholder": "E-postanızı girin"
+      },
+      "submit": "Şifre Sıfırlama Talebi"
+    },
+    "feedback": {
+      "successGeneric": "Bu e-posta mevcutsa, bir sıfırlama bağlantısı gönderilmiştir.",
+      "missingEmail": "E-posta gerekli.",
+      "genericError": "Bir şeyler ters gitti. Lütfen tekrar deneyin.",
+      "unexpectedError": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+    },
+    "email": {
+      "subject": "Daily Page şifrenizi sıfırlayın",
+      "heading": "Şifre Sıfırlama Talebi",
+      "headingWithName": "Şifre Sıfırlama İsteği, {username}",
+      "body": "Şifrenizi sıfırlamak için aşağıdaki bağlantıya tıklayın.",
+      "cta": "Şifremi Sıfırla",
+      "expires": "Bu bağlantının süresi {hours} saat içinde doluyor.",
+      "ignore": "Şifre sıfırlama talebinde bulunmadıysanız bu e-postayı güvenle yok sayabilirsiniz."
+    }
+  }
+}

--- a/i18n/tr/home.json
+++ b/i18n/tr/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Son 24 Saatteki Popüler Gönderiler",
+      "description": "Daily Page, herkesin yaratıcı düşüncelerini, anılarını veya deneylerini tek seferde yayınlayabileceği minimalist, bağımsız bir yazı sitesidir. Yeni fikirleri keşfedin, odalara katılın ve sesinize katkıda bulunun."
+    },
+    "hero": {
+      "eyebrow": "Yazmak, okumak ve geri dönmek için sessiz bir yer",
+      "title": "Daily Page'ye hoş geldiniz!",
+      "subtitle": "Son 24 saatin en popüler gönderilerini keşfedin.",
+      "ctaPrefix": "İlham mı hissediyorsunuz?",
+      "cta": "Bir odaya katıl",
+      "ctaSuffix": "ve kendi gönderinizi oluşturun!"
+    },
+    "stats": {
+      "blocks": "Gönderiler",
+      "rooms": "Odalar",
+      "tags": "Etiketler",
+      "collabsToday": "Bugünkü İşbirlikleri"
+    },
+    "activity": {
+      "title": "Daily Page'de canlı",
+      "subtitle": "Tek bakışta yeni konuşmalar ve tepkiler.",
+      "fallbackActor": "Birisi",
+      "inRoom": "içinde",
+      "comments": {
+        "title": "Son yorumlar",
+        "more": "Tartışmaları ara",
+        "commentVerb": "yorum yaptı:",
+        "replyVerb": "yanıt verdi:",
+        "empty": "Henüz yeni yorum yok. Bir sonraki konuşma gönderiniz ile başlayabilir."
+      },
+      "reactions": {
+        "title": "Son tepkiler",
+        "more": "Popüler gönderilere göz atın",
+        "empty": "Henüz yeni bir tepki yok. İyi bir gönderi bunu hızla uyandırabilir.",
+        "types": {
+          "heart": "kalp bıraktı:",
+          "leaf": "yaprakla tepki verdi:",
+          "wow": "şaşkınlıkla tepki verdi:",
+          "laugh": "güldü"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Öne Çıkan Oda",
+      "roomInfoDays": "Son {days} gündeki etkinlik: {blocks} gönderi, {votes} oy.",
+      "roomInfo24h": "Son 24 saatteki etkinlik: {blocks} gönderi, {votes} oy.",
+      "checkItOut": "Buna bir bak",
+      "blockRibbon": "★ Öne Çıkan Gönderi",
+      "votes": "{n} oy",
+      "noContent": "(İçerik sağlanmadı...)",
+      "viewBlock": "Gönderiyi Görüntüle"
+    },
+    "trendingTags": {
+      "title": "Trend Olan Etiketler",
+      "suffixDays": "(son {days} gün)",
+      "suffixAllTime": "(tüm zamanlar)",
+      "blocks": "{n} gönderi",
+      "votes": "{n} oy",
+      "empty": "Henüz trend etiketi yok. Harika bir şeyi etiketleyen ilk kişi olun!"
+    },
+    "trendingBlocks": {
+      "title": "Trend Olan Gönderiler",
+      "suffixDays": "(son {days} gün)",
+      "createdBy": "Oluşturan:",
+      "in": "içinde",
+      "on": "tarihinde",
+      "unknownRoom": "Bilinmeyen Oda",
+      "empty24h": "Son 24 saatte henüz gönderi yok. Yakında tekrar kontrol et, dostum!"
+    }
+  }
+}

--- a/i18n/tr/layout.json
+++ b/i18n/tr/layout.json
@@ -1,0 +1,50 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Hoş geldin, Kullanıcı!",
+    "logout": "Oturumu kapat",
+    "login": "Giriş / Kayıt Ol",
+    "language": "Dil",
+    "openMenu": "Ana menüyü aç",
+    "closeMenu": "Ana menüyü kapat",
+    "privacy": "Gizlilik Politikası",
+    "uiFallbackNotice": "{requested} henüz çevrilmedi. Şimdilik {current} gösteriliyor.",
+    "copyButton": {
+      "copy": "Kopyala",
+      "copied": "Kopyalandı!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "English",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "עברית",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Tema",
+      "toggleToDark": "Karanlık moda geç",
+      "toggleToLight": "Işık moduna geç"
+    }
+  }
+}

--- a/i18n/tr/modals.json
+++ b/i18n/tr/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Lütfen Giriş Yapın",
+      "message": "Devam etmek için giriş yapmanız gerekiyor.",
+      "messageWithAction": "{action}'de oturum açmanız gerekir.",
+      "cta": "Giriş Yap"
+    },
+    "actions": {
+      "voteOnBlock": "bir gönderiye oy vermek",
+      "starRoom": "bu odaya yıldız ver",
+      "reactToBlock": "bu gönderiye tepki ver",
+      "commentOnBlock": "bu gönderiye yorum yap",
+      "reportComment": "bu yorumu bildir"
+    },
+    "errors": {
+      "starToggleFail": "Yıldız durumu güncellenemedi. Lütfen tekrar deneyin."
+    }
+  }
+}

--- a/i18n/tr/nav.json
+++ b/i18n/tr/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Ana Sayfa",
+    "rooms": "Odalar",
+    "tags": "Etiketler",
+    "archive": "Arşiv",
+    "search": "Ara",
+    "bestOf": "En İyisi",
+    "about": "Hakkında",
+    "support": "Destek",
+    "otherProjects": "Diğer Projeler",
+    "auth": {
+      "welcomePrefix": "Hoş geldin, ",
+      "welcomeFallbackUser": "sen",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Kontrol Paneli"
+  }
+}

--- a/i18n/tr/notifications.json
+++ b/i18n/tr/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Bildirimler",
+      "openMenu": "Bildirimleri aç",
+      "loading": "Bildirimler yükleniyor...",
+      "error": "Bildirimler şu anda yüklenemiyor.",
+      "empty": "Henüz bildirim yok.",
+      "markRead": "Okundu olarak işaretle",
+      "fallbackActor": "Birisi",
+      "fallbackBlockTitle": "gönderiniz",
+      "item": {
+        "blockComment": "{actorUsername}, \"{blockTitle}\" gönderinize yorum yaptı.",
+        "commentReply": "{actorUsername}, \"{blockTitle}\" hakkındaki yorumunuza yanıt verdi.",
+        "unknown": "Bildirim"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "\"{blockTitle}\" üzerine yeni yorum",
+        "heading": "Gönderinize yeni yorum",
+        "headingWithName": "Merhaba {username},",
+        "body": "<strong>{actorUsername}</strong> gönderinize yorum yaptı <strong>{blockTitle}</strong>.",
+        "cta": "Daily Page'deki konuşmayı görüntüleyin",
+        "fallbackActor": "Birisi",
+        "fallbackBlockTitle": "gönderiniz"
+      },
+      "commentReply": {
+        "subject": "\"{blockTitle}\" ile ilgili yeni yanıt",
+        "heading": "Yorumunuza yeni yanıt",
+        "headingWithName": "Merhaba {username},",
+        "body": "<strong>{actorUsername}</strong>, <strong>{blockTitle}</strong> hakkındaki yorumunuza yanıt verdi.",
+        "cta": "Daily Page'deki konuşmayı görüntüleyin",
+        "fallbackActor": "Birisi",
+        "fallbackBlockTitle": "gönderiniz"
+      }
+    }
+  }
+}

--- a/i18n/tr/privacy.json
+++ b/i18n/tr/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Gizlilik Politikası",
+      "description": "Daily Page'nin verilerinizi sade bir dille nasıl topladığı, kullandığı ve koruduğu."
+    },
+    "title": "Gizlilik Politikası",
+    "lastUpdated": "Son güncelleme: {date}",
+    "intro": {
+      "h2": "Giriş",
+      "p1": "Daily Page (\"biz\", \"biz\" veya \"bizim\") dailypage.org web sitesini (bundan sonra \"Hizmet\" olarak anılacaktır) işletmektedir.",
+      "p2": "Bu sayfa, Hizmetimizi kullandığınızda kişisel verilerin toplanması, kullanılması ve ifşa edilmesine ilişkin politikalarımız hakkında sizi bilgilendirir."
+    },
+    "collection": {
+      "h2": "Bilgi Toplama ve Kullanma",
+      "p": "Hizmetimizi geliştirmek ve sunmak için minimum düzeyde kişisel veri topluyoruz. Bu, hesap yönetimine yönelik e-posta adreslerini ve kullanıcılar tarafından gönüllü olarak gönderilen içeriği içerir."
+    },
+    "usage": {
+      "h2": "Veri Kullanımı",
+      "p": "Toplanan veriler yalnızca hesap kimlik doğrulaması, içerik denetimi ve kullanıcı deneyimini geliştirmek için kullanılır."
+    },
+    "storage": {
+      "h2": "Veri Depolama ve Güvenlik",
+      "p": "Verileriniz güvenli bir şekilde saklanır ve yasaların gerektirdiği durumlar dışında, açık rıza olmadan asla üçüncü şahıslarla paylaşılmaz veya satılmaz."
+    },
+    "cookies": {
+      "h2": "Çerezler",
+      "p": "Çerezleri yalnızca oturum yönetimi ve kullanıcı deneyimini geliştirmek için kullanıyoruz. Çerezleri tarayıcınızın ayarlarından devre dışı bırakabilirsiniz."
+    },
+    "rights": {
+      "h2": "Haklarınız",
+      "p": "İstediğiniz zaman bizimle iletişime geçerek kişisel verilerinizin silinmesini veya değiştirilmesini talep edebilirsiniz."
+    },
+    "changes": {
+      "h2": "Bu Gizlilik Politikasındaki Değişiklikler",
+      "p": "Gizlilik Politikamızı zaman zaman güncelleyebiliriz. Değişiklikler bu sayfada yayınlanacaktır."
+    },
+    "contact": {
+      "h2": "Bize Ulaşın",
+      "p": "Bu Gizlilik Politikasıyla ilgili sorularınız için bizimle şu adresten iletişime geçin:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/tr/profile.json
+++ b/i18n/tr/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "{username} Profili",
+      "descriptionUser": "{username}'nin son etkinliğini, yıldızlı odalarını ve istatistiklerini görüntüleyin."
+    },
+    "profile": {
+      "profilePicAlt": "Profil resmi",
+      "noBio": "(Biyografi mevcut değil.)"
+    },
+    "activity": {
+      "title": "Son Etkinlik",
+      "updatedOn": "{date} tarihinde güncellendi",
+      "none": "Yakın zamanda etkinlik yok.",
+      "viewAllBlocks": "Tüm Gönderileri Görüntüle"
+    },
+    "starredRooms": {
+      "title": "Yıldızlı Odalar",
+      "none": "Henüz yıldızlı oda yok.",
+      "unnamedRoom": "İsimsiz Oda"
+    },
+    "stats": {
+      "title": "Kullanıcı İstatistikleri",
+      "totalBlocks": "Oluşturulan Toplam Gönderi",
+      "collaborations": "İşbirlikleri",
+      "daysActive": "Aktif Günler"
+    }
+  }
+}

--- a/i18n/tr/random.json
+++ b/i18n/tr/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Diğer Projeler",
+      "description": "Daily Page'deki beyzbol günlüklerini, rastgele yazma deneylerini ve diğer yan projeleri keşfedin."
+    },
+    "title": "Diğer Projeler",
+    "tagline": "Deneyler ve yan görevler için rahat bir köşe.",
+    "links": {
+      "baseball": "📖 Beyzbol Günlüğü",
+      "randomWriter": "🎲 Rastgele Yazar"
+    },
+    "cta": {
+      "backToRooms": "Ana Odalara Geri Dön"
+    }
+  }
+}

--- a/i18n/tr/randomWriter.json
+++ b/i18n/tr/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Rastgele Yazar",
+      "description": "Eğlence, ilham veya kaos için sonsuz bir rastgele sözde metin akışı oluşturun."
+    },
+    "title": "Rastgele Yazar",
+    "buttons": {
+      "clear": "Temizle",
+      "stop": "Yazmayı bırak",
+      "start": "Yazmaya başla"
+    }
+  }
+}

--- a/i18n/tr/reactions.json
+++ b/i18n/tr/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} tepkileri: {count}",
+    "loginToReact": "Tepki vermek için giriş yapın",
+    "countsLabel": "Tepkiler"
+  }
+}

--- a/i18n/tr/readMore.json
+++ b/i18n/tr/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Daha fazla...",
+    "aria": "Yazının tamamını okuyun: {title}"
+  }
+}

--- a/i18n/tr/resetPassword.json
+++ b/i18n/tr/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Şifrenizi Sıfırlayın",
+      "description": "Hesabınız için yeni bir şifre belirleyin."
+    },
+    "header": {
+      "title": "Şifrenizi Sıfırlayın",
+      "subtitle": "Yeniden erişim kazanmak için yeni bir şifre seçin."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Yeni Şifre",
+        "placeholder": "Yeni şifreyi girin"
+      },
+      "submit": "Yeni Şifre Belirle"
+    },
+    "feedback": {
+      "missingToken": "Eksik veya geçersiz jeton.",
+      "missingFields": "Jeton ve yeni şifre gerekli.",
+      "invalidOrExpired": "Geçersiz veya süresi dolmuş jeton.",
+      "success": "Şifre başarıyla güncellendi!",
+      "genericError": "Bir şeyler ters gitti. Lütfen tekrar deneyin.",
+      "unexpectedError": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+    }
+  }
+}

--- a/i18n/tr/roomDashboard.json
+++ b/i18n/tr/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "{roomName}'deki son ve devam eden gönderileri keşfedin."
+    },
+    "links": {
+      "exploreLabel": "Keşfetmek:",
+      "allBlocks": "🗂️ Tüm gönderiler",
+      "browseByDate": "🗓️ Tarihe göre",
+      "bestOf": "🏅 En iyileri",
+      "searchInRoom": "🔎 Ara"
+    },
+    "actions": {
+      "createBlock": "Gönderi Oluştur",
+      "starTitle": "Bu odaya yıldız ekleyin",
+      "unstarTitle": "Bu odanın yıldızını kaldır"
+    },
+    "tabs": {
+      "locked": "Kilitli Gönderiler",
+      "inProgress": "Devam Eden Gönderiler"
+    },
+    "sections": {
+      "lockedHeader": "Kilitli gönderiler",
+      "inProgressHeader": "Devam eden gönderiler"
+    },
+    "editorial": {
+      "heading": "Öne çıkan kılavuzlar",
+      "description": "Bu oda için seçilmiş öne çıkan kılavuzlarla buradan başlayın.",
+      "roleNames": {
+        "pillar": "Temel kılavuz",
+        "companion": "Okuma kılavuzu",
+        "texture": "Arka plan kılavuzu"
+      }
+    },
+    "empty": {
+      "noDescription": "Açıklama mevcut değil.",
+      "noLocked": "Henüz kilitli gönderi yok! 1 saat işlem yapılmaması durumunda otomatik kilitlenir.",
+      "noInProgress": "Henüz devam eden gönderi yok! Bir tanesine başlama zamanı.",
+      "noBlocks": "Henüz gönderi yok! İlkini yaratın ve izinizi bırakın. 😎"
+    }
+  }
+}

--- a/i18n/tr/roomsDirectory.json
+++ b/i18n/tr/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Oda Dizini",
+      "description": "Her oda farklı bir dünyaya açılan kapıdır. İçeri girin, hikayenizi paylaşın ve güzel bir şey inşa etmek için diğerlerine katılın."
+    },
+    "eyebrow": "Köşenizi bulun",
+    "heading": "Oda Dizini",
+    "intro": "Şu anda hareketli olan odalarla başlayın veya ilginizi çeken bir şey bulana kadar konulara göz atın. Her oda sesinizi bekleyen farklı bir yazma fikri, hayran topluluğu veya ortak tutkudur.",
+    "empty": "Şu anda müsait oda yok. Daha sonra tekrar kontrol edin!",
+    "jumpToActive": "Aktif odaları görün",
+    "jumpToTopics": "Konuya göre göz atın",
+    "statsLabel": "Oda dizininde öne çıkanlar",
+    "liveNow": "Şu anda aktif",
+    "recentlyActive": "Yakın Zamanda Aktif",
+    "recentlyActiveSubtitle": "Şu anda içinde insanların olduğu bir odayı bulmanın en hızlı yolu.",
+    "browseByTopic": "Konuya göre göz atın",
+    "topicSubtitle": "Odalarını keşfetmek için bir konu açın.",
+    "roomCount": "{count} oda",
+    "stats": {
+      "rooms": "keşfedilecek odalar",
+      "topics": "konu grupları",
+      "active": "aktif seçimler"
+    },
+    "activeUsers": "Aktif Kullanıcılar: {count}",
+    "visitRoom": "Odayı Ziyaret Et",
+    "close": "Kapat",
+    "noTitle": "Başlık Mevcut Değil",
+    "noDescription": "Açıklama Mevcut Değil"
+  }
+}

--- a/i18n/tr/search.json
+++ b/i18n/tr/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Ara",
+      "description": "Herkese açık gönderileri arayın."
+    },
+    "title": "Ara",
+    "placeholder": "Gönderilerde ara...",
+    "hint": "Arama yapmak için en az 2 karakter yazın.",
+    "noResults": "Sonuç bulunamadı.",
+    "untitled": "İsimsiz",
+    "votesTitle": "Oylar",
+    "pageLabel": "Sayfa",
+    "filters": {
+      "inRoom": "Odada"
+    },
+    "buttons": {
+      "search": "Ara",
+      "prev": "Önceki",
+      "next": "Sonraki"
+    }
+  }
+}

--- a/i18n/tr/signup.json
+++ b/i18n/tr/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Bir hesap oluşturun",
+      "description": "Tüm özelliklere erişmek için Daily Page'ye kaydolun."
+    },
+    "header": {
+      "title": "Hesabınızı Oluşturun",
+      "subtitle": "Günlük yazılarınızı oluşturmaya ve paylaşmaya başlamak için Daily Page'ye katılın!"
+    },
+    "form": {
+      "email": {
+        "label": "E-posta",
+        "placeholder": "E-postanızı girin"
+      },
+      "username": {
+        "label": "Kullanıcı adı",
+        "placeholder": "Kullanıcı adınızı girin"
+      },
+      "password": {
+        "label": "Şifre",
+        "placeholder": "Bir şifre girin"
+      },
+      "submit": "Kaydol",
+      "feedback": {
+        "success": "Form gönderimi başarılı!",
+        "successCreatedVerify": "Hesap başarıyla oluşturuldu! Hesabınızı doğrulamak için lütfen e-postanızı kontrol edin.",
+        "genericError": "Hesap oluşturulamadı. Lütfen tekrar deneyin.",
+        "unexpectedError": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+      }
+    }
+  }
+}

--- a/i18n/tr/starredRooms.json
+++ b/i18n/tr/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Tüm Yıldızlı Odalar",
+      "description": "Yıldız eklediğiniz tüm odaların listesi."
+    },
+    "nav": {
+      "backToDashboard": "← Kontrol Paneli'e geri dön"
+    },
+    "header": {
+      "title": "🌟 Tüm Yıldızlı Odalarınız 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "İsimsiz Oda",
+      "noDescription": "Açıklama yok."
+    },
+    "empty": {
+      "message": "Henüz hiçbir odaya yıldız eklemediniz!"
+    }
+  }
+}

--- a/i18n/tr/support.json
+++ b/i18n/tr/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Destek",
+      "description": "Nasıl iletişime geçilir, sorunlar bildirilir, özellikler veya odalar talep edilir ve Daily Page'ye finansal olarak nasıl destek verilir?"
+    },
+    "contact": {
+      "h1": "★ Bir soru sormak, bir sorun bildirmek veya bir özellik talep etmek istiyorum.",
+      "p1": {
+        "before": "GitHub'u kullanmayı tercih ediyorsanız lütfen kontrol edin",
+        "link": "bu projenin sorunlar sayfasını",
+        "after": "ve görüşünüzü ekleyin. Pull request'ler de elbette memnuniyetle karşılanır."
+      },
+      "p2": {
+        "before": "Alternatif olarak,",
+        "link": "e-posta gönder",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Bu projeye katkıda bulunarak destek olmak istiyorum.",
+      "p1": {
+        "before": "Bu projeye fon sağladığınız için şimdiden teşekkür ederiz. Lütfen ödemeleri güvenli bir şekilde gönderin",
+        "paypal": "PayPal",
+        "middle": "veya isterseniz,",
+        "amazon": "Amazon'da sattığım oyuncaklardan birkaç paket sipariş edin",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Yeni bir oda talep etmek istiyorum.",
+      "form": {
+        "nameLabel": "Oda Adı",
+        "topicLabel": "Konu (isteğe bağlı)",
+        "descriptionLabel": "Açıklama",
+        "submit": "Talebi Gönder",
+        "success": "İstek başarıyla gönderildi!",
+        "errorGeneric": "İstek gönderilemedi. Lütfen tekrar deneyin.",
+        "errorUnexpected": "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin."
+      }
+    }
+  }
+}

--- a/i18n/tr/tags.json
+++ b/i18n/tr/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Etiketlere Genel Bakış",
+      "description": "Zamana göre hızlı filtrelerle Daily Page'de kullanılan tüm etiketlere göz atın."
+    },
+    "title": "Etiketlere Genel Bakış",
+    "intro": "Daily Page'de kullanılan tüm etiketleri keşfedin.",
+    "tagCloudTitle": "Etiket Bulutu",
+    "timeframe": {
+      "last24h": "Son 24 Saat",
+      "last7d": "Son 7 Gün",
+      "last30d": "Son 30 Gün",
+      "all": "Tüm Zamanlar"
+    },
+    "error": {
+      "loading": "Etiketlere genel bakış yüklenirken hata oluştu"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": "| Daily Page",
+        "description": "ile etiketlenen gönderiler"
+      },
+      "header": {
+        "label": "Etiket:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Toplam gönderiler",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Oluşturan:",
+        "inRoom": "içinde",
+        "unknownRoom": "Bilinmeyen Oda",
+        "onDate": "tarihinde"
+      },
+      "chart": {
+        "label": "Zaman İçinde Oluşturulan Gönderiler"
+      },
+      "empty": {
+        "message": "Henüz bu etikete sahip gönderi bulunamadı. Belki de ilkini siz oluşturmalısınız? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Etiket sayfası yüklenirken hata oluştu"
+      }
+    }
+  }
+}

--- a/i18n/tr/translation.json
+++ b/i18n/tr/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Çeviri dili:",
+    "see": "bkz.",
+    "originalBlock": "orijinal gönderi"
+  }
+}

--- a/i18n/tr/userBlocks.json
+++ b/i18n/tr/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Gönderileriniz",
+      "description": "Oluşturduğunuz veya üzerinde ortak çalışma yaptığınız tüm gönderilere göz atın ve bunları sıralayın."
+    },
+    "header": {
+      "dashboardLink": "Kontrol Paneliniz",
+      "profileLink": "{username} Profili",
+      "allBlocks": "Tüm Gönderiler"
+    },
+    "empty": "Henüz gönderi yok.",
+    "pagination": {
+      "prev": "← Önceki",
+      "next": "Sonraki →"
+    },
+    "titleUser": "{username}'in Gönderileri"
+  }
+}

--- a/i18n/tr/verifyEmail.json
+++ b/i18n/tr/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "E-postayı Doğrula",
+      "description": "Daily Page için e-posta adresinizi doğrulayın."
+    },
+    "header": {
+      "title": "E-postanız doğrulanıyor..."
+    },
+    "status": {
+      "checking": "Jeton kontrol ediliyor, lütfen bekleyin...",
+      "missingToken": "Doğrulama jetonu eksik veya geçersiz.",
+      "genericFailure": "Doğrulama başarısız oldu.",
+      "unexpectedError": "Beklenmeyen bir hata oluştu.",
+      "success": "Hesabınız başarıyla doğrulandı!",
+      "invalidOrExpired": "Geçersiz veya süresi dolmuş doğrulama jetonu."
+    },
+    "verificationMsg": {
+      "subject": "Daily Page hesabınızı doğrulayın ✨",
+      "heading": "Daily Page, {username}'ye hoş geldiniz!",
+      "body": "Lütfen aşağıya tıklayarak e-postanızı doğrulayın:",
+      "cta": "E-posta Adresini Doğrulayın",
+      "expires": "Bu bağlantının süresi {hours} saat içinde doluyor."
+    }
+  }
+}

--- a/i18n/tr/voteControls.json
+++ b/i18n/tr/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Olumlu oy ver",
+    "downvote": "Olumsuz oy",
+    "errors": {
+      "failed": "Oyunuz kaydedilemedi."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -74,4 +74,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'ko' }).catch(console.error), 6_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'ar' }).catch(console.error), 6_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'hi' }).catch(console.error), 7_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'tr' }).catch(console.error), 7_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

Adds complete Turkish (`tr`) UI localization, using English as the source of truth.

## Changes

- Added Turkish translations for all 40 English locale JSON files
- Registered `tr` as a fully supported UI language
- Added Turkish to hreflang output, notification emails, and homepage cache warming
- Reviewed hard-coded UI text outside `i18n/`
- Left DB-backed room name and description translations unchanged

## Validation

- Confirmed Turkish matches English file-for-file and key-for-key
- Confirmed interpolation placeholders and HTML tags are preserved
- Parsed all 560 locale JSON files successfully
- Verified the Turkish translator loads at runtime
- Ran `npm test`: 279 specs passed

## Notes

The legacy iPod/audio-player interface still contains hard-coded English and should be localized separately.

Full-project lint still reports 16 unrelated pre-existing errors.