### PR TITLE
feat(i18n): add full Dutch UI support

### DIFF
--- a/i18n/nl/about.json
+++ b/i18n/nl/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page - Over",
+      "description": "Wat Daily Page is, hoe het werkt en waarom het is gebouwd als een langzamere, vriendelijkere hoek van het internet."
+    },
+    "title": "Over Daily Page",
+    "tagline": "Voed je geest, niet je feed.",
+    "mission": {
+      "h2": "Missie",
+      "p1": "Een indie-schrijflab – begonnen in mijn woonkamer, aangewakkerd door de nieuwsgierigheid van lezers.",
+      "p2": "Het is niet gebouwd om je hersenen te rotten, maar om het te voeden: een plek waar je langzaam kunt schrijven, anoniem als je wilt, en je nooit zorgen hoeft te maken dat je indruk op iemand maakt."
+    },
+    "how": {
+      "h2": "Hoe het werkt",
+      "features": {
+        "rooms": {
+          "label": "Kamers",
+          "text": "zijn topic-silo’s (denk aan “subreddit, maar vriendelijker”)."
+        },
+        "blocks": {
+          "label": "Berichten",
+          "text": "zijn gezamenlijke schrijfruimtes: iedereen (zelfs ‘anoniem’) kan er een maken, deze bewerken totdat deze is vergrendeld, en op anderen stemmen."
+        },
+        "privacy": {
+          "label": "Privacy en delen",
+          "text": "betekent dat openbare berichten live in de feed van de kamer staan. Verborgen concepten worden verborgen totdat ze worden vergrendeld, maar u krijgt een deellink waarmee u vrienden kunt uitnodigen."
+        },
+        "markdown": {
+          "label": "Markdown en media",
+          "text": "Hiermee kunt u in Markdown schrijven, afbeeldingen insluiten en samen bewerken zoals in Google Documenten."
+        },
+        "trends": {
+          "label": "Trends & Tags",
+          "text": "hiermee kunt u uw bericht taggen, tagtrends volgen en topinhoud ontdekken (7 d / 30 d / altijd)."
+        },
+        "streaks": {
+          "label": "Schrijfreeksen",
+          "text": "houd uw dagelijkse schrijfreeks levend - uw beste stimulans om elke dag te verschijnen."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Hoe we hier zijn gekomen",
+      "p1": "In 2018 bouwde ik een op datum gebaseerde wiki voor ‘de pagina van vandaag’ en zag hoe een paar introspectieve schrijvers er een uitlaatklep voor hun gedachten van maakten. Het werd nooit groot, maar het plantte wel een zaadje.",
+      "p2": "Snel vooruit naar nu, en Daily Page is dat zaad dat in veel kamers is gegroeid: een rustig sociaal web voor introverte mensen, idealisten en iedereen die zin heeft in een langzamer tempo."
+    },
+    "next": {
+      "h2": "Wat is het volgende",
+      "p1": "We zijn nog maar net begonnen: rijkere insluitingen, diepere gebruikersstatistieken, reputatiescoreborden en meer manieren om doordachte creaties te belonen.",
+      "p2": "Bedankt dat je deel uitmaakt van dit kleine indie-experiment."
+    },
+    "cta": {
+      "rooms": "Ontdek kamers",
+      "signup": "Sluit u aan bij de gemeenschap"
+    }
+  }
+}

--- a/i18n/nl/accountSecurity.json
+++ b/i18n/nl/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Accountbeveiliging",
+      "description": "Beheer uw Daily Page-wachtwoord en tweefactorauthenticatie."
+    },
+    "backToDashboard": "Terug naar dashboard",
+    "heading": "Accountbeveiliging",
+    "subheading": "Houd uw account beveiligd met een sterk wachtwoord en een authenticator-app.",
+    "password": {
+      "title": "Wachtwoord wijzigen",
+      "description": "Gebruik een uniek wachtwoord van minimaal 8 tekens.",
+      "current": {
+        "label": "Huidig ​​wachtwoord"
+      },
+      "new": {
+        "label": "Nieuw wachtwoord"
+      },
+      "submit": "Wachtwoord bijwerken"
+    },
+    "twoFactor": {
+      "title": "Tweefactorauthenticatie",
+      "statusOn": "Ingeschakeld",
+      "statusOff": "Uit",
+      "description": "Voeg een eenmalige code uit een authenticator-app toe na uw wachtwoord wanneer u inlogt.",
+      "currentPassword": {
+        "label": "Huidig ​​wachtwoord"
+      },
+      "startSetup": "Authenticator-app instellen",
+      "qrAlt": "QR-code van Authenticator-app",
+      "manualKey": "Handmatige instelsleutel",
+      "code": {
+        "label": "6-cijferige code"
+      },
+      "enable": "Schakel 2FA in",
+      "disableCode": {
+        "label": "Authenticatiecode"
+      },
+      "disable": "Schakel 2FA uit"
+    },
+    "recoveryCodes": {
+      "title": "Bewaar uw herstelcodes",
+      "description": "Gebruik een van deze eenmalige codes om in te loggen als u de toegang tot uw authenticator-app kwijtraakt.",
+      "regenerateDescription": "Genereer een nieuwe set herstelcodes als u de vorige set bent kwijtgeraakt. Hierdoor worden eventuele oude herstelcodes ongeldig.",
+      "regenerate": "Genereer nieuwe herstelcodes",
+      "warning": "Bewaar ze op een veilige plek. Ze zullen niet meer getoond worden."
+    },
+    "feedback": {
+      "passwordChanged": "Uw wachtwoord is bijgewerkt.",
+      "setupReady": "Scan de QR-code en voer vervolgens de 6-cijferige code in om de installatie te voltooien.",
+      "twoFactorEnabled": "Tweefactorauthenticatie is nu ingeschakeld.",
+      "twoFactorDisabled": "Tweefactorauthenticatie is nu uitgeschakeld.",
+      "recoveryCodesRegenerated": "Uw herstelcodes zijn opnieuw gegenereerd. Sla de nieuwe codes nu op.",
+      "missingFields": "Vul alle verplichte velden in.",
+      "missingCurrentPassword": "Voer uw huidige wachtwoord in om door te gaan.",
+      "passwordTooShort": "Uw nieuwe wachtwoord moet minimaal 8 tekens lang zijn.",
+      "invalidCurrentPassword": "Het huidige wachtwoord kwam niet overeen.",
+      "missingCode": "Voer de 6-cijferige code uit uw authenticator-app in.",
+      "invalidCode": "Die code werkte niet. Probeer het opnieuw.",
+      "noPendingSetup": "Begin opnieuw met instellen voordat u een code invoert.",
+      "setupExpired": "Die installatiesessie is verlopen. Begin opnieuw met instellen en ontvang een nieuwe QR-code.",
+      "twoFactorNotEnabled": "Tweefactorauthenticatie is niet ingeschakeld voor dit account.",
+      "genericError": "Er is iets misgegaan. Probeer het opnieuw.",
+      "unexpectedError": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+    }
+  }
+}

--- a/i18n/nl/anonymousUser.json
+++ b/i18n/nl/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "De anonieme wandelaar",
+      "description": "Geen profiel. Geen verleden. Gewoon vibraties."
+    },
+    "ascii": {
+      "ariaLabel": "ASCII-kunst van een grillig wezen met citaat"
+    },
+    "header": {
+      "title": "De anonieme"
+    },
+    "body": {
+      "line1": "Je bent in de leegte gestruikeld. Er is hier niets te zien...",
+      "line2": "gewoon een dwalende geest zonder verhaal."
+    },
+    "buttons": {
+      "home": "← Terug naar huis",
+      "signup": "Creëer een identiteit"
+    }
+  }
+}

--- a/i18n/nl/archive.json
+++ b/i18n/nl/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Archief",
+      "description": "Ontdek het volledige archief per maand.",
+      "titleRoom": "Daily Page — Archief · {roomName}",
+      "descriptionRoom": "Ontdek eerdere schrijfsels in de {roomName}-kamer, maand na maand. Ga naar een willekeurige datum om te zien wat anderen in de loop van de tijd in deze ruimte hebben gedeeld."
+    },
+    "nav": {
+      "prev": "Vorig",
+      "next": "Volgende"
+    },
+    "title": "📚 Blader door archieven",
+    "titleRoom": "📚 {roomName} — Archief",
+    "roomViewing": "Archief voor kamer {roomName} bekijken",
+    "viewRoomLink": "Kamer bekijken",
+    "noContent": "Nog geen inhoud beschikbaar.",
+    "backToRoom": "← Terug naar kamerdashboard",
+    "calendar": {
+      "meta": {
+        "description": "Bekijk alle creatieve berichten die zijn gepubliceerd in {month} {year} – van snelle gedachten tot diepe reflecties. Klik op een datum om te zien wat er is gedeeld.",
+        "descriptionRoom": "Bekijk de creatieve activiteit in {roomName} tijdens {month} {year}. Kies een datum om de berichten te bekijken die die dag zijn gedeeld."
+      },
+      "title": "📆 Archief voor {month} {year}",
+      "prevLabel": "Archief voor {month} {year}",
+      "nextLabel": "Archief voor {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Archief voor {date}",
+        "titleRoom": "{roomName} — Archief voor {date}",
+        "descriptionSite": "Ontdek de berichten die op {date} zijn geschreven, van stille notities tot wilde bekentenissen.",
+        "descriptionRoom": "Op {date} hebben schrijvers in de {roomName}-kamer hun sporen nagelaten: blader door reflecties, ideeën en uitdrukkingen die die dag zijn gedeeld."
+      },
+      "heading": "Archief voor {date}",
+      "empty": "Er is geen inhoud gevonden voor deze datum.",
+      "labels": {
+        "createdBy": "Gemaakt door:",
+        "in": "in",
+        "on": "op {datetime}",
+        "unknownRoom": "Onbekende kamer"
+      },
+      "nav": {
+        "prevDay": "Vorige dag",
+        "nextDay": "Volgende dag"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Alle berichten",
+        "descriptionRoom": "Blader door elk bericht dat ooit in de {roomName}-ruimte is gepubliceerd. Sorteer op datum, titel of stemmen om de geschiedenis ervan te verkennen."
+      },
+      "header": {
+        "allBlocks": "— Alle berichten"
+      },
+      "sort": {
+        "label": "Sorteer op",
+        "options": {
+          "date": "Datum",
+          "title": "Titel",
+          "votes": "Stemmen"
+        },
+        "submit": "Gaan"
+      }
+    },
+    "pagination": {
+      "prev": "← Vorige",
+      "next": "Volgende →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daily Pages voor {time}"
+      },
+      "empty": "We konden gedurende die periode geen pagina's vinden."
+    }
+  }
+}

--- a/i18n/nl/auth.json
+++ b/i18n/nl/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page - Inloggen",
+        "description": "Log in op uw Daily Page-account om uw schrijfreis voort te zetten."
+      },
+      "heading": "Welkom terug!",
+      "subheading": "Log in op uw account om uw dagelijkse schrijfsels te blijven delen.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Gebruikersnaam of e-mailadres",
+          "placeholder": "Voer uw gebruikersnaam of e-mailadres in"
+        },
+        "password": {
+          "label": "Wachtwoord",
+          "placeholder": "Voer uw wachtwoord in"
+        },
+        "totpCode": {
+          "label": "Authenticator- of herstelcode",
+          "placeholder": "Voer code in"
+        }
+      },
+      "actions": {
+        "submit": "Inloggen"
+      },
+      "feedback": {
+        "success": "Inloggen succesvol! Omleiden...",
+        "twoFactorRequired": "Voer de 6-cijferige code uit uw authenticator-app in, of gebruik een herstelcode.",
+        "twoFactorFailed": "Die code werkte niet. Probeer het opnieuw.",
+        "failedGeneric": "Inloggen mislukt. Probeer het opnieuw.",
+        "unexpected": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+      },
+      "links": {
+        "forgotPassword": "Wachtwoord vergeten?",
+        "noAccount": "Heeft u nog geen account?",
+        "signupHere": "Schrijf je hier in!"
+      }
+    }
+  }
+}

--- a/i18n/nl/bestOf.json
+++ b/i18n/nl/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Het beste van Daily Page",
+      "description": "De meest geliefde berichten op Daily Page: grappig, eerlijk, poëtisch of gewoon raar. Bekijk wat er de afgelopen dag, week, maand en daarna opviel.",
+      "titleRoom": "Het beste van {roomName}",
+      "descriptionRoom": "Ontdek opvallende berichten uit de {roomName}-ruimte, de berichten waar lezers de afgelopen 24 uur, 7 dagen, 30 dagen en altijd het meest van genoten."
+    },
+    "heading": "🏆 Het beste van Daily Page",
+    "headingRoomPrefix": "🏆 Het beste van",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 uur",
+      "7d": "🚀 7 dagen",
+      "30d": "🌕 30 dagen",
+      "all": "👑 Altijd"
+    },
+    "labels": {
+      "createdBy": "Gemaakt door:",
+      "inRoom": "in",
+      "onDate": "op {date}",
+      "unknownRoom": "Onbekende kamer",
+      "noBlocks": "Geen berichten gevonden.",
+      "viewRoom": "Kamer bekijken"
+    }
+  }
+}

--- a/i18n/nl/blockCommon.json
+++ b/i18n/nl/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Voorlopige versie"
+    },
+    "deleteModal": {
+      "title": "Bericht verwijderen?",
+      "message": "Deze actie kan niet ongedaan worden gemaakt.",
+      "confirm": "Verwijderen",
+      "cancel": "Annuleren",
+      "closeAriaLabel": "Dichtbij"
+    },
+    "toasts": {
+      "deleteSuccess": "Bericht succesvol verwijderd!",
+      "deleteFailed": "Kan bericht niet verwijderen."
+    }
+  }
+}

--- a/i18n/nl/blockEditor.json
+++ b/i18n/nl/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Jij)"
+    },
+    "meta": {
+      "title": "Bericht bewerken - {blockTitle}",
+      "titleFallback": "Bewerk bericht"
+    },
+    "errors": {
+      "imageUrlRequired": "Voer een afbeeldings-URL in.",
+      "notFound": "Bericht niet gevonden of hoort niet bij deze kamer.",
+      "loadFailed": "Er is een fout opgetreden bij het laden van de berichteditor.",
+      "updateTitleFailed": "Fout bij updaten van titel."
+    },
+    "roomInfo": {
+      "label": "Kamer:"
+    },
+    "title": {
+      "placeholder": "Voer de berichttitel in",
+      "editTooltip": "Titel bewerken",
+      "lock": "Bericht vergrendelen",
+      "delete": "Bericht verwijderen"
+    },
+    "description": {
+      "label": "Beschrijving",
+      "editTooltip": "Beschrijving bewerken",
+      "placeholder": "Voer een beschrijving in",
+      "noDescriptionOwner": "Nog geen beschrijving...",
+      "noDescriptionViewer": "Er is geen beschrijving opgegeven...",
+      "save": "Opslaan",
+      "cancel": "Annuleren",
+      "expand": "Uitbreiden",
+      "collapse": "Inklappen",
+      "updateError": "Fout bij updaten van beschrijving."
+    },
+    "status": {
+      "lastBackup": "Laatste back-up: {datetime}",
+      "lastBackupUnknown": "Laatste back-up: onbekend"
+    },
+    "peers": {
+      "label": "Leeftijdsgenoten:"
+    },
+    "toasts": {
+      "blockLocked": "Dit bericht is vergrendeld!"
+    },
+    "editor": {
+      "placeholder": "De blanco pagina wacht op jouw stem; schrijf onbevreesd."
+    },
+    "loading": {
+      "label": "Laden",
+      "quote": "Laat de wereld door je heen branden. Gooi het prismalicht, witgloeiend, op papier.<br> – Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Je hebt al 5 minuten niets geschreven. Klik op OK om de sessie voort te zetten; anders wordt u doorgestuurd naar het archief.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link delen",
+      "copyTooltip": "Kopiëren naar Klembord",
+      "copied": "Gekopieerd!"
+    },
+    "toolbar": {
+      "insertImage": "Afbeelding invoegen",
+      "insertImageUrlPlaceholder": "Voer de afbeeldings-URL in",
+      "insertImageAltPlaceholder": "Alt-tekst (optioneel)",
+      "insertImageConfirm": "Bevestigen",
+      "insertImageCancel": "Annuleren"
+    },
+    "buttons": {
+      "downloadFile": "Bestand downloaden"
+    },
+    "lockModal": {
+      "messageLine1": "Weet je zeker dat je dit bericht wilt vergrendelen?",
+      "messageLine2": "Hierdoor wordt het definitief gemaakt en wordt verdere bewerking voorkomen.",
+      "confirm": "Slot",
+      "cancel": "Annuleren",
+      "successToast": "Bericht vergrendeld.",
+      "errorToast": "Fout bij vergrendelen van bericht."
+    },
+    "tags": {
+      "headerWithTags": "Tags:",
+      "headerNoTags": "Nog geen tags! Voeg wat toe:",
+      "updateError": "Fout bij updaten van tags."
+    },
+    "fullBlock": {
+      "headingPrefix": "Sorry; het bericht \"{blockTitle}\" is nu",
+      "headingStatus": "volledig bezet.",
+      "retryPrefix": "Alsjeblieft",
+      "retryLink": "probeer een ander bericht",
+      "retrySuffix": "of kom een ​​andere keer terug.",
+      "consolationPrefix": "Terwijl u wacht, kunt u gerust lezen",
+      "consolationBestOf": "enkele van onze favoriete berichten",
+      "consolationMiddle": "of om te bladeren",
+      "consolationArchive": "het archief."
+    }
+  }
+}

--- a/i18n/nl/blockList.json
+++ b/i18n/nl/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "alle tijd",
+      "days": "in de afgelopen {n} dagen",
+      "day": "in de afgelopen 24 uur"
+    },
+    "createdBy": "Gemaakt door:",
+    "on": "op"
+  }
+}

--- a/i18n/nl/blockTags.json
+++ b/i18n/nl/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tags:",
+      "noTags": "Nog geen tags! Voeg wat toe:"
+    },
+    "input": {
+      "placeholder": "Nieuw label",
+      "addButton": "Toevoegen"
+    },
+    "buttons": {
+      "removeTag": "X"
+    }
+  }
+}

--- a/i18n/nl/blockView.json
+++ b/i18n/nl/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Bericht - {blockTitle}",
+      "titleFallback": "Bericht"
+    },
+    "labels": {
+      "room": "Kamer",
+      "author": "Auteur",
+      "created": "Gemaakt",
+      "unknownAuthor": "Anoniem",
+      "authorAvatarAlt": "De avatar van {username}",
+      "viewAuthorProfile": "Bekijk het profiel van {username}",
+      "lang": "Vertalingen:",
+      "available": "beschikbaar"
+    },
+    "buttons": {
+      "edit": "Bewerken",
+      "deleteBlock": "Bericht verwijderen",
+      "share": "Deel",
+      "flagContent": "Markeer inhoud"
+    },
+    "description": {
+      "label": "Beschrijving",
+      "none": "Er is geen beschrijving opgegeven...",
+      "expand": "Uitbreiden",
+      "collapse": "Inklappen"
+    },
+    "editorial": {
+      "heading": "Leesgids",
+      "roleLabel": "Leestype",
+      "clusterLabel": "Gids",
+      "sequence": "Onderdeel {sequence}",
+      "primaryPillarHeading": "Begin hier",
+      "relatedHeading": "Blijf lezen",
+      "clusterHeading": "Meer in deze gids",
+      "expandSection": "Laat {count} meer zien",
+      "collapseSection": "Laat minder zien",
+      "roleNames": {
+        "pillar": "Kern gids",
+        "companion": "Diepe duik",
+        "texture": "Achtergrond"
+      }
+    },
+    "comments": {
+      "heading": "Opmerkingen",
+      "count": "{count} opmerkingen",
+      "empty": "Er heeft nog niemand gereageerd. Opmerkingen worden hier weergegeven wanneer het gesprek begint.",
+      "composer": {
+        "label": "Voeg een opmerking toe",
+        "placeholder": "Schrijf een reactie...",
+        "submit": "Reactie plaatsen",
+        "submitting": "Posten...",
+        "success": "Reactie geplaatst.",
+        "error": "Kan uw reactie momenteel niet plaatsen.",
+        "loginPrompt": "Log in om deel te nemen aan het gesprek.",
+        "loginCta": "Log in om commentaar te geven",
+        "verifyPrompt": "Verifieer uw e-mailadres voordat u een reactie plaatst.",
+        "verifyCta": "E-mail verifiëren"
+      },
+      "sort": {
+        "label": "Sorteren",
+        "oldestFirst": "Oudste eerst",
+        "newestFirst": "Nieuwste eerst"
+      },
+      "by": "Door",
+      "unknownAuthor": "Onbekend",
+      "reply": {
+        "action": "Antwoord",
+        "label": "Voeg een antwoord toe",
+        "placeholder": "Schrijf een antwoord...",
+        "submit": "Antwoord plaatsen",
+        "submitting": "Posten...",
+        "success": "Reactie geplaatst.",
+        "error": "Kan uw antwoord momenteel niet plaatsen.",
+        "cancel": "Annuleren",
+        "loginPrompt": "Log in om te reageren."
+      },
+      "manage": {
+        "edited": "Bewerkt",
+        "editAction": "Bewerken",
+        "deleteAction": "Verwijderen",
+        "deleteConfirm": "Deze reactie verwijderen? Hiermee worden ook alle antwoorden eronder verwijderd.",
+        "deleteSuccess": "Reactie verwijderd.",
+        "deleteError": "Kan deze reactie momenteel niet verwijderen.",
+        "forbidden": "U kunt alleen uw eigen opmerkingen beheren.",
+        "edit": {
+          "label": "Opmerking bewerken",
+          "save": "Opslaan",
+          "saving": "Opslaan...",
+          "cancel": "Annuleren",
+          "success": "Reactie bijgewerkt.",
+          "error": "Kan deze reactie momenteel niet bijwerken."
+        }
+      },
+      "report": {
+        "action": "Melden",
+        "pending": "Melden...",
+        "success": "Commentaar gerapporteerd.",
+        "error": "Kan deze reactie momenteel niet rapporteren.",
+        "ownError": "U kunt uw eigen reactie niet rapporteren.",
+        "hidden": "Commentaar verborgen na rapport.",
+        "reported": "Gerapporteerd"
+      },
+      "deepLink": {
+        "focused": "Gelinkte opmerking",
+        "unavailable": "De gekoppelde reactie is niet langer beschikbaar."
+      },
+      "loadMore": "Laad meer reacties",
+      "loading": "Laden...",
+      "loadError": "Kan momenteel niet meer reacties laden."
+    },
+    "share": {
+      "title": "Deel dit bericht",
+      "shareOn": "Deel op:",
+      "nativeText": "Bekijk dit bericht: {title}",
+      "alt": {
+        "facebook": "Facebook-logo",
+        "reddit": "Reddit-logo",
+        "whatsapp": "WhatsApp-logo",
+        "twitter": "Twitter-logo"
+      }
+    },
+    "errors": {
+      "notFound": "Bericht niet gevonden of hoort niet bij deze kamer.",
+      "loadFailed": "Fout bij het laden van berichtweergave."
+    }
+  }
+}

--- a/i18n/nl/createBlock.json
+++ b/i18n/nl/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Maak een nieuw bericht - Daily Page",
+      "description": "Start een nieuwe creatieve post met optionele tags, taal en zichtbaarheid."
+    },
+    "heading": "Maak een nieuw bericht",
+    "roomInfo": {
+      "roomLabel": "Kamer:",
+      "unavailable": "Kamerinformatie niet beschikbaar.",
+      "noDescription": "Geen beschrijving beschikbaar."
+    },
+    "form": {
+      "title": {
+        "label": "Titel:",
+        "placeholder": {
+          "full": "bijv. 'Mijn meesterwerk', 'Het beste idee ooit', 'Clickbait voor nerds'",
+          "short": "bijv. 'Mijn meesterwerk'"
+        }
+      },
+      "description": {
+        "label": "Beschrijving (optioneel):",
+        "placeholder": "Leg je genialiteit uit... of doe er gewoon mee."
+      },
+      "initialContent": {
+        "label": "Initiële inhoud (optioneel):",
+        "help": "Begin hier met schrijven of druk op 'Maken' om door te gaan naar de volledige editorpagina, waar u afbeeldingen kunt insluiten en in realtime kunt samenwerken.",
+        "placeholder": "Begin hier met je bericht, of ga door met bewerken nadat het is gemaakt..."
+      },
+      "visibility": {
+        "label": "Zichtbaarheid:"
+      },
+      "submit": "Bericht maken"
+    },
+    "visibility": {
+      "public": {
+        "label": "Openbaar",
+        "title": "Kan door iedereen in realtime worden bewerkt. Geen login nodig.",
+        "inline": "Kan door iedereen in realtime worden bewerkt. Geen login nodig."
+      },
+      "unlisted": {
+        "label": "Niet-beursgenoteerd concept",
+        "title": "Verborgen voor openbaar browsen terwijl het bewerkbaar is. Zichtbaar na vergrendeling.",
+        "inline": "Verborgen voor openbaar browsen terwijl het bewerkbaar is. Zichtbaar na vergrendeling.",
+        "tooltip": "Verborgen concepten zijn verborgen voor openbaar browsen, terwijl ze wel kunnen worden bewerkt. Iedereen met de link kan samenwerken en het bericht wordt openbaar wanneer het is vergrendeld."
+      }
+    },
+    "advanced": {
+      "summary": "Geavanceerde opties",
+      "lang": {
+        "label": "Taal:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Vertaal bestaand bericht (URL of ID):",
+        "placeholder": "Plak een bericht-URL of ID (optioneel)",
+        "invalid": "Dat lijkt niet op een geldige bericht-URL of ID.",
+        "fetchError": "Kan berichtinformatie niet ophalen."
+      }
+    },
+    "messages": {
+      "langExists": "Er bestaat al een vertaling voor die taal. Kies een andere taal.",
+      "genericError": "Er is iets misgegaan. Probeer het opnieuw."
+    }
+  }
+}

--- a/i18n/nl/dashboard.json
+++ b/i18n/nl/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Dashboard",
+      "description": "Uw Daily Page-dashboard en accountoverzicht."
+    },
+    "profile": {
+      "profilePicAlt": "Profielfoto",
+      "noBio": "Nog geen biografie. Klik op \"Bewerken\" om er een toe te voegen!",
+      "editBio": "Biografie bewerken",
+      "bioPlaceholder": "Vul hier uw biografie in",
+      "save": "Opslaan",
+      "cancel": "Annuleren"
+    },
+    "activity": {
+      "title": "Recente activiteit",
+      "none": "Geen recente activiteit.",
+      "updatedOn": "Bijgewerkt op {date}",
+      "viewAllBlocks": "Bekijk alle berichten"
+    },
+    "drafts": {
+      "title": "Ga door met schrijven",
+      "none": "Geen open concepten.",
+      "updatedOn": "Bijgewerkt op {date}",
+      "unlisted": "Niet vermeld",
+      "viewAll": "Bekijk alle berichten"
+    },
+    "streak": {
+      "title": "Schrijfstrook",
+      "line": "{days} dagen op rij! Blijf doorgaan!"
+    },
+    "starredRooms": {
+      "title": "Kamers met ster",
+      "none": "Je hebt nog geen kamers met een ster gemarkeerd. Begin met verkennen om je favorieten te vinden!",
+      "viewAll": "Bekijk alle kamers met sterren",
+      "unnamedRoom": "Naamloze kamer"
+    },
+    "security": {
+      "title": "Accountbeveiliging",
+      "summary": "Wijzig uw wachtwoord en beheer tweefactorauthenticatie.",
+      "manage": "Beheer beveiliging"
+    },
+    "stats": {
+      "title": "Jouw statistieken",
+      "totalBlocks": "Totaal aantal berichten gemaakt",
+      "collaborations": "Samenwerkingen",
+      "votesGiven": "Stemmen gegeven",
+      "daysActive": "Dagen actief",
+      "viewDetailed": "Bekijk gedetailleerde statistieken 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Kan profielfoto niet uploaden. Probeer het opnieuw.",
+      "uploadUnexpected": "Er is een onverwachte fout opgetreden. Probeer het opnieuw.",
+      "bioUpdateFailed": "Fout bij updaten biografie. Probeer het opnieuw."
+    }
+  }
+}

--- a/i18n/nl/detailedStats.json
+++ b/i18n/nl/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Gedetailleerde statistieken",
+      "description": "Een gedetailleerd overzicht van uw Daily Page-activiteit."
+    },
+    "nav": {
+      "backToDashboard": "← Terug naar Dashboard"
+    },
+    "header": {
+      "title": "📊 Uw statistiekenoverzicht 📊"
+    },
+    "cards": {
+      "totalBlocks": "Totaal aantal berichten gemaakt 📝",
+      "collaborations": "Samenwerkingen 🤝",
+      "votesGiven": "Stemmen gegeven 👍",
+      "daysActive": "Dagen actief 📆"
+    },
+    "chart": {
+      "datasetLabel": "Jouw statistieken",
+      "labels": {
+        "blocksCreated": "Berichten gemaakt",
+        "collaborations": "Samenwerkingen",
+        "votesGiven": "Stemmen gegeven",
+        "daysActive": "Dagen actief"
+      }
+    }
+  }
+}

--- a/i18n/nl/errors.json
+++ b/i18n/nl/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Oeps! Er is iets misgegaan.",
+      "message": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw.",
+      "home": "Terug naar Thuis"
+    },
+    "notFound": {
+      "title": "404 - Pagina niet gevonden",
+      "metaTitle": "Pagina niet gevonden",
+      "message": "Sorry, we konden de pagina die u zocht niet vinden.",
+      "homePrefix": "Je kunt teruggaan naar",
+      "homeLink": "de startpagina",
+      "roomsPrefix": "of bekijk de",
+      "roomsLink": "kamers map."
+    }
+  }
+}

--- a/i18n/nl/flagModal.json
+++ b/i18n/nl/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Rapporteer ongepaste inhoud",
+    "fields": {
+      "reason": {
+        "label": "Reden",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Aanstootgevend (haatdragende taal of laster)",
+          "inappropriate": "Ongepast (naaktheid, grafische inhoud, enz.)",
+          "other": "Ander"
+        }
+      },
+      "details": {
+        "label": "Details (optioneel)",
+        "placeholder": "Beschrijf wat je zag..."
+      }
+    },
+    "buttons": {
+      "submit": "Rapport indienen",
+      "cancel": "Annuleren"
+    },
+    "toasts": {
+      "success": "Rapport ingediend - bedankt!",
+      "failed": "Kan rapport niet indienen."
+    }
+  }
+}

--- a/i18n/nl/forgotPassword.json
+++ b/i18n/nl/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Wachtwoord opnieuw instellen",
+      "description": "Vraag een resetlink aan voor uw Daily Page-account."
+    },
+    "header": {
+      "title": "Wachtwoord vergeten?",
+      "subtitle": "Voer uw e-mailadres in en wij sturen u een resetlink."
+    },
+    "form": {
+      "email": {
+        "label": "E-mailadres",
+        "placeholder": "Voer uw e-mailadres in"
+      },
+      "submit": "Vraag wachtwoordreset aan"
+    },
+    "feedback": {
+      "successGeneric": "Als dat e-mailadres bestaat, is er een resetlink verzonden.",
+      "missingEmail": "E-mail is vereist.",
+      "genericError": "Er is iets misgegaan. Probeer het opnieuw.",
+      "unexpectedError": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+    },
+    "email": {
+      "subject": "Reset uw Daily Page-wachtwoord",
+      "heading": "Verzoek om wachtwoord opnieuw instellen",
+      "headingWithName": "Verzoek om wachtwoord opnieuw instellen, {username}",
+      "body": "Klik op de onderstaande link om uw wachtwoord opnieuw in te stellen.",
+      "cta": "Reset mijn wachtwoord",
+      "expires": "Deze link verloopt over {hours} uur/uren.",
+      "ignore": "Als u geen wachtwoordreset heeft aangevraagd, kunt u deze e-mail gerust negeren."
+    }
+  }
+}

--- a/i18n/nl/home.json
+++ b/i18n/nl/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Populaire berichten van de afgelopen 24 uur",
+      "description": "Daily Page is een minimalistische, indie-schrijfsite waar iedereen creatieve gedachten, herinneringen of experimenten kan posten - één bericht tegelijk. Ontdek nieuwe ideeën, sluit je aan bij kamers en draag je stem bij."
+    },
+    "hero": {
+      "eyebrow": "Een rustige plek om te schrijven, lezen en terugkeren",
+      "title": "Welkom bij Daily Page!",
+      "subtitle": "Ontdek de populairste berichten van de afgelopen 24 uur.",
+      "ctaPrefix": "Voel je je geïnspireerd?",
+      "cta": "Sluit je aan bij een kamer",
+      "ctaSuffix": "en maak je eigen bericht!"
+    },
+    "stats": {
+      "blocks": "Berichten",
+      "rooms": "Kamers",
+      "tags": "Tags",
+      "collabsToday": "Samenwerkingen vandaag"
+    },
+    "activity": {
+      "title": "Live op Daily Page",
+      "subtitle": "Frisse gesprekken en reacties, alles in één oogopslag.",
+      "fallbackActor": "Iemand",
+      "inRoom": "in",
+      "comments": {
+        "title": "Recente opmerkingen",
+        "more": "Zoek discussies",
+        "commentVerb": "commentaar op gegeven",
+        "replyVerb": "antwoordde op",
+        "empty": "Nog geen recente opmerkingen. Het volgende gesprek kan beginnen met jouw bericht."
+      },
+      "reactions": {
+        "title": "Recente reacties",
+        "more": "Blader door populaire berichten",
+        "empty": "Nog geen recente reacties. Een goede post zou dit snel wakker kunnen maken.",
+        "types": {
+          "heart": "hartelijk",
+          "leaf": "reageerde met een blad op",
+          "wow": "reageerde met wauw op",
+          "laugh": "lachte om"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Uitgelichte kamer",
+      "roomInfoDays": "Activiteit gedurende de afgelopen {days} dagen: {blocks} berichten, {votes} stemmen.",
+      "roomInfo24h": "Activiteit gedurende de afgelopen 24 uur: {blocks} berichten, {votes} stemmen.",
+      "checkItOut": "Bekijk het eens",
+      "blockRibbon": "★ Aanbevolen bericht",
+      "votes": "{n} stemmen",
+      "noContent": "(Geen inhoud verstrekt...)",
+      "viewBlock": "Bekijk bericht"
+    },
+    "trendingTags": {
+      "title": "Trending-tags",
+      "suffixDays": "(laatste {days} dagen)",
+      "suffixAllTime": "(altijd)",
+      "blocks": "{n} berichten",
+      "votes": "{n} stemmen",
+      "empty": "Nog geen trending-tags. Wees de eerste die iets leuks tagt!"
+    },
+    "trendingBlocks": {
+      "title": "Populaire berichten",
+      "suffixDays": "(laatste {days} dagen)",
+      "createdBy": "Gemaakt door:",
+      "in": "in",
+      "on": "op",
+      "unknownRoom": "Onbekende kamer",
+      "empty24h": "Nog geen berichten in de afgelopen 24 uur. Kom snel nog eens terug, compa!"
+    }
+  }
+}

--- a/i18n/nl/layout.json
+++ b/i18n/nl/layout.json
@@ -1,0 +1,50 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Welkom, gebruiker!",
+    "logout": "Uitloggen",
+    "login": "Inloggen / Aanmelden",
+    "language": "Taal",
+    "openMenu": "Hoofdmenu openen",
+    "closeMenu": "Sluit het hoofdmenu",
+    "privacy": "Privacybeleid",
+    "uiFallbackNotice": "{requested} is nog niet vertaald. Voorlopig wordt {current} weergegeven.",
+    "copyButton": {
+      "copy": "Kopiëren",
+      "copied": "Gekopieerd!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "English",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "עברית",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Thema",
+      "toggleToDark": "Schakel over naar de donkere modus",
+      "toggleToLight": "Schakel over naar de lichtmodus"
+    }
+  }
+}

--- a/i18n/nl/modals.json
+++ b/i18n/nl/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Log in",
+      "message": "U moet ingelogd zijn om door te gaan.",
+      "messageWithAction": "U moet ingelogd zijn bij {action}.",
+      "cta": "Inloggen"
+    },
+    "actions": {
+      "voteOnBlock": "stemmen op een bericht",
+      "starRoom": "ster deze kamer",
+      "reactToBlock": "reageer op dit bericht",
+      "commentOnBlock": "reageer op dit bericht",
+      "reportComment": "rapporteer deze reactie"
+    },
+    "errors": {
+      "starToggleFail": "Kan de sterstatus niet updaten. Probeer het opnieuw."
+    }
+  }
+}

--- a/i18n/nl/nav.json
+++ b/i18n/nl/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Thuis",
+    "rooms": "Kamers",
+    "tags": "Tags",
+    "archive": "Archief",
+    "search": "Zoekopdracht",
+    "bestOf": "Beste van",
+    "about": "Over",
+    "support": "Steun",
+    "otherProjects": "Andere projecten",
+    "auth": {
+      "welcomePrefix": "Welkom,",
+      "welcomeFallbackUser": "Jij",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Dashboard"
+  }
+}

--- a/i18n/nl/notifications.json
+++ b/i18n/nl/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Meldingen",
+      "openMenu": "Meldingen openen",
+      "loading": "Meldingen laden...",
+      "error": "Kan meldingen momenteel niet laden.",
+      "empty": "Nog geen meldingen.",
+      "markRead": "Markeer gelezen",
+      "fallbackActor": "Iemand",
+      "fallbackBlockTitle": "jouw bericht",
+      "item": {
+        "blockComment": "{actorUsername} heeft gereageerd op uw bericht \"{blockTitle}\".",
+        "commentReply": "{actorUsername} heeft gereageerd op uw opmerking over \"{blockTitle}\".",
+        "unknown": "Kennisgeving"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Nieuwe reactie op \"{blockTitle}\"",
+        "heading": "Nieuwe reactie op je bericht",
+        "headingWithName": "Hallo {username},",
+        "body": "<strong>{actorUsername}</strong> heeft gereageerd op uw bericht <strong>{blockTitle}</strong>.",
+        "cta": "Bekijk het gesprek op Daily Page",
+        "fallbackActor": "Iemand",
+        "fallbackBlockTitle": "jouw bericht"
+      },
+      "commentReply": {
+        "subject": "Nieuw antwoord op \"{blockTitle}\"",
+        "heading": "Nieuw antwoord op uw opmerking",
+        "headingWithName": "Hallo {username},",
+        "body": "<strong>{actorUsername}</strong> heeft gereageerd op uw opmerking over <strong>{blockTitle}</strong>.",
+        "cta": "Bekijk het gesprek op Daily Page",
+        "fallbackActor": "Iemand",
+        "fallbackBlockTitle": "jouw bericht"
+      }
+    }
+  }
+}

--- a/i18n/nl/privacy.json
+++ b/i18n/nl/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Privacybeleid",
+      "description": "Hoe Daily Page uw gegevens verzamelt, gebruikt en beschermt, in duidelijke taal."
+    },
+    "title": "Privacybeleid",
+    "lastUpdated": "Laatst bijgewerkt: {date}",
+    "intro": {
+      "h2": "Invoering",
+      "p1": "Daily Page (\"ons\", \"wij\" of \"onze\") beheert de website dailypage.org (hierna de \"Service\" genoemd).",
+      "p2": "Deze pagina informeert u over ons beleid met betrekking tot het verzamelen, gebruiken en openbaar maken van persoonlijke gegevens wanneer u onze Service gebruikt."
+    },
+    "collection": {
+      "h2": "Informatieverzameling en -gebruik",
+      "p": "We verzamelen minimale persoonlijke gegevens om onze Service te verbeteren en te leveren. Dit omvat e-mailadressen voor accountbeheer en inhoud die vrijwillig door gebruikers is ingediend."
+    },
+    "usage": {
+      "h2": "Gegevensgebruik",
+      "p": "De verzamelde gegevens worden uitsluitend gebruikt voor accountauthenticatie, contentmoderatie en het verbeteren van de gebruikerservaring."
+    },
+    "storage": {
+      "h2": "Gegevensopslag en beveiliging",
+      "p": "Uw gegevens worden veilig opgeslagen en nooit zonder uitdrukkelijke toestemming aan derden gedeeld of verkocht, behalve zoals vereist door de wet."
+    },
+    "cookies": {
+      "h2": "Koekjes",
+      "p": "We gebruiken cookies uitsluitend voor sessiebeheer en het verbeteren van de gebruikerservaring. U kunt cookies uitschakelen via uw browserinstellingen."
+    },
+    "rights": {
+      "h2": "Uw rechten",
+      "p": "U kunt op elk moment verzoeken om verwijdering of wijziging van uw persoonlijke gegevens door contact met ons op te nemen."
+    },
+    "changes": {
+      "h2": "Wijzigingen in dit privacybeleid",
+      "p": "We kunnen ons privacybeleid van tijd tot tijd bijwerken. Wijzigingen zullen op deze pagina worden geplaatst."
+    },
+    "contact": {
+      "h2": "Neem contact met ons op",
+      "p": "Voor vragen over dit privacybeleid kunt u contact met ons opnemen via:",
+      "emailLabel": "vraag@dailypage.org"
+    }
+  }
+}

--- a/i18n/nl/profile.json
+++ b/i18n/nl/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Het profiel van {username}",
+      "descriptionUser": "Bekijk de recente activiteit, kamers met ster en statistieken van {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Profielfoto",
+      "noBio": "(Geen bio beschikbaar.)"
+    },
+    "activity": {
+      "title": "Recente activiteit",
+      "updatedOn": "Bijgewerkt op {date}",
+      "none": "Geen recente activiteit.",
+      "viewAllBlocks": "Bekijk alle berichten"
+    },
+    "starredRooms": {
+      "title": "Kamers met ster",
+      "none": "Er zijn nog geen kamers met ster.",
+      "unnamedRoom": "Naamloze kamer"
+    },
+    "stats": {
+      "title": "Gebruikersstatistieken",
+      "totalBlocks": "Totaal aantal berichten gemaakt",
+      "collaborations": "Samenwerkingen",
+      "daysActive": "Dagen actief"
+    }
+  }
+}

--- a/i18n/nl/random.json
+++ b/i18n/nl/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Andere projecten",
+      "description": "Ontdek honkbaljournaling, willekeurige schrijfexperimenten en andere zijprojecten van Daily Page."
+    },
+    "title": "Andere projecten",
+    "tagline": "Een gezellig hoekje voor experimenten en zijmissies.",
+    "links": {
+      "baseball": "📖 Honkbaldagboek",
+      "randomWriter": "🎲 Willekeurige schrijver"
+    },
+    "cta": {
+      "backToRooms": "Terug naar de hoofdkamers"
+    }
+  }
+}

--- a/i18n/nl/randomWriter.json
+++ b/i18n/nl/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page - Willekeurige schrijver",
+      "description": "Genereer een oneindige stroom willekeurige pseudotekst voor plezier, inspiratie of chaos."
+    },
+    "title": "Willekeurige schrijver",
+    "buttons": {
+      "clear": "Duidelijk",
+      "stop": "Houd op met schrijven",
+      "start": "Begin met schrijven"
+    }
+  }
+}

--- a/i18n/nl/reactions.json
+++ b/i18n/nl/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji}-reacties: {count}",
+    "loginToReact": "Log in om te reageren",
+    "countsLabel": "Reacties"
+  }
+}

--- a/i18n/nl/readMore.json
+++ b/i18n/nl/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Meer...",
+    "aria": "Lees het volledige bericht: {title}"
+  }
+}

--- a/i18n/nl/resetPassword.json
+++ b/i18n/nl/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Reset uw wachtwoord",
+      "description": "Stel een nieuw wachtwoord in voor uw account."
+    },
+    "header": {
+      "title": "Reset uw wachtwoord",
+      "subtitle": "Kies een nieuw wachtwoord om weer toegang te krijgen."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Nieuw wachtwoord",
+        "placeholder": "Voer een nieuw wachtwoord in"
+      },
+      "submit": "Nieuw wachtwoord instellen"
+    },
+    "feedback": {
+      "missingToken": "Ontbrekend of ongeldig token.",
+      "missingFields": "Token en nieuw wachtwoord zijn vereist.",
+      "invalidOrExpired": "Ongeldig of verlopen token.",
+      "success": "Wachtwoord succesvol bijgewerkt!",
+      "genericError": "Er is iets misgegaan. Probeer het opnieuw.",
+      "unexpectedError": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+    }
+  }
+}

--- a/i18n/nl/roomDashboard.json
+++ b/i18n/nl/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Ontdek recente en lopende berichten in {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Ontdekken:",
+      "allBlocks": "🗂️Alle berichten",
+      "browseByDate": "🗓️ Op datum",
+      "bestOf": "🏅 Het beste van",
+      "searchInRoom": "🔎 Zoeken"
+    },
+    "actions": {
+      "createBlock": "Maak een bericht",
+      "starTitle": "Geef deze kamer een ster",
+      "unstarTitle": "Verwijder de ster van deze kamer"
+    },
+    "tabs": {
+      "locked": "Vergrendelde berichten",
+      "inProgress": "Berichten in uitvoering"
+    },
+    "sections": {
+      "lockedHeader": "Vergrendelde berichten",
+      "inProgressHeader": "Berichten in uitvoering"
+    },
+    "editorial": {
+      "heading": "Aanbevolen gidsen",
+      "description": "Begin hier met de aanbevolen gidsen die voor deze kamer zijn samengesteld.",
+      "roleNames": {
+        "pillar": "Kern gids",
+        "companion": "Leesgids",
+        "texture": "Achtergrondgids"
+      }
+    },
+    "empty": {
+      "noDescription": "Geen beschrijving beschikbaar.",
+      "noLocked": "Nog geen vergrendelde berichten! Berichten worden automatisch vergrendeld na 1 uur inactiviteit.",
+      "noInProgress": "Nog geen lopende berichten! Tijd om er een te beginnen.",
+      "noBlocks": "Nog geen berichten! Creëer de eerste en laat uw stempel achter. 😎"
+    }
+  }
+}

--- a/i18n/nl/roomsDirectory.json
+++ b/i18n/nl/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Kamerlijst",
+      "description": "Elke kamer is een deuropening naar een andere wereld. Stap binnen, deel uw verhaal en bouw samen met anderen aan iets moois."
+    },
+    "eyebrow": "Vind jouw hoek",
+    "heading": "Kamerlijst",
+    "intro": "Begin met de kamers die op dit moment levend aanvoelen, of dwaal af op onderwerp totdat er iets klikt. Elke kamer is een andere schrijfopdracht, fandom of gedeelde obsessie die op jouw stem wacht.",
+    "empty": "Er zijn momenteel geen kamers beschikbaar. Kom later terug!",
+    "jumpToActive": "Zie actieve kamers",
+    "jumpToTopics": "Blader op onderwerp",
+    "statsLabel": "Hoogtepunten van de ruimtelijst",
+    "liveNow": "Leef nu",
+    "recentlyActive": "Recent actief",
+    "recentlyActiveSubtitle": "De snelste manier om op dit moment een kamer met mensen te vinden.",
+    "browseByTopic": "Blader op onderwerp",
+    "topicSubtitle": "Open een onderwerp om de kamers ervan te verkennen.",
+    "roomCount": "{count} kamers",
+    "stats": {
+      "rooms": "kamers om te verkennen",
+      "topics": "onderwerp groepen",
+      "active": "actieve keuzes"
+    },
+    "activeUsers": "Actieve gebruikers: {count}",
+    "visitRoom": "Kamer bezoeken",
+    "close": "Dichtbij",
+    "noTitle": "Geen titel beschikbaar",
+    "noDescription": "Geen beschrijving beschikbaar"
+  }
+}

--- a/i18n/nl/search.json
+++ b/i18n/nl/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Zoekopdracht",
+      "description": "Zoek naar openbare berichten."
+    },
+    "title": "Zoekopdracht",
+    "placeholder": "Berichten zoeken...",
+    "hint": "Typ minimaal 2 tekens om te zoeken.",
+    "noResults": "Geen resultaten gevonden.",
+    "untitled": "Zonder titel",
+    "votesTitle": "Stemmen",
+    "pageLabel": "Pagina",
+    "filters": {
+      "inRoom": "In de kamer"
+    },
+    "buttons": {
+      "search": "Zoekopdracht",
+      "prev": "Vorige",
+      "next": "Volgende"
+    }
+  }
+}

--- a/i18n/nl/signup.json
+++ b/i18n/nl/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Maak een account aan",
+      "description": "Meld u aan voor Daily Page om toegang te krijgen tot alle functies."
+    },
+    "header": {
+      "title": "Maak uw account aan",
+      "subtitle": "Word lid van Daily Page en begin met het maken en delen van uw dagelijkse schrijfsels!"
+    },
+    "form": {
+      "email": {
+        "label": "E-mail",
+        "placeholder": "Voer uw e-mailadres in"
+      },
+      "username": {
+        "label": "Gebruikersnaam",
+        "placeholder": "Voer uw gebruikersnaam in"
+      },
+      "password": {
+        "label": "Wachtwoord",
+        "placeholder": "Voer een wachtwoord in"
+      },
+      "submit": "Aanmelden",
+      "feedback": {
+        "success": "Formulierinzending succesvol!",
+        "successCreatedVerify": "Account aangemaakt! Controleer uw e-mail om uw account te verifiëren.",
+        "genericError": "Kan account niet aanmaken. Probeer het opnieuw.",
+        "unexpectedError": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+      }
+    }
+  }
+}

--- a/i18n/nl/starredRooms.json
+++ b/i18n/nl/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Alle kamers met sterren",
+      "description": "Een lijst met alle kamers waaraan u een ster heeft toegevoegd."
+    },
+    "nav": {
+      "backToDashboard": "← Terug naar Dashboard"
+    },
+    "header": {
+      "title": "🌟 Al uw kamers met sterren 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Naamloze kamer",
+      "noDescription": "Geen beschrijving."
+    },
+    "empty": {
+      "message": "Je hebt nog geen kamers met een ster gemarkeerd!"
+    }
+  }
+}

--- a/i18n/nl/support.json
+++ b/i18n/nl/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Ondersteuning",
+      "description": "Hoe u contact kunt opnemen, problemen kunt melden, functies of kamers kunt aanvragen en Daily Page financieel kunt ondersteunen."
+    },
+    "contact": {
+      "h1": "★ Ik wil graag een vraag stellen, een probleem melden of een functie aanvragen.",
+      "p1": {
+        "before": "Als je liever GitHub gebruikt, vink dit dan aan",
+        "link": "de problemen van dit project",
+        "after": "en voeg uw stem toe. Pull-verzoeken zijn uiteraard ook welkom."
+      },
+      "p2": {
+        "before": "Als alternatief,",
+        "link": "stuur een e-mail",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Ik wil dit project graag steunen met een bijdrage.",
+      "p1": {
+        "before": "Bij voorbaat dank voor de financiering van dit project. Verstuur betalingen veilig via",
+        "paypal": "PayPal",
+        "middle": "of, als u dat liever heeft,",
+        "amazon": "bestel een paar zakken met het speelgoed dat ik op Amazon verkoop",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Ik wil graag een nieuwe kamer aanvragen.",
+      "form": {
+        "nameLabel": "Kamernaam",
+        "topicLabel": "Onderwerp (optioneel)",
+        "descriptionLabel": "Beschrijving",
+        "submit": "Verzoek indienen",
+        "success": "Aanvraag succesvol verzonden!",
+        "errorGeneric": "Kan verzoek niet indienen. Probeer het opnieuw.",
+        "errorUnexpected": "Er is een onverwachte fout opgetreden. Probeer het opnieuw."
+      }
+    }
+  }
+}

--- a/i18n/nl/tags.json
+++ b/i18n/nl/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Tagsoverzicht",
+      "description": "Blader door alle tags die op Daily Page worden gebruikt, met snelle filters op tijd."
+    },
+    "title": "Tagsoverzicht",
+    "intro": "Ontdek alle tags die worden gebruikt op Daily Page.",
+    "tagCloudTitle": "Tagwolk",
+    "timeframe": {
+      "last24h": "Afgelopen 24 uur",
+      "last7d": "Laatste 7 dagen",
+      "last30d": "Laatste 30 dagen",
+      "all": "Altijd"
+    },
+    "error": {
+      "loading": "Fout bij laden van tagsoverzicht"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": "| Daily Page",
+        "description": "Berichten getagd met"
+      },
+      "header": {
+        "label": "Label:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Totaal aantal berichten met",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Gemaakt door:",
+        "inRoom": "in",
+        "unknownRoom": "Onbekende kamer",
+        "onDate": "op"
+      },
+      "chart": {
+        "label": "Berichten die in de loop van de tijd zijn gemaakt"
+      },
+      "empty": {
+        "message": "Er zijn nog geen berichten gevonden met deze tag. Misschien moet je de eerste maken? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Fout bij laden van tagpagina"
+      }
+    }
+  }
+}

--- a/i18n/nl/translation.json
+++ b/i18n/nl/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Vertaald uit",
+    "see": "zien",
+    "originalBlock": "origineel bericht"
+  }
+}

--- a/i18n/nl/userBlocks.json
+++ b/i18n/nl/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Jouw berichten",
+      "description": "Blader en sorteer alle berichten die je hebt gemaakt of waaraan je hebt meegewerkt."
+    },
+    "header": {
+      "dashboardLink": "Jouw Dashboard",
+      "profileLink": "Het profiel van {username}",
+      "allBlocks": "Alle berichten"
+    },
+    "empty": "Nog geen berichten.",
+    "pagination": {
+      "prev": "← Vorige",
+      "next": "Volgende →"
+    },
+    "titleUser": "Berichten van {username}"
+  }
+}

--- a/i18n/nl/verifyEmail.json
+++ b/i18n/nl/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "E-mail verifiëren",
+      "description": "Verifieer uw e-mailadres voor Daily Page."
+    },
+    "header": {
+      "title": "Je e-mailadres verifiëren..."
+    },
+    "status": {
+      "checking": "Token wordt gecontroleerd. Even geduld a.u.b....",
+      "missingToken": "Verificatietoken ontbreekt of is ongeldig.",
+      "genericFailure": "Verificatie mislukt.",
+      "unexpectedError": "Er is een onverwachte fout opgetreden.",
+      "success": "Uw account is succesvol geverifieerd!",
+      "invalidOrExpired": "Ongeldig of verlopen verificatietoken."
+    },
+    "verificationMsg": {
+      "subject": "Verifieer je Daily Page-account ✨",
+      "heading": "Welkom bij Daily Page, {username}!",
+      "body": "Controleer uw e-mailadres door hieronder te klikken:",
+      "cta": "Controleer het e-mailadres",
+      "expires": "Deze link verloopt over {hours} uur."
+    }
+  }
+}

--- a/i18n/nl/voteControls.json
+++ b/i18n/nl/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Stem omhoog",
+    "downvote": "Stem af",
+    "errors": {
+      "failed": "Kan uw stem niet opslaan."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -75,4 +75,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'ar' }).catch(console.error), 6_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'hi' }).catch(console.error), 7_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'tr' }).catch(console.error), 7_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'nl' }).catch(console.error), 8_000);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- Add complete Dutch (`nl`) translations for all UI namespaces
- Register Dutch as a fully supported UI, email, hreflang, and home-cache language
- Preserve English catalog structure, interpolation placeholders, and HTML tokens
- Leave DB-backed room metadata translations unchanged

## Validation

- Confirmed Dutch matches English file-for-file and key-for-key
- Parsed all locale JSON files successfully
- Verified interpolation placeholders and HTML tokens are preserved
- Ran `git diff --check`
- Ran test suite: 279 specs passed
- Ran lint; it still reports 16 pre-existing errors in unrelated files

## Notes

Remaining hard-coded UI text is primarily limited to the legacy music/iPod interface and developer-only views. Client-side English fallback strings remain as defensive safeguards.