### PR TITLE
feat(i18n): add full Swedish UI support

### DIFF
--- a/i18n/sv/about.json
+++ b/i18n/sv/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Om",
+      "description": "Vad Daily Page är, hur den fungerar och varför den byggdes som ett långsammare, snällare hörn av webben."
+    },
+    "title": "Om Daily Page",
+    "tagline": "Mata ditt sinne, inte ditt flöde.",
+    "mission": {
+      "h2": "Uppdrag",
+      "p1": "Ett indieskrivlabb – startade i mitt vardagsrum, underblåst av läsarnas nyfikenhet.",
+      "p2": "Den är byggd för att inte ruttna din hjärna, utan för att ge den näring: en plats där du kan skriva långsamt, anonymt om du vill, och aldrig oroa dig för att imponera på någon."
+    },
+    "how": {
+      "h2": "Hur det fungerar",
+      "features": {
+        "rooms": {
+          "label": "Rum",
+          "text": "är ämnessilor (tänk \"subreddit, men vänligare\")."
+        },
+        "blocks": {
+          "label": "Inlägg",
+          "text": "är skrivutrymmen för samarbete – vem som helst (även \"anonym\") kan skapa en, redigera den tills den är låst och rösta på andra."
+        },
+        "privacy": {
+          "label": "Sekretess och delning",
+          "text": "betyder offentliga inlägg live i rummets flöde. Olistade utkast gömmer sig tills de är låsta, men du får en delningslänk för att bjuda in vänner."
+        },
+        "markdown": {
+          "label": "Markdown och media",
+          "text": "låter dig skriva i markdown, bädda in bilder och samredigera som i Google Dokument."
+        },
+        "trends": {
+          "label": "Trender och taggar",
+          "text": "låter dig tagga ditt inlägg, spåra taggtrender och upptäcka toppinnehåll (7 d / 30 d / genom tiderna)."
+        },
+        "streaks": {
+          "label": "Skrivsviter",
+          "text": "håll din dagliga skrivserie vid liv – ditt bästa incitament att dyka upp varje dag."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Hur vi kom hit",
+      "p1": "2018 byggde jag en datumbaserad wiki för \"dagens sida\" och såg några introspektiva skribenter förvandla den till ett utlopp för sina tankar. Den blev aldrig stor – men den sådde ett frö.",
+      "p2": "Spola framåt till nu, och Daily Page är det frö som har vuxit in i många rum – en tyst social webb för introverta, idealister och alla som vill ha ett långsammare tempo."
+    },
+    "next": {
+      "h2": "Vad händer härnäst",
+      "p1": "Vi har precis kommit igång: rikare inbäddningar, djupare användarstatistik, anseendetavlor och fler sätt att belöna genomtänkt skapande.",
+      "p2": "Tack för att du är en del av detta lilla indie-experiment."
+    },
+    "cta": {
+      "rooms": "Utforska rum",
+      "signup": "Gå med i gemenskapen"
+    }
+  }
+}

--- a/i18n/sv/accountSecurity.json
+++ b/i18n/sv/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Kontosäkerhet",
+      "description": "Hantera ditt Daily Page-lösenord och tvåfaktorsautentisering."
+    },
+    "backToDashboard": "Tillbaka till instrumentpanelen",
+    "heading": "Kontosäkerhet",
+    "subheading": "Håll ditt konto skyddat med ett starkt lösenord och en autentiseringsapp.",
+    "password": {
+      "title": "Ändra lösenord",
+      "description": "Använd ett unikt lösenord med minst 8 tecken.",
+      "current": {
+        "label": "Aktuellt lösenord"
+      },
+      "new": {
+        "label": "Nytt lösenord"
+      },
+      "submit": "Uppdatera lösenord"
+    },
+    "twoFactor": {
+      "title": "tvåfaktorsautentisering",
+      "statusOn": "aktiverad",
+      "statusOff": "Av",
+      "description": "Lägg till en engångskod från en autentiseringsapp efter ditt lösenord när du loggar in.",
+      "currentPassword": {
+        "label": "Aktuellt lösenord"
+      },
+      "startSetup": "Konfigurera Authenticator-appen",
+      "qrAlt": "Authenticator app QR-kod",
+      "manualKey": "Manuell inställningsnyckel",
+      "code": {
+        "label": "6-siffrig kod"
+      },
+      "enable": "Aktivera 2FA",
+      "disableCode": {
+        "label": "Autentiseringskod"
+      },
+      "disable": "Inaktivera 2FA"
+    },
+    "recoveryCodes": {
+      "title": "Spara dina återställningskoder",
+      "description": "Använd en av dessa engångskoder för att logga in om du förlorar åtkomsten till din autentiseringsapp.",
+      "regenerateDescription": "Generera en ny uppsättning återställningskoder om du tappade bort den tidigare uppsättningen. Detta ogiltigförklarar alla gamla återställningskoder.",
+      "regenerate": "Generera nya återställningskoder",
+      "warning": "Förvara dem på ett säkert ställe. De kommer inte att visas igen."
+    },
+    "feedback": {
+      "passwordChanged": "Ditt lösenord har uppdaterats.",
+      "setupReady": "Skanna QR-koden och ange sedan den 6-siffriga koden för att avsluta installationen.",
+      "twoFactorEnabled": "Tvåfaktorsautentisering är nu aktiverad.",
+      "twoFactorDisabled": "Tvåfaktorsautentisering är nu inaktiverad.",
+      "recoveryCodesRegenerated": "Dina återställningskoder har återskapats. Spara de nya koderna nu.",
+      "missingFields": "Vänligen fyll i alla obligatoriska fält.",
+      "missingCurrentPassword": "Ange ditt nuvarande lösenord för att fortsätta.",
+      "passwordTooShort": "Ditt nya lösenord måste bestå av minst 8 tecken.",
+      "invalidCurrentPassword": "Det aktuella lösenordet matchade inte.",
+      "missingCode": "Ange den sexsiffriga koden från din autentiseringsapp.",
+      "invalidCode": "Den koden fungerade inte. Försök igen.",
+      "noPendingSetup": "Starta installationen igen innan du anger en kod.",
+      "setupExpired": "Den installationssessionen löpte ut. Börja konfigureringen igen för att få en ny QR-kod.",
+      "twoFactorNotEnabled": "Tvåfaktorsautentisering är inte aktiverad för det här kontot.",
+      "genericError": "Något gick fel. Försök igen.",
+      "unexpectedError": "Ett oväntat fel inträffade. Försök igen."
+    }
+  }
+}

--- a/i18n/sv/anonymousUser.json
+++ b/i18n/sv/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Den anonyme vandraren",
+      "description": "Ingen profil. Inget förflutet. Bara vibbar."
+    },
+    "ascii": {
+      "ariaLabel": "ASCII konst av nyckfull varelse med citat"
+    },
+    "header": {
+      "title": "Den anonyma"
+    },
+    "body": {
+      "line1": "Du har snubblat in i tomrummet. Det finns inget att se här -",
+      "line2": "bara en vandrande ande utan en historia."
+    },
+    "buttons": {
+      "home": "← Återvänd hem",
+      "signup": "Skapa en identitet"
+    }
+  }
+}

--- a/i18n/sv/archive.json
+++ b/i18n/sv/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arkiv",
+      "description": "Utforska hela arkivet per månad.",
+      "titleRoom": "Daily Page — Arkiv · {roomName}",
+      "descriptionRoom": "Utforska tidigare skrivande i {roomName}-rummet — månad för månad. Hoppa till valfritt datum för att se vad andra delat i det här utrymmet över tid."
+    },
+    "nav": {
+      "prev": "Föregående",
+      "next": "Nästa"
+    },
+    "title": "📚 Bläddra i arkiv",
+    "titleRoom": "📚 {roomName} — Arkiv",
+    "roomViewing": "Visningsarkiv för rum {roomName}",
+    "viewRoomLink": "Visa rum",
+    "noContent": "Inget innehåll tillgängligt ännu.",
+    "backToRoom": "← Tillbaka till rummets översikt",
+    "calendar": {
+      "meta": {
+        "description": "Se alla kreativa inlägg publicerade i {month} {year} – från snabba tankar till djupa reflektioner. Klicka på valfritt datum för att utforska vad som delades.",
+        "descriptionRoom": "Se den kreativa aktiviteten i {roomName} under {month} {year}. Välj ett datum för att utforska inläggen som delas den dagen."
+      },
+      "title": "📆 Arkiv för {month} {year}",
+      "prevLabel": "Arkiv för {month} {year}",
+      "nextLabel": "Arkiv för {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Arkiv för {date}",
+        "titleRoom": "{roomName} — Arkiv för {date}",
+        "descriptionSite": "Utforska inläggen skrivna på {date} – från tysta anteckningar till vilda bekännelser.",
+        "descriptionRoom": "På {date} satte skribenter i {roomName}-rummet sina spår – bläddra igenom reflektioner, idéer och uttryck som delades den dagen."
+      },
+      "heading": "Arkiv för {date}",
+      "empty": "Inget innehåll hittades för detta datum.",
+      "labels": {
+        "createdBy": "Skapad av:",
+        "in": "i",
+        "on": "på {datetime}",
+        "unknownRoom": "Okänt rum"
+      },
+      "nav": {
+        "prevDay": "Föregående dag",
+        "nextDay": "Nästa dag"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Alla inlägg",
+        "descriptionRoom": "Bläddra i alla inlägg som någonsin publicerats i {roomName}-rummet. Sortera efter datum, titel eller röster för att utforska dess historia."
+      },
+      "header": {
+        "allBlocks": "— Alla inlägg"
+      },
+      "sort": {
+        "label": "Sortera efter",
+        "options": {
+          "date": "Datum",
+          "title": "Titel",
+          "votes": "röster"
+        },
+        "submit": "Visa"
+      }
+    },
+    "pagination": {
+      "prev": "← Föregående",
+      "next": "Nästa →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daily Page för {time}"
+      },
+      "empty": "Vi kunde inte hitta några sidor under den tidsramen."
+    }
+  }
+}

--- a/i18n/sv/auth.json
+++ b/i18n/sv/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Logga in",
+        "description": "Logga in på ditt Daily Page-konto för att fortsätta din skrivresa."
+      },
+      "heading": "Välkommen tillbaka!",
+      "subheading": "Logga in på ditt konto för att fortsätta dela ditt dagliga skrivande.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Användarnamn eller e-post",
+          "placeholder": "Ange ditt användarnamn eller e-postadress"
+        },
+        "password": {
+          "label": "Lösenord",
+          "placeholder": "Ange ditt lösenord"
+        },
+        "totpCode": {
+          "label": "Authenticator eller återställningskod",
+          "placeholder": "Ange kod"
+        }
+      },
+      "actions": {
+        "submit": "Logga in"
+      },
+      "feedback": {
+        "success": "Inloggning lyckad! Omdirigerar...",
+        "twoFactorRequired": "Ange den sexsiffriga koden från din autentiseringsapp eller använd en återställningskod.",
+        "twoFactorFailed": "Den koden fungerade inte. Försök igen.",
+        "failedGeneric": "Inloggning misslyckades. Försök igen.",
+        "unexpected": "Ett oväntat fel inträffade. Försök igen."
+      },
+      "links": {
+        "forgotPassword": "Glömt ditt lösenord?",
+        "noAccount": "Har du inte ett konto än?",
+        "signupHere": "Registrera dig här!"
+      }
+    }
+  }
+}

--- a/i18n/sv/bestOf.json
+++ b/i18n/sv/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Bästa av Daily Page",
+      "description": "De mest älskade inläggen på Daily Page – roliga, ärliga, poetiska eller helt enkelt konstiga. Se vad som stack ut under den senaste dagen, veckan, månaden och därefter.",
+      "titleRoom": "Det bästa av {roomName}",
+      "descriptionRoom": "Upptäck enastående inlägg från {roomName}-rummet – de som läsarna älskade mest under de senaste 24 timmarna, 7 dagarna, 30 dagarna och hela tiden."
+    },
+    "heading": "🏆 Bästa av Daily Page",
+    "headingRoomPrefix": "🏆 Bäst i ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 timmar",
+      "7d": "🚀 7 dagar",
+      "30d": "🌕 30 dagar",
+      "all": "👑 Genom tiderna"
+    },
+    "labels": {
+      "createdBy": "Skapad av:",
+      "inRoom": "i",
+      "onDate": "på {date}",
+      "unknownRoom": "Okänt rum",
+      "noBlocks": "Inga inlägg hittades.",
+      "viewRoom": "Visa rum"
+    }
+  }
+}

--- a/i18n/sv/blockCommon.json
+++ b/i18n/sv/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Utkast"
+    },
+    "deleteModal": {
+      "title": "Ta bort inlägg?",
+      "message": "Denna åtgärd kan inte ångras.",
+      "confirm": "Ta bort",
+      "cancel": "Avbryt",
+      "closeAriaLabel": "Stäng"
+    },
+    "toasts": {
+      "deleteSuccess": "Inlägget har raderats!",
+      "deleteFailed": "Det gick inte att ta bort inlägget."
+    }
+  }
+}

--- a/i18n/sv/blockEditor.json
+++ b/i18n/sv/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Du)"
+    },
+    "meta": {
+      "title": "Redigera inlägg - {blockTitle}",
+      "titleFallback": "Redigera inlägg"
+    },
+    "errors": {
+      "imageUrlRequired": "Ange en bildadress.",
+      "notFound": "Inlägg hittades inte eller tillhör inte detta rum.",
+      "loadFailed": "Ett fel uppstod när inläggsredigeraren laddades.",
+      "updateTitleFailed": "Fel vid uppdatering av titel."
+    },
+    "roomInfo": {
+      "label": "Rum:"
+    },
+    "title": {
+      "placeholder": "Ange inläggets titel",
+      "editTooltip": "Redigera titel",
+      "lock": "Låsstolpe",
+      "delete": "Ta bort inlägg"
+    },
+    "description": {
+      "label": "Beskrivning",
+      "editTooltip": "Redigera beskrivning",
+      "placeholder": "Ange beskrivning",
+      "noDescriptionOwner": "Ingen beskrivning ännu...",
+      "noDescriptionViewer": "Ingen beskrivning tillhandahållen...",
+      "save": "Spara",
+      "cancel": "Avbryt",
+      "expand": "Expandera",
+      "collapse": "Kollaps",
+      "updateError": "Fel vid uppdatering av beskrivning."
+    },
+    "status": {
+      "lastBackup": "Senaste säkerhetskopiering: {datetime}",
+      "lastBackupUnknown": "Senaste säkerhetskopiering: Okänd"
+    },
+    "peers": {
+      "label": "Deltagare:"
+    },
+    "toasts": {
+      "blockLocked": "Det här inlägget har låsts!"
+    },
+    "editor": {
+      "placeholder": "Den tomma sidan väntar på din röst; skriva orädd."
+    },
+    "loading": {
+      "label": "Laddar",
+      "quote": "Låt världen brinna genom dig. Kasta prismaljuset, vitt varmt, på papper.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Du har inte skrivit något på 5 minuter. Klicka på OK för att fortsätta sessionen; annars kommer du att omdirigeras till arkivet.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Delningslänk",
+      "copyTooltip": "Kopiera till Urklipp",
+      "copied": "Kopierat!"
+    },
+    "toolbar": {
+      "insertImage": "Infoga bild",
+      "insertImageUrlPlaceholder": "Ange bildens URL",
+      "insertImageAltPlaceholder": "Alt text (valfritt)",
+      "insertImageConfirm": "Bekräfta",
+      "insertImageCancel": "Avbryt"
+    },
+    "buttons": {
+      "downloadFile": "Ladda ner fil"
+    },
+    "lockModal": {
+      "messageLine1": "Är du säker på att du vill låsa det här inlägget?",
+      "messageLine2": "Detta kommer att slutföra det och förhindra ytterligare redigering.",
+      "confirm": "Lås",
+      "cancel": "Avbryt",
+      "successToast": "Post låst framgångsrikt.",
+      "errorToast": "Fel vid låsning av stolpen."
+    },
+    "tags": {
+      "headerWithTags": "Taggar:",
+      "headerNoTags": "Inga taggar än! Lägg till några:",
+      "updateError": "Fel vid uppdatering av taggar."
+    },
+    "fullBlock": {
+      "headingPrefix": "Tyvärr; inlägget \"{blockTitle}\" är nu",
+      "headingStatus": "fullt upptagen.",
+      "retryPrefix": "Snälla",
+      "retryLink": "prova ett annat inlägg",
+      "retrySuffix": "eller kom tillbaka en annan gång.",
+      "consolationPrefix": "Medan du väntar, läs gärna",
+      "consolationBestOf": "några av våra favoritinlägg",
+      "consolationMiddle": "eller för att bläddra",
+      "consolationArchive": "arkivet."
+    }
+  }
+}

--- a/i18n/sv/blockList.json
+++ b/i18n/sv/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "hela tiden",
+      "days": "under de senaste {n} dagarna",
+      "day": "under de senaste 24 timmarna"
+    },
+    "createdBy": "Skapad av:",
+    "on": "på"
+  }
+}

--- a/i18n/sv/blockTags.json
+++ b/i18n/sv/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Taggar:",
+      "noTags": "Inga taggar än! Lägg till några:"
+    },
+    "input": {
+      "placeholder": "Ny tag",
+      "addButton": "Lägg till"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/sv/blockView.json
+++ b/i18n/sv/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Inlägg - {blockTitle}",
+      "titleFallback": "Inlägg"
+    },
+    "labels": {
+      "room": "Rum",
+      "author": "Författare",
+      "created": "Skapad",
+      "unknownAuthor": "Anonym",
+      "authorAvatarAlt": "{username}s avatar",
+      "viewAuthorProfile": "Visa {username}s profil",
+      "lang": "Översättningar:",
+      "available": "tillgänglig"
+    },
+    "buttons": {
+      "edit": "Redigera",
+      "deleteBlock": "Ta bort inlägg",
+      "share": "Dela",
+      "flagContent": "Anmäl innehåll"
+    },
+    "description": {
+      "label": "Beskrivning",
+      "none": "Ingen beskrivning tillhandahållen...",
+      "expand": "Expandera",
+      "collapse": "Kollaps"
+    },
+    "editorial": {
+      "heading": "Läsguide",
+      "roleLabel": "Lästyp",
+      "clusterLabel": "Guide",
+      "sequence": "Del {sequence}",
+      "primaryPillarHeading": "Börja här",
+      "relatedHeading": "Fortsätt läsa",
+      "clusterHeading": "Mer i den här guiden",
+      "expandSection": "Visa {count} mer",
+      "collapseSection": "Visa mindre",
+      "roleNames": {
+        "pillar": "Huvudguide",
+        "companion": "Djupt dyk",
+        "texture": "Bakgrund"
+      }
+    },
+    "comments": {
+      "heading": "Kommentarer",
+      "count": "{count} kommentarer",
+      "empty": "Ingen har svarat än. Kommentarer kommer att dyka upp här när konversationen startar.",
+      "composer": {
+        "label": "Lägg till en kommentar",
+        "placeholder": "Skriv en kommentar...",
+        "submit": "Skriv kommentar",
+        "submitting": "Postar...",
+        "success": "Kommentar postad.",
+        "error": "Det går inte att skriva din kommentar just nu.",
+        "loginPrompt": "Logga in för att gå med i konversationen.",
+        "loginCta": "Logga in för att kommentera",
+        "verifyPrompt": "Verifiera din e-postadress innan du postar en kommentar.",
+        "verifyCta": "Verifiera e-post"
+      },
+      "sort": {
+        "label": "Sortera",
+        "oldestFirst": "Äldsta först",
+        "newestFirst": "Nyaste först"
+      },
+      "by": "Av",
+      "unknownAuthor": "Okänd",
+      "reply": {
+        "action": "Svar",
+        "label": "Lägg till ett svar",
+        "placeholder": "Skriv ett svar...",
+        "submit": "Skicka svar",
+        "submitting": "Postar...",
+        "success": "Svar postat.",
+        "error": "Det går inte att skicka ditt svar just nu.",
+        "cancel": "Avbryt",
+        "loginPrompt": "Logga in för att svara."
+      },
+      "manage": {
+        "edited": "redigerad",
+        "editAction": "Redigera",
+        "deleteAction": "Ta bort",
+        "deleteConfirm": "Ta bort den här kommentaren? Detta tar också bort alla svar under den.",
+        "deleteSuccess": "Kommentar raderad.",
+        "deleteError": "Det går inte att ta bort den här kommentaren just nu.",
+        "forbidden": "Du kan bara hantera dina egna kommentarer.",
+        "edit": {
+          "label": "Redigera kommentar",
+          "save": "Spara",
+          "saving": "Sparar...",
+          "cancel": "Avbryt",
+          "success": "Kommentar uppdaterad.",
+          "error": "Det går inte att uppdatera den här kommentaren just nu."
+        }
+      },
+      "report": {
+        "action": "Rapport",
+        "pending": "Rapportering...",
+        "success": "Kommentar rapporterad.",
+        "error": "Det går inte att rapportera den här kommentaren just nu.",
+        "ownError": "Du kan inte rapportera din egen kommentar.",
+        "hidden": "Kommentar dold efter rapport.",
+        "reported": "rapporterad"
+      },
+      "deepLink": {
+        "focused": "Länkad kommentar",
+        "unavailable": "Den länkade kommentaren är inte längre tillgänglig."
+      },
+      "loadMore": "Ladda fler kommentarer",
+      "loading": "Laddar...",
+      "loadError": "Det går inte att ladda fler kommentarer just nu."
+    },
+    "share": {
+      "title": "Dela detta inlägg",
+      "shareOn": "Dela på:",
+      "nativeText": "Kolla in det här inlägget: {title}",
+      "alt": {
+        "facebook": "Facebook-logotyp",
+        "reddit": "Reddit-logotyp",
+        "whatsapp": "WhatsApp-logotyp",
+        "twitter": "Twitter-logotyp"
+      }
+    },
+    "errors": {
+      "notFound": "Inlägg hittades inte eller tillhör inte detta rum.",
+      "loadFailed": "Fel vid laddning av inläggsvy."
+    }
+  }
+}

--- a/i18n/sv/createBlock.json
+++ b/i18n/sv/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Skapa ett nytt inlägg — Daily Page",
+      "description": "Starta ett nytt kreativt inlägg med valfria taggar, språk och synlighet."
+    },
+    "heading": "Skapa ett nytt inlägg",
+    "roomInfo": {
+      "roomLabel": "Rum:",
+      "unavailable": "Rumsinformation inte tillgänglig.",
+      "noDescription": "Ingen beskrivning tillgänglig."
+    },
+    "form": {
+      "title": {
+        "label": "Titel:",
+        "placeholder": {
+          "full": "t.ex. 'My Masterpiece', 'The Best Idea Ever', 'Clickbait for Nerds'",
+          "short": "t.ex. \"Mitt mästerverk\""
+        }
+      },
+      "description": {
+        "label": "Beskrivning (valfritt):",
+        "placeholder": "Förklara din briljans... eller bara ving den."
+      },
+      "initialContent": {
+        "label": "Initialt innehåll (valfritt):",
+        "help": "Börja skriva här eller tryck på \"Skapa\" för att fortsätta på hela redigeringssidan, där du kan bädda in bilder och samarbeta i realtid.",
+        "placeholder": "Börja ditt inlägg här, eller fortsätt redigera efter skapande..."
+      },
+      "visibility": {
+        "label": "Synlighet:"
+      },
+      "submit": "Skapa inlägg"
+    },
+    "visibility": {
+      "public": {
+        "label": "Offentlig",
+        "title": "Kan redigeras av vem som helst i realtid. Ingen inloggning behövs.",
+        "inline": "Kan redigeras av vem som helst i realtid. Ingen inloggning behövs."
+      },
+      "unlisted": {
+        "label": "Onoterat utkast",
+        "title": "Dold från offentlig surfning medan den är redigerbar. Syns efter låsning.",
+        "inline": "Dold från offentlig surfning medan den är redigerbar. Syns efter låsning.",
+        "tooltip": "Olistade utkast är dolda från offentlig surfning medan de är redigerbara. Alla med länken kan samarbeta och inlägget blir offentligt när det är låst."
+      }
+    },
+    "advanced": {
+      "summary": "Avancerade alternativ",
+      "lang": {
+        "label": "Språk:",
+        "options": {
+          "en": "engelska",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "nederländska",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "Hebreiska",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Översätt befintligt inlägg (URL eller ID):",
+        "placeholder": "Klistra in en inläggs-URL eller ID (valfritt)",
+        "invalid": "Det ser inte ut som en giltig inläggs-URL eller ID.",
+        "fetchError": "Det gick inte att hämta inläggsinformation."
+      }
+    },
+    "messages": {
+      "langExists": "Det finns redan en översättning för det språket. Välj ett annat språk.",
+      "genericError": "Något gick fel. Försök igen."
+    }
+  }
+}

--- a/i18n/sv/dashboard.json
+++ b/i18n/sv/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Översikt",
+      "description": "Din Daily Page-kontos instrumentpanel och kontoöversikt."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbild",
+      "noBio": "Ingen biografi ännu. Klicka på \"Redigera\" för att lägga till en!",
+      "editBio": "Redigera bio",
+      "bioPlaceholder": "Ange din biografi här",
+      "save": "Spara",
+      "cancel": "Avbryt"
+    },
+    "activity": {
+      "title": "Senaste aktivitet",
+      "none": "Ingen senaste aktivitet.",
+      "updatedOn": "Uppdaterad på {date}",
+      "viewAllBlocks": "Visa alla inlägg"
+    },
+    "drafts": {
+      "title": "Fortsätt skriva",
+      "none": "Inga öppna utkast.",
+      "updatedOn": "Uppdaterad på {date}",
+      "unlisted": "Onoterat",
+      "viewAll": "Visa alla inlägg"
+    },
+    "streak": {
+      "title": "Skrivsvit",
+      "line": "{days} dagar i rad! Fortsätta!"
+    },
+    "starredRooms": {
+      "title": "Stjärnmärkta rum",
+      "none": "Du har inte stjärnmärkt några rum än. Börja utforska för att hitta dina favoriter!",
+      "viewAll": "Visa alla stjärnmärkta rum",
+      "unnamedRoom": "Namnlöst rum"
+    },
+    "security": {
+      "title": "Kontosäkerhet",
+      "summary": "Ändra ditt lösenord och hantera tvåfaktorsautentisering.",
+      "manage": "Hantera säkerhet"
+    },
+    "stats": {
+      "title": "Din statistik",
+      "totalBlocks": "Totalt antal inlägg skapade",
+      "collaborations": "Samarbeten",
+      "votesGiven": "givna röster",
+      "daysActive": "dagar aktiv",
+      "viewDetailed": "Visa detaljerad statistik 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Det gick inte att ladda upp profilbilden. Försök igen.",
+      "uploadUnexpected": "Ett oväntat fel inträffade. Försök igen.",
+      "bioUpdateFailed": "Fel vid uppdatering av bio. Försök igen."
+    }
+  }
+}

--- a/i18n/sv/detailedStats.json
+++ b/i18n/sv/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Detaljerad statistik",
+      "description": "En detaljerad uppdelning av din Daily Page-aktivitet."
+    },
+    "nav": {
+      "backToDashboard": "← Tillbaka till Dashboard"
+    },
+    "header": {
+      "title": "📊 Din statistiköversikt 📊"
+    },
+    "cards": {
+      "totalBlocks": "Totalt antal inlägg skapade 📝",
+      "collaborations": "Samarbeten 🤝",
+      "votesGiven": "givna röster 👍",
+      "daysActive": "dagar aktiva 📆"
+    },
+    "chart": {
+      "datasetLabel": "Din statistik",
+      "labels": {
+        "blocksCreated": "Inlägg skapade",
+        "collaborations": "Samarbeten",
+        "votesGiven": "givna röster",
+        "daysActive": "dagar aktiv"
+      }
+    }
+  }
+}

--- a/i18n/sv/errors.json
+++ b/i18n/sv/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Hoppsan! Något gick fel.",
+      "message": "Ett oväntat fel inträffade. Försök igen senare.",
+      "home": "Tillbaka till hemmet"
+    },
+    "notFound": {
+      "title": "404 - Sidan hittades inte",
+      "metaTitle": "Sidan hittades inte",
+      "message": "Tyvärr, vi kunde inte hitta sidan du letade efter.",
+      "homePrefix": "Du kan gå tillbaka till",
+      "homeLink": "hemsidan",
+      "roomsPrefix": "eller kolla in",
+      "roomsLink": "rumskatalog."
+    }
+  }
+}

--- a/i18n/sv/flagModal.json
+++ b/i18n/sv/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Rapportera olämpligt innehåll",
+    "fields": {
+      "reason": {
+        "label": "Anledning",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Stötande (hatiskt språk eller förtal)",
+          "inappropriate": "Olämpligt (nakenhet, grafiskt innehåll, etc.)",
+          "other": "Övrigt"
+        }
+      },
+      "details": {
+        "label": "Detaljer (valfritt)",
+        "placeholder": "Beskriv vad du såg..."
+      }
+    },
+    "buttons": {
+      "submit": "Skicka rapport",
+      "cancel": "Avbryt"
+    },
+    "toasts": {
+      "success": "Rapport skickad – tack!",
+      "failed": "Det gick inte att skicka rapporten."
+    }
+  }
+}

--- a/i18n/sv/forgotPassword.json
+++ b/i18n/sv/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Återställ lösenord",
+      "description": "Begär en återställningslänk för ditt Daily Page-konto."
+    },
+    "header": {
+      "title": "Glömt ditt lösenord?",
+      "subtitle": "Ange din e-postadress så skickar vi en återställningslänk till dig."
+    },
+    "form": {
+      "email": {
+        "label": "E-postadress",
+        "placeholder": "Ange din e-postadress"
+      },
+      "submit": "Begär lösenordsåterställning"
+    },
+    "feedback": {
+      "successGeneric": "Om det e-postmeddelandet finns har en återställningslänk skickats.",
+      "missingEmail": "E-post krävs.",
+      "genericError": "Något gick fel. Försök igen.",
+      "unexpectedError": "Ett oväntat fel inträffade. Försök igen."
+    },
+    "email": {
+      "subject": "Återställ lösenordet för ditt Daily Page-konto",
+      "heading": "Begäran om återställning av lösenord",
+      "headingWithName": "Begäran om återställning av lösenord, {username}",
+      "body": "Klicka på länken nedan för att återställa ditt lösenord.",
+      "cta": "Återställ mitt lösenord",
+      "expires": "Den här länken upphör om {hours} timme(r).",
+      "ignore": "Om du inte begärde en lösenordsåterställning kan du lugnt ignorera detta e-postmeddelande."
+    }
+  }
+}

--- a/i18n/sv/home.json
+++ b/i18n/sv/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Populära inlägg från de senaste 24 timmarna",
+      "description": "Daily Page är en minimalistisk, indie-skrivsida där vem som helst kan lägga upp kreativa tankar, minnen eller experiment – ett inlägg i taget. Utforska nya idéer, gå med i rum och bidra med din röst."
+    },
+    "hero": {
+      "eyebrow": "En lugn plats för att skriva, läsa och återvända",
+      "title": "Välkommen till Daily Page!",
+      "subtitle": "Utforska de mest populära inläggen från de senaste 24 timmarna.",
+      "ctaPrefix": "Känner du dig inspirerad?",
+      "cta": "Gå med i ett rum",
+      "ctaSuffix": "och skapa ditt eget inlägg!"
+    },
+    "stats": {
+      "blocks": "Inlägg",
+      "rooms": "Rum",
+      "tags": "Taggar",
+      "collabsToday": "Samarbeten idag"
+    },
+    "activity": {
+      "title": "Live på Daily Page",
+      "subtitle": "Nya samtal och reaktioner, allt i en blick.",
+      "fallbackActor": "Någon",
+      "inRoom": "i",
+      "comments": {
+        "title": "Senaste kommentarer",
+        "more": "Sök diskussioner",
+        "commentVerb": "kommenterade",
+        "replyVerb": "svarade på",
+        "empty": "Inga nya kommentarer än. Nästa konversation kan börja med ditt inlägg."
+      },
+      "reactions": {
+        "title": "Senaste reaktioner",
+        "more": "Bläddra bland populära inlägg",
+        "empty": "Inga senaste reaktioner än. Ett bra inlägg skulle kunna väcka detta snabbt.",
+        "types": {
+          "heart": "hjärta",
+          "leaf": "reagerade med ett blad på",
+          "wow": "reagerade med wow till",
+          "laugh": "skrattade åt"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Utvalda rum",
+      "roomInfoDays": "Aktivitet under de senaste {days} dagarna: {blocks} inlägg, {votes} röster.",
+      "roomInfo24h": "Aktivitet under de senaste 24 timmarna: {blocks} inlägg, {votes} röster.",
+      "checkItOut": "Kolla in det",
+      "blockRibbon": "★ Utvalda inlägg",
+      "votes": "{n} röster",
+      "noContent": "(Inget innehåll tillhandahålls...)",
+      "viewBlock": "Visa inlägg"
+    },
+    "trendingTags": {
+      "title": "Trendande taggar",
+      "suffixDays": "(senaste {days} dagarna)",
+      "suffixAllTime": "(genom tiderna)",
+      "blocks": "{n} inlägg",
+      "votes": "{n} röster",
+      "empty": "Inga trendiga taggar ännu. Bli först med att tagga något coolt!"
+    },
+    "trendingBlocks": {
+      "title": "Populära inlägg",
+      "suffixDays": "(senaste {days} dagarna)",
+      "createdBy": "Skapad av:",
+      "in": "i",
+      "on": "på",
+      "unknownRoom": "Okänt rum",
+      "empty24h": "Inga inlägg ännu under de senaste 24 timmarna. Kom tillbaka snart, kompa!"
+    }
+  }
+}

--- a/i18n/sv/layout.json
+++ b/i18n/sv/layout.json
@@ -1,0 +1,50 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Välkommen, användare!",
+    "logout": "Logga ut",
+    "login": "Logga in / Registrera dig",
+    "language": "Språk",
+    "openMenu": "Öppna huvudmenyn",
+    "closeMenu": "Stäng huvudmenyn",
+    "privacy": "Sekretesspolicy",
+    "uiFallbackNotice": "{requested} är inte översatt än. Visar {current} för tillfället.",
+    "copyButton": {
+      "copy": "Kopiera",
+      "copied": "Kopierat!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "engelska",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "nederländska",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "Hebreiska",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Tema",
+      "toggleToDark": "Växla till mörkt läge",
+      "toggleToLight": "Växla till ljusläge"
+    }
+  }
+}

--- a/i18n/sv/modals.json
+++ b/i18n/sv/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Logga in",
+      "message": "Du måste vara inloggad för att fortsätta.",
+      "messageWithAction": "Du måste vara inloggad på {action}.",
+      "cta": "Logga in"
+    },
+    "actions": {
+      "voteOnBlock": "rösta på ett inlägg",
+      "starRoom": "stjärna detta rum",
+      "reactToBlock": "reagerar på det här inlägget",
+      "commentOnBlock": "kommentera det här inlägget",
+      "reportComment": "rapportera den här kommentaren"
+    },
+    "errors": {
+      "starToggleFail": "Det gick inte att uppdatera stjärnstatus. Försök igen."
+    }
+  }
+}

--- a/i18n/sv/nav.json
+++ b/i18n/sv/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Hem",
+    "rooms": "Rum",
+    "tags": "Taggar",
+    "archive": "Arkiv",
+    "search": "Sök",
+    "bestOf": "Bäst",
+    "about": "Om",
+    "support": "Support",
+    "otherProjects": "Andra projekt",
+    "auth": {
+      "welcomePrefix": "Välkommen,",
+      "welcomeFallbackUser": "dig",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Översikt"
+  }
+}

--- a/i18n/sv/notifications.json
+++ b/i18n/sv/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Aviseringar",
+      "openMenu": "Öppna meddelanden",
+      "loading": "Laddar aviseringar...",
+      "error": "Det går inte att ladda aviseringar just nu.",
+      "empty": "Inga meddelanden än.",
+      "markRead": "Markera läst",
+      "fallbackActor": "Någon",
+      "fallbackBlockTitle": "ditt inlägg",
+      "item": {
+        "blockComment": "{actorUsername} kommenterade ditt inlägg \"{blockTitle}\".",
+        "commentReply": "{actorUsername} svarade på din kommentar om \"{blockTitle}\".",
+        "unknown": "Underrättelse"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Ny kommentar på \"{blockTitle}\"",
+        "heading": "Ny kommentar på ditt inlägg",
+        "headingWithName": "Hej {username},",
+        "body": "<strong>{actorUsername}</strong> kommenterade ditt inlägg <strong>{blockTitle}</strong>.",
+        "cta": "Se konversationen på Daily Page",
+        "fallbackActor": "Någon",
+        "fallbackBlockTitle": "ditt inlägg"
+      },
+      "commentReply": {
+        "subject": "Nytt svar på \"{blockTitle}\"",
+        "heading": "Nytt svar på din kommentar",
+        "headingWithName": "Hej {username},",
+        "body": "<strong>{actorUsername}</strong> svarade på din kommentar om <strong>{blockTitle}</strong>.",
+        "cta": "Se konversationen på Daily Page",
+        "fallbackActor": "Någon",
+        "fallbackBlockTitle": "ditt inlägg"
+      }
+    }
+  }
+}

--- a/i18n/sv/privacy.json
+++ b/i18n/sv/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Sekretesspolicy",
+      "description": "Hur Daily Page samlar in, använder och skyddar dina data, på vanligt språk."
+    },
+    "title": "Sekretesspolicy",
+    "lastUpdated": "Senast uppdaterad: {date}",
+    "intro": {
+      "h2": "Introduktion",
+      "p1": "Daily Page (\"oss\", \"vi\" eller \"vår\") driver webbplatsen dailypage.org (hädanefter kallad \"Tjänsten\").",
+      "p2": "Denna sida informerar dig om våra policyer angående insamling, användning och avslöjande av personuppgifter när du använder vår tjänst."
+    },
+    "collection": {
+      "h2": "Insamling och användning av information",
+      "p": "Vi samlar in minimala personuppgifter för att förbättra och tillhandahålla vår tjänst. Detta inkluderar e-postadresser för kontohantering och innehåll som skickas frivilligt av användare."
+    },
+    "usage": {
+      "h2": "Dataanvändning",
+      "p": "Data som samlas in används endast för kontoautentisering, innehållsmoderering och för att förbättra användarupplevelsen."
+    },
+    "storage": {
+      "h2": "Datalagring och säkerhet",
+      "p": "Dina data lagras på ett säkert sätt och delas eller säljs aldrig till tredje part utan uttryckligt medgivande, förutom vad som krävs enligt lag."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "Vi använder cookies enbart för sessionshantering och för att förbättra användarupplevelsen. Du kan inaktivera cookies via din webbläsarinställningar."
+    },
+    "rights": {
+      "h2": "Dina rättigheter",
+      "p": "Du kan begära radering eller ändring av dina personuppgifter när som helst genom att kontakta oss."
+    },
+    "changes": {
+      "h2": "Ändringar av denna integritetspolicy",
+      "p": "Vi kan komma att uppdatera vår integritetspolicy då och då. Ändringar kommer att publiceras på denna sida."
+    },
+    "contact": {
+      "h2": "Kontakta oss",
+      "p": "För frågor om denna integritetspolicy, kontakta oss på:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/sv/profile.json
+++ b/i18n/sv/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "{username}s profil",
+      "descriptionUser": "Visa {username}s senaste aktivitet, stjärnmärkta rum och statistik."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbild",
+      "noBio": "(Ingen bio tillgänglig.)"
+    },
+    "activity": {
+      "title": "Senaste aktivitet",
+      "updatedOn": "Uppdaterad på {date}",
+      "none": "Ingen senaste aktivitet.",
+      "viewAllBlocks": "Visa alla inlägg"
+    },
+    "starredRooms": {
+      "title": "Stjärnmärkta rum",
+      "none": "Inga stjärnmärkta rum än.",
+      "unnamedRoom": "Namnlöst rum"
+    },
+    "stats": {
+      "title": "Användarstatistik",
+      "totalBlocks": "Totalt antal inlägg skapade",
+      "collaborations": "Samarbeten",
+      "daysActive": "dagar aktiv"
+    }
+  }
+}

--- a/i18n/sv/random.json
+++ b/i18n/sv/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Andra projekt",
+      "description": "Utforska baseballjournalföring, slumpmässiga skrivexperiment och andra sidoprojekt från Daily Page."
+    },
+    "title": "Andra projekt",
+    "tagline": "En mysig hörna för experiment och sidouppdrag.",
+    "links": {
+      "baseball": "📖 Baseballjournal",
+      "randomWriter": "🎲 Slumpskrivare"
+    },
+    "cta": {
+      "backToRooms": "Tillbaka till huvudrummen"
+    }
+  }
+}

--- a/i18n/sv/randomWriter.json
+++ b/i18n/sv/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Slumpskrivare",
+      "description": "Generera en oändlig ström av slumpmässig pseudotext för nöje, inspiration eller kaos."
+    },
+    "title": "Slumpskrivare",
+    "buttons": {
+      "clear": "Klar",
+      "stop": "Sluta skriva",
+      "start": "Börja skriva"
+    }
+  }
+}

--- a/i18n/sv/reactions.json
+++ b/i18n/sv/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} reaktioner: {count}",
+    "loginToReact": "Logga in för att reagera",
+    "countsLabel": "Reaktioner"
+  }
+}

--- a/i18n/sv/readMore.json
+++ b/i18n/sv/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Mer...",
+    "aria": "Läs hela inlägget: {title}"
+  }
+}

--- a/i18n/sv/resetPassword.json
+++ b/i18n/sv/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Återställ ditt lösenord",
+      "description": "Ange ett nytt lösenord för ditt konto."
+    },
+    "header": {
+      "title": "Återställ ditt lösenord",
+      "subtitle": "Välj ett nytt lösenord för att få åtkomst igen."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Nytt lösenord",
+        "placeholder": "Ange nytt lösenord"
+      },
+      "submit": "Ange nytt lösenord"
+    },
+    "feedback": {
+      "missingToken": "Saknas eller ogiltig token.",
+      "missingFields": "Token och nytt lösenord krävs.",
+      "invalidOrExpired": "Ogiltig eller utgången token.",
+      "success": "Lösenordet har uppdaterats framgångsrikt!",
+      "genericError": "Något gick fel. Försök igen.",
+      "unexpectedError": "Ett oväntat fel inträffade. Försök igen."
+    }
+  }
+}

--- a/i18n/sv/roomDashboard.json
+++ b/i18n/sv/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Utforska senaste och pågående inlägg i {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Utforska:",
+      "allBlocks": "🗂️ Alla inlägg",
+      "browseByDate": "🗓️ Efter datum",
+      "bestOf": "🏅 Bäst",
+      "searchInRoom": "🔎 Sök"
+    },
+    "actions": {
+      "createBlock": "Skapa ett inlägg",
+      "starTitle": "Stjärnmärk detta rum",
+      "unstarTitle": "Avstjärna detta rum"
+    },
+    "tabs": {
+      "locked": "Låsta inlägg",
+      "inProgress": "Pågående inlägg"
+    },
+    "sections": {
+      "lockedHeader": "Låsta inlägg",
+      "inProgressHeader": "Pågående inlägg"
+    },
+    "editorial": {
+      "heading": "Utvalda guider",
+      "description": "Börja här med de utvalda guiderna som tagits fram för det här rummet.",
+      "roleNames": {
+        "pillar": "Huvudguide",
+        "companion": "Läsguide",
+        "texture": "Bakgrundsguide"
+      }
+    },
+    "empty": {
+      "noDescription": "Ingen beskrivning tillgänglig.",
+      "noLocked": "Inga låsta inlägg ännu! Automatisk låsning av inlägg efter 1 timmes inaktivitet.",
+      "noInProgress": "Inga pågående inlägg ännu! Dags att börja en.",
+      "noBlocks": "Inga inlägg än! Skapa den första och lämna dina spår. 😎"
+    }
+  }
+}

--- a/i18n/sv/roomsDirectory.json
+++ b/i18n/sv/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Rumskatalog",
+      "description": "Varje rum är en dörröppning till en annan värld. Gå in, dela din berättelse och gå med andra i att bygga något vackert."
+    },
+    "eyebrow": "Hitta ditt hörn",
+    "heading": "Rumskatalog",
+    "intro": "Börja med rummen som känns levande just nu, eller vandra efter ämne tills något klickar. Varje rum är en annan skrivuppmaning, fandom eller delad besatthet som väntar på din röst.",
+    "empty": "Inga rum är tillgängliga för tillfället. Kom tillbaka senare!",
+    "jumpToActive": "Se aktiva rum",
+    "jumpToTopics": "Bläddra efter ämne",
+    "statsLabel": "Rumskatalogens höjdpunkter",
+    "liveNow": "Live nu",
+    "recentlyActive": "Nyligen aktiv",
+    "recentlyActiveSubtitle": "Det snabbaste sättet att hitta ett rum med människor i just nu.",
+    "browseByTopic": "Bläddra efter ämne",
+    "topicSubtitle": "Öppna ett ämne för att utforska dess rum.",
+    "roomCount": "{count} rum",
+    "stats": {
+      "rooms": "rum att utforska",
+      "topics": "ämnesgrupper",
+      "active": "aktiva val"
+    },
+    "activeUsers": "Aktiva användare: {count}",
+    "visitRoom": "Besöksrum",
+    "close": "Stäng",
+    "noTitle": "Ingen titel tillgänglig",
+    "noDescription": "Ingen beskrivning tillgänglig"
+  }
+}

--- a/i18n/sv/search.json
+++ b/i18n/sv/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Sök",
+      "description": "Sök efter offentliga inlägg."
+    },
+    "title": "Sök",
+    "placeholder": "Sök inlägg...",
+    "hint": "Skriv minst 2 tecken för att söka.",
+    "noResults": "Inga resultat hittades.",
+    "untitled": "Namnlös",
+    "votesTitle": "röster",
+    "pageLabel": "sida",
+    "filters": {
+      "inRoom": "I rummet"
+    },
+    "buttons": {
+      "search": "Sök",
+      "prev": "Föreg",
+      "next": "Nästa"
+    }
+  }
+}

--- a/i18n/sv/signup.json
+++ b/i18n/sv/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Skapa ett konto",
+      "description": "Registrera dig för Daily Page för att få tillgång till alla funktioner."
+    },
+    "header": {
+      "title": "Skapa ditt konto",
+      "subtitle": "Gå med i Daily Page för att börja skapa och dela ditt dagliga skrivande!"
+    },
+    "form": {
+      "email": {
+        "label": "E-post",
+        "placeholder": "Ange din e-postadress"
+      },
+      "username": {
+        "label": "Användarnamn",
+        "placeholder": "Ange ditt användarnamn"
+      },
+      "password": {
+        "label": "Lösenord",
+        "placeholder": "Ange ett lösenord"
+      },
+      "submit": "Registrera dig",
+      "feedback": {
+        "success": "Formuläret har skickats in!",
+        "successCreatedVerify": "Konto skapat framgångsrikt! Kontrollera din e-post för att verifiera ditt konto.",
+        "genericError": "Det gick inte att skapa konto. Försök igen.",
+        "unexpectedError": "Ett oväntat fel inträffade. Försök igen."
+      }
+    }
+  }
+}

--- a/i18n/sv/starredRooms.json
+++ b/i18n/sv/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Alla stjärnmärkta rum",
+      "description": "En lista över alla rum du har stjärnmärkt."
+    },
+    "nav": {
+      "backToDashboard": "← Tillbaka till Dashboard"
+    },
+    "header": {
+      "title": "🌟 Alla dina stjärnmärkta rum 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Namnlöst rum",
+      "noDescription": "Ingen beskrivning."
+    },
+    "empty": {
+      "message": "Du har inte stjärnmärkt några rum än!"
+    }
+  }
+}

--- a/i18n/sv/support.json
+++ b/i18n/sv/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Support",
+      "description": "Hur man tar kontakt, rapporterar problem, begär funktioner eller rum och stöttar Daily Page ekonomiskt."
+    },
+    "contact": {
+      "h1": "★ Jag skulle vilja ställa en fråga, rapportera ett problem eller begära en funktion.",
+      "p1": {
+        "before": "Om du föredrar att använda GitHub, kontrollera",
+        "link": "det här projektets problem",
+        "after": "och lägg till din röst. Pull-förfrågningar är naturligtvis också välkomna."
+      },
+      "p2": {
+        "before": "Alternativt,",
+        "link": "skicka ett e-postmeddelande",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Jag skulle vilja stödja detta projekt genom ett bidrag.",
+      "p1": {
+        "before": "Tack på förhand för att du finansierar detta projekt. Skicka betalningar säkert genom",
+        "paypal": "PayPal",
+        "middle": "eller, om du föredrar,",
+        "amazon": "beställ några påsar av leksakerna jag säljer på Amazon",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Jag skulle vilja be om ett nytt rum.",
+      "form": {
+        "nameLabel": "Rumsnamn",
+        "topicLabel": "Ämne (valfritt)",
+        "descriptionLabel": "Beskrivning",
+        "submit": "Skicka förfrågan",
+        "success": "Förfrågan har skickats!",
+        "errorGeneric": "Det gick inte att skicka begäran. Försök igen.",
+        "errorUnexpected": "Ett oväntat fel inträffade. Försök igen."
+      }
+    }
+  }
+}

--- a/i18n/sv/tags.json
+++ b/i18n/sv/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Taggöversikt",
+      "description": "Bläddra bland alla taggar som används på Daily Page, med snabba filter efter tid."
+    },
+    "title": "Taggar Översikt",
+    "intro": "Utforska alla taggar som används i Daily Page.",
+    "tagCloudTitle": "Taggmoln",
+    "timeframe": {
+      "last24h": "Senaste 24 timmarna",
+      "last7d": "Senaste 7 dagarna",
+      "last30d": "Senaste 30 dagarna",
+      "all": "alla tider"
+    },
+    "error": {
+      "loading": "Fel vid laddning av taggöversikt"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": "| Daily Page",
+        "description": "Inlägg taggade med"
+      },
+      "header": {
+        "label": "Tagg:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Totalt antal inlägg med",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Skapad av:",
+        "inRoom": "i",
+        "unknownRoom": "Okänt rum",
+        "onDate": "på"
+      },
+      "chart": {
+        "label": "Inlägg skapade över tid"
+      },
+      "empty": {
+        "message": "Inga inlägg hittades med denna tagg än. Du kanske borde skapa den första? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Det gick inte att läsa in taggsidan"
+      }
+    }
+  }
+}

--- a/i18n/sv/translation.json
+++ b/i18n/sv/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Översatt från",
+    "see": "se",
+    "originalBlock": "originalinlägg"
+  }
+}

--- a/i18n/sv/userBlocks.json
+++ b/i18n/sv/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Dina inlägg",
+      "description": "Bläddra och sortera alla inlägg som du har skapat eller samarbetat med."
+    },
+    "header": {
+      "dashboardLink": "Din instrumentpanel",
+      "profileLink": "{username}s profil",
+      "allBlocks": "Alla inlägg"
+    },
+    "empty": "Inga inlägg ännu.",
+    "pagination": {
+      "prev": "← Föregående",
+      "next": "Nästa →"
+    },
+    "titleUser": "{username}s inlägg"
+  }
+}

--- a/i18n/sv/verifyEmail.json
+++ b/i18n/sv/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Verifiera e-post",
+      "description": "Verifiera din e-postadress för Daily Page."
+    },
+    "header": {
+      "title": "Verifierar din e-post..."
+    },
+    "status": {
+      "checking": "Kontrollerar token, vänligen vänta...",
+      "missingToken": "Verifieringstoken saknas eller är ogiltig.",
+      "genericFailure": "Verifiering misslyckades.",
+      "unexpectedError": "Ett oväntat fel inträffade.",
+      "success": "Ditt konto har verifierats framgångsrikt!",
+      "invalidOrExpired": "Ogiltig eller utgången verifieringstoken."
+    },
+    "verificationMsg": {
+      "subject": "Verifiera ditt Daily Page-konto ✨",
+      "heading": "Välkommen till Daily Page, {username}!",
+      "body": "Vänligen verifiera din e-post genom att klicka nedan:",
+      "cta": "Verifiera e-postadress",
+      "expires": "Den här länken upphör att gälla om {hours} timmar."
+    }
+  }
+}

--- a/i18n/sv/voteControls.json
+++ b/i18n/sv/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Uppröst",
+    "downvote": "Nedröst",
+    "errors": {
+      "failed": "Det gick inte att spara din röst."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -76,4 +76,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'hi' }).catch(console.error), 7_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'tr' }).catch(console.error), 7_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'nl' }).catch(console.error), 8_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'sv' }).catch(console.error), 8_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- add complete Swedish UI translations under `i18n/sv`
- register `sv` as a fully supported UI, email, hreflang, and home-cache locale
- preserve English locale structure and translation placeholders
- leave DB-backed room translations unchanged

## Validation

- verified Swedish matches English file-for-file and key-for-key
- verified all locale JSON parses correctly
- verified translation placeholders match English
- verified Swedish translations load through the runtime
- passed all 279 specs
- passed `git diff --check`

## Notes

Repository-wide lint continues to report pre-existing unrelated errors.

Broader existing hard-coded UI strings remain in route/API error responses and legacy side-project interfaces. These were left unchanged to keep this rollout focused.