### PR TITLE
Add complete Danish UI localization

### DIFF
--- a/i18n/da/about.json
+++ b/i18n/da/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Om",
+      "description": "Hvad Daily Page er, hvordan det virker, og hvorfor det blev bygget som et langsommere, venligere hjørne af nettet."
+    },
+    "title": "Om Daily Page",
+    "tagline": "Giv dit sind mad, ikke dit foder.",
+    "mission": {
+      "h2": "Mission",
+      "p1": "Et indie-skrivelaboratorium – startede i min stue, drevet af læserens nysgerrighed.",
+      "p2": "Det er bygget til ikke at rådne din hjerne, men for at nære den: et sted, hvor du kan skrive langsomt, anonymt, hvis du vil, og aldrig bekymre dig om at imponere nogen."
+    },
+    "how": {
+      "h2": "Hvordan det virker",
+      "features": {
+        "rooms": {
+          "label": "Rum",
+          "text": "er emne-siloer (tænk \"subreddit, men venligere\")."
+        },
+        "blocks": {
+          "label": "Indlæg",
+          "text": "er kollaborative skriverum - alle (selv \"anonyme\") kan oprette et, redigere det, indtil det er låst, og stemme på andre."
+        },
+        "privacy": {
+          "label": "Privatliv og deling",
+          "text": "betyder, at offentlige opslag er live i rummets feed. Unoterede kladder skjules, indtil de er låst, men du får et delelink for at invitere venner."
+        },
+        "markdown": {
+          "label": "Markdown & Media",
+          "text": "lader dig skrive i markdown, integrere billeder og co-redigere ligesom i Google Docs."
+        },
+        "trends": {
+          "label": "Trends og tags",
+          "text": "lad dig tagge dit opslag, spore tag-tendenser og opdage topindhold (7 d / 30 d / alle tider)."
+        },
+        "streaks": {
+          "label": "Striber",
+          "text": "hold din daglige skriverække i live – dit bedste incitament til at dukke op hver dag."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Hvordan vi kom hertil",
+      "p1": "I 2018 byggede jeg en date-baseret wiki til \"dagens side\" og så nogle få introspektive forfattere gøre den til en afsætningsmulighed for deres tanker. Den blev aldrig stor - men den plantede et frø.",
+      "p2": "Spol frem til nu, og Daily Page er det frø, der er vokset ind i mange rum - et stille socialt web for introverte, idealister og alle, der ønsker et langsommere tempo."
+    },
+    "next": {
+      "h2": "Hvad er det næste",
+      "p1": "Vi er lige begyndt: rigere indlejringer, dybere brugerstatistikker, omdømme-ranglister og flere måder at belønne tankevækkende skabelse på.",
+      "p2": "Tak fordi du er en del af dette lille indie-eksperiment."
+    },
+    "cta": {
+      "rooms": "Udforsk rum",
+      "signup": "Tilmeld dig fællesskabet"
+    }
+  }
+}

--- a/i18n/da/accountSecurity.json
+++ b/i18n/da/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Kontosikkerhed",
+      "description": "Administrer din Daily Page adgangskode og to-faktor godkendelse."
+    },
+    "backToDashboard": "Tilbage til dashboard",
+    "heading": "Kontosikkerhed",
+    "subheading": "Hold din konto beskyttet med en stærk adgangskode og en godkendelsesapp.",
+    "password": {
+      "title": "Skift adgangskode",
+      "description": "Brug en unik adgangskode med mindst 8 tegn.",
+      "current": {
+        "label": "Nuværende adgangskode"
+      },
+      "new": {
+        "label": "Ny adgangskode"
+      },
+      "submit": "Opdater adgangskode"
+    },
+    "twoFactor": {
+      "title": "To-faktor-godkendelse",
+      "statusOn": "Aktiveret",
+      "statusOff": "Slukket",
+      "description": "Tilføj en engangskode fra en godkendelsesapp efter din adgangskode, når du logger ind.",
+      "currentPassword": {
+        "label": "Nuværende adgangskode"
+      },
+      "startSetup": "Konfigurer Authenticator-appen",
+      "qrAlt": "Authenticator app QR-kode",
+      "manualKey": "Manuel opsætningstast",
+      "code": {
+        "label": "6-cifret kode"
+      },
+      "enable": "Aktiver 2FA",
+      "disableCode": {
+        "label": "Autentificeringskode"
+      },
+      "disable": "Deaktiver 2FA"
+    },
+    "recoveryCodes": {
+      "title": "Gem dine gendannelseskoder",
+      "description": "Brug en af ​​disse engangskoder til at logge ind, hvis du mister adgangen til din autentificeringsapp.",
+      "regenerateDescription": "Generer et nyt sæt gendannelseskoder, hvis du mistede det forrige sæt. Dette ugyldiggør eventuelle gamle gendannelseskoder.",
+      "regenerate": "Generer nye gendannelseskoder",
+      "warning": "Opbevar dem et sikkert sted. De vil ikke blive vist igen."
+    },
+    "feedback": {
+      "passwordChanged": "Din adgangskode blev opdateret.",
+      "setupReady": "Scan QR-koden, og indtast derefter den 6-cifrede kode for at afslutte opsætningen.",
+      "twoFactorEnabled": "To-faktor-godkendelse er nu aktiveret.",
+      "twoFactorDisabled": "To-faktor-godkendelse er nu deaktiveret.",
+      "recoveryCodesRegenerated": "Dine gendannelseskoder blev gendannet. Gem de nye koder nu.",
+      "missingFields": "Udfyld venligst alle obligatoriske felter.",
+      "missingCurrentPassword": "Indtast din nuværende adgangskode for at fortsætte.",
+      "passwordTooShort": "Din nye adgangskode skal være på mindst 8 tegn.",
+      "invalidCurrentPassword": "Den aktuelle adgangskode matchede ikke.",
+      "missingCode": "Indtast den 6-cifrede kode fra din autentificeringsapp.",
+      "invalidCode": "Den kode virkede ikke. Prøv venligst igen.",
+      "noPendingSetup": "Start opsætningen igen, før du indtaster en kode.",
+      "setupExpired": "Denne opsætningssession udløb. Start opsætningen igen for at få en ny QR-kode.",
+      "twoFactorNotEnabled": "To-faktor-godkendelse er ikke aktiveret for denne konto.",
+      "genericError": "Noget gik galt. Prøv venligst igen.",
+      "unexpectedError": "Der opstod en uventet fejl. Prøv venligst igen."
+    }
+  }
+}

--- a/i18n/da/anonymousUser.json
+++ b/i18n/da/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Den anonyme vandrer",
+      "description": "Ingen profil. Ingen fortid. Bare vibes."
+    },
+    "ascii": {
+      "ariaLabel": "ASCII kunst af lunefuldt væsen med citat"
+    },
+    "header": {
+      "title": "Den Anonyme"
+    },
+    "body": {
+      "line1": "Du er snublet ind i tomrummet. Der er intet at se her -",
+      "line2": "bare en omvandrende ånd uden en historie."
+    },
+    "buttons": {
+      "home": "← Vend hjem",
+      "signup": "Skab en identitet"
+    }
+  }
+}

--- a/i18n/da/archive.json
+++ b/i18n/da/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arkiv",
+      "description": "Udforsk hele arkivet efter måned.",
+      "titleRoom": "Daily Page — Arkiv · {roomName}",
+      "descriptionRoom": "Udforsk tidligere skrivninger i rummet {roomName} - måned for måned. Hop til en hvilken som helst dato for at se, hvad andre har delt i dette rum over tid."
+    },
+    "nav": {
+      "prev": "Tidligere",
+      "next": "Næste"
+    },
+    "title": "📚 Gennemse arkiver",
+    "titleRoom": "📚 {roomName} — Arkiver",
+    "roomViewing": "Viser arkiv for rum {roomName}",
+    "viewRoomLink": "Udsigt rum",
+    "noContent": "Intet indhold tilgængeligt endnu.",
+    "backToRoom": "← Tilbage til Rumoversigt",
+    "calendar": {
+      "meta": {
+        "description": "Se alle kreative indlæg udgivet i {month} {year}—fra hurtige tanker til dybe refleksioner. Klik på en hvilken som helst dato for at se, hvad der blev delt.",
+        "descriptionRoom": "Se den kreative aktivitet i {roomName} under {month} {year}. Vælg en dato for at udforske de opslag, der blev delt den dag."
+      },
+      "title": "📆 Arkiv for {month} {year}",
+      "prevLabel": "Arkiv for {month} {year}",
+      "nextLabel": "Arkiv for {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Arkiv for {date}",
+        "titleRoom": "{roomName} — Arkiv for {date}",
+        "descriptionSite": "Udforsk indlæg skrevet på {date}—fra stille noter til vilde bekendelser.",
+        "descriptionRoom": "På {date} satte forfattere i rummet {roomName} deres præg - rul gennem refleksioner, ideer og udtryk, der blev delt den dag."
+      },
+      "heading": "Arkiv for {date}",
+      "empty": "Der blev ikke fundet noget indhold for denne dato.",
+      "labels": {
+        "createdBy": "Skabt af:",
+        "in": "i",
+        "on": "på {datetime}",
+        "unknownRoom": "Ukendt rum"
+      },
+      "nav": {
+        "prevDay": "Forrige dag",
+        "nextDay": "Næste dag"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Alle indlæg",
+        "descriptionRoom": "Gennemse hvert indlæg, der nogensinde er udgivet i rummet {roomName}. Sorter efter dato, titel eller stemmer for at udforske dens historie."
+      },
+      "header": {
+        "allBlocks": "— Alle indlæg"
+      },
+      "sort": {
+        "label": "Sorter efter",
+        "options": {
+          "date": "Dato",
+          "title": "Titel",
+          "votes": "Stemmer"
+        },
+        "submit": "Gå"
+      }
+    },
+    "pagination": {
+      "prev": "← Forrige",
+      "next": "Næste →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daglige sider for {time}"
+      },
+      "empty": "Vi kunne ikke finde nogen sider i denne tidsramme."
+    }
+  }
+}

--- a/i18n/da/auth.json
+++ b/i18n/da/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Log ind",
+        "description": "Log ind på din Daily Page-konto for at fortsætte din skriverejse."
+      },
+      "heading": "Velkommen tilbage!",
+      "subheading": "Log ind på din konto for at fortsætte med at dele din daglige skrivning.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Brugernavn eller e-mail",
+          "placeholder": "Indtast dit brugernavn eller din e-mail"
+        },
+        "password": {
+          "label": "Adgangskode",
+          "placeholder": "Indtast din adgangskode"
+        },
+        "totpCode": {
+          "label": "Autentificerings- eller gendannelseskode",
+          "placeholder": "Indtast kode"
+        }
+      },
+      "actions": {
+        "submit": "Log ind"
+      },
+      "feedback": {
+        "success": "Login lykkedes! Omdirigerer...",
+        "twoFactorRequired": "Indtast den 6-cifrede kode fra din autentificeringsapp, eller brug en gendannelseskode.",
+        "twoFactorFailed": "Den kode virkede ikke. Prøv venligst igen.",
+        "failedGeneric": "Login mislykkedes. Prøv venligst igen.",
+        "unexpected": "Der opstod en uventet fejl. Prøv venligst igen."
+      },
+      "links": {
+        "forgotPassword": "Har du glemt din adgangskode?",
+        "noAccount": "Har du ikke en konto endnu?",
+        "signupHere": "Tilmeld dig her!"
+      }
+    }
+  }
+}

--- a/i18n/da/bestOf.json
+++ b/i18n/da/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Det bedste fra Daily Page",
+      "description": "De mest elskede indlæg på Daily Page—sjove, ærlige, poetiske eller bare underlige. Se, hvad der skilte sig ud i løbet af den seneste dag, uge, måned og videre.",
+      "titleRoom": "Det bedste fra {roomName}",
+      "descriptionRoom": "Oplev enestående indlæg fra rummet {roomName} – dem, læserne elskede mest i løbet af de sidste 24 timer, 7 dage, 30 dage og hele tiden."
+    },
+    "heading": "🏆 Bedst fra Daily Page",
+    "headingRoomPrefix": "🏆 Bedst af",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 timer",
+      "7d": "🚀 7 dage",
+      "30d": "🌕 30 dage",
+      "all": "👑 Alle tider"
+    },
+    "labels": {
+      "createdBy": "Skabt af:",
+      "inRoom": "i",
+      "onDate": "på {date}",
+      "unknownRoom": "Ukendt rum",
+      "noBlocks": "Ingen indlæg fundet.",
+      "viewRoom": "Udsigt rum"
+    }
+  }
+}

--- a/i18n/da/blockCommon.json
+++ b/i18n/da/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Udkast"
+    },
+    "deleteModal": {
+      "title": "Slet indlæg?",
+      "message": "Denne handling kan ikke fortrydes.",
+      "confirm": "Slet",
+      "cancel": "Ophæve",
+      "closeAriaLabel": "Tæt"
+    },
+    "toasts": {
+      "deleteSuccess": "Indlægget blev slettet!",
+      "deleteFailed": "Kunne ikke slette indlægget."
+    }
+  }
+}

--- a/i18n/da/blockEditor.json
+++ b/i18n/da/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Du)"
+    },
+    "meta": {
+      "title": "Rediger indlæg - {blockTitle}",
+      "titleFallback": "Rediger indlæg"
+    },
+    "errors": {
+      "imageUrlRequired": "Indtast venligst en billed-URL.",
+      "notFound": "Indlægget blev ikke fundet eller hører ikke til dette rum.",
+      "loadFailed": "Der opstod en fejl under indlæsning af indlægseditoren.",
+      "updateTitleFailed": "Fejl under opdatering af titel."
+    },
+    "roomInfo": {
+      "label": "Rum:"
+    },
+    "title": {
+      "placeholder": "Indtast indlægstitel",
+      "editTooltip": "Rediger titel",
+      "lock": "Låsestolpe",
+      "delete": "Slet indlæg"
+    },
+    "description": {
+      "label": "Beskrivelse",
+      "editTooltip": "Rediger beskrivelse",
+      "placeholder": "Indtast beskrivelse",
+      "noDescriptionOwner": "Ingen beskrivelse endnu...",
+      "noDescriptionViewer": "Ingen beskrivelse angivet...",
+      "save": "Spare",
+      "cancel": "Ophæve",
+      "expand": "Udvide",
+      "collapse": "Bryde sammen",
+      "updateError": "Fejl ved opdatering af beskrivelse."
+    },
+    "status": {
+      "lastBackup": "Sidste backup: {datetime}",
+      "lastBackupUnknown": "Sidste backup: Ukendt"
+    },
+    "peers": {
+      "label": "Peers:"
+    },
+    "toasts": {
+      "blockLocked": "Dette indlæg er blevet låst!"
+    },
+    "editor": {
+      "placeholder": "Den tomme side venter på din stemme; skrive frygtløst."
+    },
+    "loading": {
+      "label": "Indlæser",
+      "quote": "Lad verden brænde igennem dig. Kast prismelyset, hvidt varmt, på papir.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Du har ikke skrevet noget i 5 minutter. Klik på OK for at fortsætte sessionen; ellers vil du blive omdirigeret til arkivet.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link til deling",
+      "copyTooltip": "Kopiér til udklipsholder",
+      "copied": "Kopieret!"
+    },
+    "toolbar": {
+      "insertImage": "Indsæt billede",
+      "insertImageUrlPlaceholder": "Indtast billed-URL",
+      "insertImageAltPlaceholder": "Alt tekst (valgfrit)",
+      "insertImageConfirm": "Bekræfte",
+      "insertImageCancel": "Ophæve"
+    },
+    "buttons": {
+      "downloadFile": "Download fil"
+    },
+    "lockModal": {
+      "messageLine1": "Er du sikker på, at du vil låse dette indlæg?",
+      "messageLine2": "Dette vil afslutte det og forhindre yderligere redigering.",
+      "confirm": "Låse",
+      "cancel": "Ophæve",
+      "successToast": "Indlægget blev låst.",
+      "errorToast": "Fejl ved låsning af post."
+    },
+    "tags": {
+      "headerWithTags": "Tags:",
+      "headerNoTags": "Ingen tags endnu! Tilføj nogle:",
+      "updateError": "Fejl under opdatering af tags."
+    },
+    "fullBlock": {
+      "headingPrefix": "Undskyld; indlægget \"{blockTitle}\" er nu",
+      "headingStatus": "fuldt optaget.",
+      "retryPrefix": "Behage",
+      "retryLink": "prøv et andet indlæg",
+      "retrySuffix": "eller kom tilbage en anden gang.",
+      "consolationPrefix": "Mens du venter, er du velkommen til at læse",
+      "consolationBestOf": "nogle af vores yndlingsindlæg",
+      "consolationMiddle": "eller for at gennemse",
+      "consolationArchive": "arkivet."
+    }
+  }
+}

--- a/i18n/da/blockList.json
+++ b/i18n/da/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "hele tiden",
+      "days": "i de sidste {n} dage",
+      "day": "inden for de sidste 24 timer"
+    },
+    "createdBy": "Skabt af:",
+    "on": "på"
+  }
+}

--- a/i18n/da/blockTags.json
+++ b/i18n/da/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tags:",
+      "noTags": "Ingen tags endnu! Tilføj nogle:"
+    },
+    "input": {
+      "placeholder": "Nyt tag",
+      "addButton": "Tilføje"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/da/blockView.json
+++ b/i18n/da/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Indlæg - {blockTitle}",
+      "titleFallback": "Stolpe"
+    },
+    "labels": {
+      "room": "Rum",
+      "author": "Forfatter",
+      "created": "Oprettet",
+      "unknownAuthor": "Anonym",
+      "authorAvatarAlt": "{username}s avatar",
+      "viewAuthorProfile": "Se {username}s profil",
+      "lang": "Oversættelser:",
+      "available": "tilgængelig"
+    },
+    "buttons": {
+      "edit": "Redigere",
+      "deleteBlock": "Slet indlæg",
+      "share": "Dele",
+      "flagContent": "Flag indhold"
+    },
+    "description": {
+      "label": "Beskrivelse",
+      "none": "Ingen beskrivelse angivet...",
+      "expand": "Udvide",
+      "collapse": "Bryde sammen"
+    },
+    "editorial": {
+      "heading": "Læsevejledning",
+      "roleLabel": "Læsetype",
+      "clusterLabel": "Guide",
+      "sequence": "Del {sequence}",
+      "primaryPillarHeading": "Start her",
+      "relatedHeading": "Fortsæt med at læse",
+      "clusterHeading": "Mere i denne guide",
+      "expandSection": "Vis {count} mere",
+      "collapseSection": "Vis mindre",
+      "roleNames": {
+        "pillar": "Kernevejledning",
+        "companion": "Dybt dyk",
+        "texture": "Baggrund"
+      }
+    },
+    "comments": {
+      "heading": "Kommentarer",
+      "count": "{count} kommentarer",
+      "empty": "Ingen har svaret endnu. Kommentarer vises her, når samtalen starter.",
+      "composer": {
+        "label": "Tilføj en kommentar",
+        "placeholder": "Skriv en kommentar...",
+        "submit": "Skriv kommentar",
+        "submitting": "Sender...",
+        "success": "Kommentar indsendt.",
+        "error": "Kan ikke skrive din kommentar lige nu.",
+        "loginPrompt": "Log ind for at deltage i samtalen.",
+        "loginCta": "Log ind for at kommentere",
+        "verifyPrompt": "Bekræft din e-mail, før du sender en kommentar.",
+        "verifyCta": "Bekræft e-mail"
+      },
+      "sort": {
+        "label": "Sortere",
+        "oldestFirst": "Ældste først",
+        "newestFirst": "Nyeste først"
+      },
+      "by": "Ved",
+      "unknownAuthor": "Ukendt",
+      "reply": {
+        "action": "Svar",
+        "label": "Tilføj et svar",
+        "placeholder": "Skriv et svar...",
+        "submit": "Send svar",
+        "submitting": "Sender...",
+        "success": "Svar indsendt.",
+        "error": "Kan ikke sende dit svar lige nu.",
+        "cancel": "Ophæve",
+        "loginPrompt": "Log ind for at svare."
+      },
+      "manage": {
+        "edited": "Redigeret",
+        "editAction": "Redigere",
+        "deleteAction": "Slet",
+        "deleteConfirm": "Vil du slette denne kommentar? Dette vil også fjerne eventuelle svar under den.",
+        "deleteSuccess": "Kommentar slettet.",
+        "deleteError": "Kan ikke slette denne kommentar lige nu.",
+        "forbidden": "Du kan kun administrere dine egne kommentarer.",
+        "edit": {
+          "label": "Rediger kommentar",
+          "save": "Spare",
+          "saving": "Gemmer...",
+          "cancel": "Ophæve",
+          "success": "Kommentar opdateret.",
+          "error": "Kan ikke opdatere denne kommentar lige nu."
+        }
+      },
+      "report": {
+        "action": "Rapport",
+        "pending": "Rapporterer...",
+        "success": "Kommentar indberettet.",
+        "error": "Kan ikke rapportere denne kommentar lige nu.",
+        "ownError": "Du kan ikke rapportere din egen kommentar.",
+        "hidden": "Kommentar skjult efter rapport.",
+        "reported": "Rapporteret"
+      },
+      "deepLink": {
+        "focused": "Linket kommentar",
+        "unavailable": "Den linkede kommentar er ikke længere tilgængelig."
+      },
+      "loadMore": "Indlæs flere kommentarer",
+      "loading": "Indlæser...",
+      "loadError": "Kan ikke indlæse flere kommentarer lige nu."
+    },
+    "share": {
+      "title": "Del dette opslag",
+      "shareOn": "Del på:",
+      "nativeText": "Tjek dette indlæg: {title}",
+      "alt": {
+        "facebook": "Facebook logo",
+        "reddit": "Reddit logo",
+        "whatsapp": "WhatsApp logo",
+        "twitter": "Twitter-logo"
+      }
+    },
+    "errors": {
+      "notFound": "Indlægget blev ikke fundet eller hører ikke til dette rum.",
+      "loadFailed": "Fejl ved indlæsning af indlægsvisning."
+    }
+  }
+}

--- a/i18n/da/createBlock.json
+++ b/i18n/da/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Opret et nyt indlæg — Daily Page",
+      "description": "Start et nyt kreativt indlæg med valgfri tags, sprog og synlighed."
+    },
+    "heading": "Opret et nyt indlæg",
+    "roomInfo": {
+      "roomLabel": "Rum:",
+      "unavailable": "Rumsinformation er ikke tilgængelig.",
+      "noDescription": "Ingen beskrivelse tilgængelig."
+    },
+    "form": {
+      "title": {
+        "label": "Titel:",
+        "placeholder": {
+          "full": "f.eks. 'My Masterpiece', 'The Best Idea Ever', 'Clickbait for Nerds'",
+          "short": "f.eks. 'Mit mesterværk'"
+        }
+      },
+      "description": {
+        "label": "Beskrivelse (valgfrit):",
+        "placeholder": "Forklar din glans ... eller bare ving den."
+      },
+      "initialContent": {
+        "label": "Indledende indhold (valgfrit):",
+        "help": "Begynd at skrive her eller tryk på \"Opret\" for at fortsætte på hele editorsiden, hvor du kan indlejre billeder og samarbejde i realtid.",
+        "placeholder": "Start dit indlæg her, eller fortsæt med at redigere efter oprettelsen..."
+      },
+      "visibility": {
+        "label": "Sigtbarhed:"
+      },
+      "submit": "Opret indlæg"
+    },
+    "visibility": {
+      "public": {
+        "label": "Offentlig",
+        "title": "Kan redigeres af alle i realtid. Ingen login nødvendig.",
+        "inline": "Kan redigeres af alle i realtid. Ingen login nødvendig."
+      },
+      "unlisted": {
+        "label": "Unoteret udkast",
+        "title": "Skjult fra offentlig browsing, mens den kan redigeres. Synlig efter låsning.",
+        "inline": "Skjult fra offentlig browsing, mens den kan redigeres. Synlig efter låsning.",
+        "tooltip": "Ikke-opførte kladder er skjult fra offentlig browsing, mens de kan redigeres. Alle med linket kan samarbejde, og indlægget bliver offentligt, når det er låst."
+      }
+    },
+    "advanced": {
+      "summary": "Avancerede muligheder",
+      "lang": {
+        "label": "Sprog:",
+        "options": {
+          "en": "engelsk",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesien",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "hebraisk",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Oversæt eksisterende indlæg (URL eller ID):",
+        "placeholder": "Indsæt et indlægs URL eller id (valgfrit)",
+        "invalid": "Det ligner ikke en gyldig indlægs-URL eller ID.",
+        "fetchError": "Kunne ikke hente indlægsoplysninger."
+      }
+    },
+    "messages": {
+      "langExists": "Der findes allerede en oversættelse til det sprog. Vælg venligst et andet sprog.",
+      "genericError": "Noget gik galt. Prøv venligst igen."
+    }
+  }
+}

--- a/i18n/da/dashboard.json
+++ b/i18n/da/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Dashboard",
+      "description": "Dit Daily Page dashboard og kontooversigt."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbillede",
+      "noBio": "Ingen bio endnu. Klik på \"Rediger\" for at tilføje en!",
+      "editBio": "Rediger bio",
+      "bioPlaceholder": "Indtast din bio her",
+      "save": "Spare",
+      "cancel": "Ophæve"
+    },
+    "activity": {
+      "title": "Seneste aktivitet",
+      "none": "Ingen nylig aktivitet.",
+      "updatedOn": "Opdateret den {date}",
+      "viewAllBlocks": "Se alle indlæg"
+    },
+    "drafts": {
+      "title": "Fortsæt med at skrive",
+      "none": "Ingen åbne kladder.",
+      "updatedOn": "Opdateret den {date}",
+      "unlisted": "Unoteret",
+      "viewAll": "Se alle indlæg"
+    },
+    "streak": {
+      "title": "Skriverække",
+      "line": "{days} dage i træk! Fortsæt!"
+    },
+    "starredRooms": {
+      "title": "Stjernemarkerede rum",
+      "none": "Du har ikke stjernemarkeret nogen rum endnu. Begynd at udforske for at finde dine favoritter!",
+      "viewAll": "Se alle stjernede rum",
+      "unnamedRoom": "Unavngivet rum"
+    },
+    "security": {
+      "title": "Kontosikkerhed",
+      "summary": "Skift din adgangskode og administrer to-faktor-godkendelse.",
+      "manage": "Administrer sikkerhed"
+    },
+    "stats": {
+      "title": "Dine statistikker",
+      "totalBlocks": "Samlet antal oprettede indlæg",
+      "collaborations": "Samarbejde",
+      "votesGiven": "Afgivne stemmer",
+      "daysActive": "Aktive dage",
+      "viewDetailed": "Se detaljerede statistikker 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Kunne ikke uploade profilbillede. Prøv venligst igen.",
+      "uploadUnexpected": "Der opstod en uventet fejl. Prøv venligst igen.",
+      "bioUpdateFailed": "Fejl under opdatering af bio. Prøv venligst igen."
+    }
+  }
+}

--- a/i18n/da/detailedStats.json
+++ b/i18n/da/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Detaljeret statistik",
+      "description": "En detaljeret oversigt over din Daily Page aktivitet."
+    },
+    "nav": {
+      "backToDashboard": "← Tilbage til Dashboard"
+    },
+    "header": {
+      "title": "📊 Oversigt over din statistik 📊"
+    },
+    "cards": {
+      "totalBlocks": "Samlet antal oprettede indlæg 📝",
+      "collaborations": "Samarbejde 🤝",
+      "votesGiven": "Stemmer givet 👍",
+      "daysActive": "Aktive dage 📆"
+    },
+    "chart": {
+      "datasetLabel": "Dine statistikker",
+      "labels": {
+        "blocksCreated": "Indlæg oprettet",
+        "collaborations": "Samarbejde",
+        "votesGiven": "Afgivne stemmer",
+        "daysActive": "Aktive dage"
+      }
+    }
+  }
+}

--- a/i18n/da/errors.json
+++ b/i18n/da/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ups! Noget gik galt.",
+      "message": "Der opstod en uventet fejl. Prøv venligst igen senere.",
+      "home": "Tilbage til Hjemmet"
+    },
+    "notFound": {
+      "title": "404 - Side ikke fundet",
+      "metaTitle": "Side ikke fundet",
+      "message": "Beklager, vi kunne ikke finde den side, du ledte efter.",
+      "homePrefix": "Du kan gå tilbage til",
+      "homeLink": "hjemmesiden",
+      "roomsPrefix": "eller tjek ud",
+      "roomsLink": "rumoversigt."
+    }
+  }
+}

--- a/i18n/da/flagModal.json
+++ b/i18n/da/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Rapporter upassende indhold",
+    "fields": {
+      "reason": {
+        "label": "Årsag",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Stødende (hadefuldt sprog eller besværligheder)",
+          "inappropriate": "Upassende (nøgenhed, grafisk indhold osv.)",
+          "other": "Andre"
+        }
+      },
+      "details": {
+        "label": "Detaljer (valgfrit)",
+        "placeholder": "Beskriv hvad du så..."
+      }
+    },
+    "buttons": {
+      "submit": "Indsend rapport",
+      "cancel": "Ophæve"
+    },
+    "toasts": {
+      "success": "Rapport indsendt - tak!",
+      "failed": "Rapporten kunne ikke indsendes."
+    }
+  }
+}

--- a/i18n/da/forgotPassword.json
+++ b/i18n/da/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Nulstil adgangskode",
+      "description": "Anmod om et nulstillingslink til din Daily Page konto."
+    },
+    "header": {
+      "title": "Glemt dit kodeord?",
+      "subtitle": "Indtast din e-mail, og vi sender dig et nulstillingslink."
+    },
+    "form": {
+      "email": {
+        "label": "E-mailadresse",
+        "placeholder": "Indtast din e-mail"
+      },
+      "submit": "Anmod om nulstilling af adgangskode"
+    },
+    "feedback": {
+      "successGeneric": "Hvis denne e-mail findes, er der sendt et nulstillingslink.",
+      "missingEmail": "E-mail er påkrævet.",
+      "genericError": "Noget gik galt. Prøv venligst igen.",
+      "unexpectedError": "Der opstod en uventet fejl. Prøv venligst igen."
+    },
+    "email": {
+      "subject": "Nulstil din Daily Page adgangskode",
+      "heading": "Anmodning om nulstilling af adgangskode",
+      "headingWithName": "Anmodning om nulstilling af adgangskode, {username}",
+      "body": "Klik på linket nedenfor for at nulstille din adgangskode.",
+      "cta": "Nulstil min adgangskode",
+      "expires": "Dette link udløber om {hours} time(r).",
+      "ignore": "Hvis du ikke har anmodet om en nulstilling af adgangskoden, kan du roligt ignorere denne e-mail."
+    }
+  }
+}

--- a/i18n/da/home.json
+++ b/i18n/da/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Populære indlæg fra de sidste 24 timer",
+      "description": "Daily Page er et minimalistisk, indie-skrivewebsted, hvor alle kan poste kreative tanker, minder eller eksperimenter – et indlæg ad gangen. Udforsk nye ideer, deltag i rum, og bidrag med din stemme."
+    },
+    "hero": {
+      "eyebrow": "Et roligt sted at skrive, læse og vende tilbage",
+      "title": "Velkommen til Daily Page!",
+      "subtitle": "Udforsk de mest populære indlæg fra de sidste 24 timer.",
+      "ctaPrefix": "Føler du dig inspireret?",
+      "cta": "Deltag i et rum",
+      "ctaSuffix": "og lav dit eget indlæg!"
+    },
+    "stats": {
+      "blocks": "Indlæg",
+      "rooms": "Rum",
+      "tags": "Tags",
+      "collabsToday": "Samarbejde i dag"
+    },
+    "activity": {
+      "title": "Live på Daily Page",
+      "subtitle": "Frisk samtale og reaktioner, alt sammen i ét blik.",
+      "fallbackActor": "Nogen",
+      "inRoom": "i",
+      "comments": {
+        "title": "Seneste kommentarer",
+        "more": "Søg efter diskussioner",
+        "commentVerb": "kommenterede",
+        "replyVerb": "svarede på",
+        "empty": "Ingen nyere kommentarer endnu. Den næste samtale kan starte med dit indlæg."
+      },
+      "reactions": {
+        "title": "Seneste reaktioner",
+        "more": "Gennemse populære indlæg",
+        "empty": "Ingen nylige reaktioner endnu. Et godt indlæg kunne hurtigt vække dette.",
+        "types": {
+          "heart": "hjerteligt",
+          "leaf": "reagerede med et blad på",
+          "wow": "reagerede med wow til",
+          "laugh": "grinede af"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Udvalgt rum",
+      "roomInfoDays": "Aktivitet over de seneste {days} dage: {blocks} indlæg, {votes} stemmer.",
+      "roomInfo24h": "Aktivitet i løbet af de sidste 24 timer: {blocks} indlæg, {votes} stemmer.",
+      "checkItOut": "Tjek det ud",
+      "blockRibbon": "★ Udvalgte indlæg",
+      "votes": "{n} stemmer",
+      "noContent": "(Intet indhold angivet...)",
+      "viewBlock": "Se indlæg"
+    },
+    "trendingTags": {
+      "title": "Populære tags",
+      "suffixDays": "(sidste {days} dage)",
+      "suffixAllTime": "(alle tider)",
+      "blocks": "{n} indlæg",
+      "votes": "{n} stemmer",
+      "empty": "Ingen populære tags endnu. Vær den første til at tagge noget fedt!"
+    },
+    "trendingBlocks": {
+      "title": "Populære indlæg",
+      "suffixDays": "(sidste {days} dage)",
+      "createdBy": "Skabt af:",
+      "in": "i",
+      "on": "på",
+      "unknownRoom": "Ukendt rum",
+      "empty24h": "Ingen indlæg endnu inden for de sidste 24 timer. Kom snart tilbage, compa!"
+    }
+  }
+}

--- a/i18n/da/layout.json
+++ b/i18n/da/layout.json
@@ -1,0 +1,55 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Velkommen, bruger!",
+    "logout": "Log ud",
+    "login": "Log ind / Tilmeld dig",
+    "language": "Sprog",
+    "openMenu": "Åbn hovedmenuen",
+    "closeMenu": "Luk hovedmenuen",
+    "privacy": "Privatlivspolitik",
+    "uiFallbackNotice": "{requested} er ikke oversat endnu. Viser {current} for nu.",
+    "copyButton": {
+      "copy": "Kopi",
+      "copied": "Kopieret!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "engelsk",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesien",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "hebraisk",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Tema",
+      "toggleToDark": "Skift til mørk tilstand",
+      "toggleToLight": "Skift til lystilstand"
+    },
+    "blockImages": {
+      "preview": "Forhåndsvisning af billede",
+      "close": "Luk forhåndsvisning af billede",
+      "open": "Åbn forhåndsvisning af billede"
+    }
+  }
+}

--- a/i18n/da/modals.json
+++ b/i18n/da/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Log venligst ind",
+      "message": "Du skal være logget ind for at fortsætte.",
+      "messageWithAction": "Du skal være logget ind på {action}.",
+      "cta": "Log ind"
+    },
+    "actions": {
+      "voteOnBlock": "stemme på et opslag",
+      "starRoom": "stjerne dette rum",
+      "reactToBlock": "reagere på dette indlæg",
+      "commentOnBlock": "kommentere dette indlæg",
+      "reportComment": "rapporter denne kommentar"
+    },
+    "errors": {
+      "starToggleFail": "Kunne ikke opdatere stjernestatus. Prøv venligst igen."
+    }
+  }
+}

--- a/i18n/da/nav.json
+++ b/i18n/da/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Hjem",
+    "rooms": "Rum",
+    "tags": "Tags",
+    "archive": "Arkiv",
+    "search": "Søg",
+    "bestOf": "Det bedste",
+    "about": "Om",
+    "support": "Støtte",
+    "otherProjects": "Andre projekter",
+    "auth": {
+      "welcomePrefix": "Velkomst,",
+      "welcomeFallbackUser": "du",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Dashboard"
+  }
+}

--- a/i18n/da/notifications.json
+++ b/i18n/da/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Meddelelser",
+      "openMenu": "Åbn notifikationer",
+      "loading": "Indlæser notifikationer...",
+      "error": "Kunne ikke indlæse notifikationer lige nu.",
+      "empty": "Ingen notifikationer endnu.",
+      "markRead": "Mark læst",
+      "fallbackActor": "Nogen",
+      "fallbackBlockTitle": "dit indlæg",
+      "item": {
+        "blockComment": "{actorUsername} kommenterede dit indlæg \"{blockTitle}\".",
+        "commentReply": "{actorUsername} svarede på din kommentar til \"{blockTitle}\".",
+        "unknown": "Notifikation"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Ny kommentar til \"{blockTitle}\"",
+        "heading": "Ny kommentar til dit indlæg",
+        "headingWithName": "Hej {username},",
+        "body": "<strong>{actorUsername}</strong> kommenterede dit indlæg <strong>{blockTitle}</strong>.",
+        "cta": "Se samtalen på Daily Page",
+        "fallbackActor": "Nogen",
+        "fallbackBlockTitle": "dit indlæg"
+      },
+      "commentReply": {
+        "subject": "Nyt svar på \"{blockTitle}\"",
+        "heading": "Nyt svar på din kommentar",
+        "headingWithName": "Hej {username},",
+        "body": "<strong>{actorUsername}</strong> svarede på din kommentar til <strong>{blockTitle}</strong>.",
+        "cta": "Se samtalen på Daily Page",
+        "fallbackActor": "Nogen",
+        "fallbackBlockTitle": "dit indlæg"
+      }
+    }
+  }
+}

--- a/i18n/da/privacy.json
+++ b/i18n/da/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Privatlivspolitik",
+      "description": "Hvordan Daily Page indsamler, bruger og beskytter dine data, i almindeligt sprog."
+    },
+    "title": "Privatlivspolitik",
+    "lastUpdated": "Sidst opdateret: {date}",
+    "intro": {
+      "h2": "Indledning",
+      "p1": "Daily Page (\"os\", \"vi\" eller \"vores\") driver websitet dailypage.org (herefter benævnt \"tjenesten\").",
+      "p2": "Denne side informerer dig om vores politikker vedrørende indsamling, brug og videregivelse af personlige data, når du bruger vores Tjeneste."
+    },
+    "collection": {
+      "h2": "Indsamling og brug af oplysninger",
+      "p": "Vi indsamler minimale personlige data for at forbedre og levere vores service. Dette inkluderer e-mailadresser til kontoadministration og indhold, der er indsendt frivilligt af brugere."
+    },
+    "usage": {
+      "h2": "Dataforbrug",
+      "p": "De indsamlede data bruges udelukkende til kontogodkendelse, indholdsmoderering og forbedring af brugeroplevelsen."
+    },
+    "storage": {
+      "h2": "Datalagring og sikkerhed",
+      "p": "Dine data opbevares sikkert og deles eller sælges aldrig til tredjemand uden udtrykkeligt samtykke, undtagen som krævet ved lov."
+    },
+    "cookies": {
+      "h2": "Cookies",
+      "p": "Vi bruger udelukkende cookies til sessionsstyring og forbedring af brugeroplevelsen. Du kan deaktivere cookies via dine browserindstillinger."
+    },
+    "rights": {
+      "h2": "Dine rettigheder",
+      "p": "Du kan til enhver tid anmode om sletning eller ændring af dine personlige data ved at kontakte os."
+    },
+    "changes": {
+      "h2": "Ændringer til denne privatlivspolitik",
+      "p": "Vi kan opdatere vores privatlivspolitik fra tid til anden. Ændringer vil blive offentliggjort på denne side."
+    },
+    "contact": {
+      "h2": "Kontakt os",
+      "p": "For spørgsmål om denne privatlivspolitik, kontakt os på:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/da/profile.json
+++ b/i18n/da/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "{username}s profil",
+      "descriptionUser": "Se {username}s seneste aktivitet, stjernemarkerede rum og statistik."
+    },
+    "profile": {
+      "profilePicAlt": "Profilbillede",
+      "noBio": "(Ingen bio tilgængelig.)"
+    },
+    "activity": {
+      "title": "Seneste aktivitet",
+      "updatedOn": "Opdateret den {date}",
+      "none": "Ingen nylig aktivitet.",
+      "viewAllBlocks": "Se alle indlæg"
+    },
+    "starredRooms": {
+      "title": "Stjernemarkerede rum",
+      "none": "Ingen stjernemarkerede rum endnu.",
+      "unnamedRoom": "Unavngivet rum"
+    },
+    "stats": {
+      "title": "Brugerstatistik",
+      "totalBlocks": "Samlet antal oprettede indlæg",
+      "collaborations": "Samarbejde",
+      "daysActive": "Aktive dage"
+    }
+  }
+}

--- a/i18n/da/random.json
+++ b/i18n/da/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Andre projekter",
+      "description": "Udforsk baseballjournalføring, tilfældige skriveeksperimenter og andre sideprojekter fra Daily Page."
+    },
+    "title": "Andre projekter",
+    "tagline": "Et hyggeligt hjørne til eksperimenter og sideopgaver.",
+    "links": {
+      "baseball": "📖 Baseball Journal",
+      "randomWriter": "🎲 Tilfældig forfatter"
+    },
+    "cta": {
+      "backToRooms": "Tilbage til hovedrum"
+    }
+  }
+}

--- a/i18n/da/randomWriter.json
+++ b/i18n/da/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Tilfældig forfatter",
+      "description": "Generer en uendelig strøm af tilfældig pseudotekst for sjov, inspiration eller kaos."
+    },
+    "title": "Tilfældig forfatter",
+    "buttons": {
+      "clear": "Klar",
+      "stop": "Stop med at skrive",
+      "start": "Begynd at skrive"
+    }
+  }
+}

--- a/i18n/da/reactions.json
+++ b/i18n/da/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} reaktioner: {count}",
+    "loginToReact": "Log ind for at reagere",
+    "countsLabel": "Reaktioner"
+  }
+}

--- a/i18n/da/readMore.json
+++ b/i18n/da/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Mere...",
+    "aria": "Læs hele indlægget: {title}"
+  }
+}

--- a/i18n/da/resetPassword.json
+++ b/i18n/da/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Nulstil din adgangskode",
+      "description": "Indstil en ny adgangskode til din konto."
+    },
+    "header": {
+      "title": "Nulstil din adgangskode",
+      "subtitle": "Vælg en ny adgangskode for at få adgang igen."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Ny adgangskode",
+        "placeholder": "Indtast ny adgangskode"
+      },
+      "submit": "Indstil ny adgangskode"
+    },
+    "feedback": {
+      "missingToken": "Manglende eller ugyldig token.",
+      "missingFields": "Token og ny adgangskode er påkrævet.",
+      "invalidOrExpired": "Ugyldigt eller udløbet token.",
+      "success": "Adgangskoden blev opdateret!",
+      "genericError": "Noget gik galt. Prøv venligst igen.",
+      "unexpectedError": "Der opstod en uventet fejl. Prøv venligst igen."
+    }
+  }
+}

--- a/i18n/da/roomDashboard.json
+++ b/i18n/da/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Udforsk seneste og igangværende indlæg i {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Udforske:",
+      "allBlocks": "🗂️ Alle indlæg",
+      "browseByDate": "🗓️ Efter dato",
+      "bestOf": "🏅 Bedst af",
+      "searchInRoom": "🔎 Søg"
+    },
+    "actions": {
+      "createBlock": "Opret et indlæg",
+      "starTitle": "Stjerne dette rum",
+      "unstarTitle": "Fjern stjerne i dette rum"
+    },
+    "tabs": {
+      "locked": "Låste indlæg",
+      "inProgress": "Igangværende indlæg"
+    },
+    "sections": {
+      "lockedHeader": "Låste indlæg",
+      "inProgressHeader": "Igangværende indlæg"
+    },
+    "editorial": {
+      "heading": "Udvalgte guider",
+      "description": "Start her med de udvalgte guider, der er udvalgt til dette rum.",
+      "roleNames": {
+        "pillar": "Kernevejledning",
+        "companion": "Læsevejledning",
+        "texture": "Baggrundsvejledning"
+      }
+    },
+    "empty": {
+      "noDescription": "Ingen beskrivelse tilgængelig.",
+      "noLocked": "Ingen låste indlæg endnu! Indlæg automatisk låsning efter 1 times inaktivitet.",
+      "noInProgress": "Ingen igangværende indlæg endnu! Tid til at starte en.",
+      "noBlocks": "Ingen indlæg endnu! Opret den første og efterlad dit præg. 😎"
+    }
+  }
+}

--- a/i18n/da/roomsDirectory.json
+++ b/i18n/da/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Rumsoversigt",
+      "description": "Hvert rum er en døråbning til en anden verden. Træd indenfor, del din historie, og vær med andre til at bygge noget smukt."
+    },
+    "eyebrow": "Find dit hjørne",
+    "heading": "Rumsoversigt",
+    "intro": "Start med de rum, der føles levende lige nu, eller gå rundt efter emne, indtil noget klikker. Hvert rum er en anden skriveprompt, fandom eller delt besættelse, der venter på din stemme.",
+    "empty": "Der er ingen ledige rum i øjeblikket. Kom tilbage senere!",
+    "jumpToActive": "Se aktive rum",
+    "jumpToTopics": "Gennemse efter emne",
+    "statsLabel": "Højdepunkter i rumkataloget",
+    "liveNow": "Lev nu",
+    "recentlyActive": "For nylig aktiv",
+    "recentlyActiveSubtitle": "Den hurtigste måde at finde et rum med folk i lige nu.",
+    "browseByTopic": "Gennemse efter emne",
+    "topicSubtitle": "Åbn et emne for at udforske dets rum.",
+    "roomCount": "{count} rum",
+    "stats": {
+      "rooms": "rum at udforske",
+      "topics": "emnegrupper",
+      "active": "aktive valg"
+    },
+    "activeUsers": "Aktive brugere: {count}",
+    "visitRoom": "Besøg rum",
+    "close": "Tæt",
+    "noTitle": "Ingen titel tilgængelig",
+    "noDescription": "Ingen beskrivelse tilgængelig"
+  }
+}

--- a/i18n/da/search.json
+++ b/i18n/da/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Søg",
+      "description": "Søg i offentlige indlæg."
+    },
+    "title": "Søg",
+    "placeholder": "Søg i indlæg...",
+    "hint": "Indtast mindst 2 tegn for at søge.",
+    "noResults": "Ingen resultater fundet.",
+    "untitled": "Uden titel",
+    "votesTitle": "Stemmer",
+    "pageLabel": "Side",
+    "filters": {
+      "inRoom": "På rumt"
+    },
+    "buttons": {
+      "search": "Søg",
+      "prev": "Forrige",
+      "next": "Næste"
+    }
+  }
+}

--- a/i18n/da/signup.json
+++ b/i18n/da/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Opret en konto",
+      "description": "Tilmeld dig Daily Page for at få adgang til alle funktioner."
+    },
+    "header": {
+      "title": "Opret din konto",
+      "subtitle": "Tilmeld dig Daily Page for at begynde at skabe og dele dit daglige forfatterskab!"
+    },
+    "form": {
+      "email": {
+        "label": "E-mail",
+        "placeholder": "Indtast din e-mail"
+      },
+      "username": {
+        "label": "Brugernavn",
+        "placeholder": "Indtast dit brugernavn"
+      },
+      "password": {
+        "label": "Adgangskode",
+        "placeholder": "Indtast en adgangskode"
+      },
+      "submit": "Tilmeld dig",
+      "feedback": {
+        "success": "Formularindsendelse lykkedes!",
+        "successCreatedVerify": "Konto oprettet! Tjek venligst din e-mail for at bekræfte din konto.",
+        "genericError": "Kunne ikke oprette konto. Prøv venligst igen.",
+        "unexpectedError": "Der opstod en uventet fejl. Prøv venligst igen."
+      }
+    }
+  }
+}

--- a/i18n/da/starredRooms.json
+++ b/i18n/da/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Alle stjernede rum",
+      "description": "En liste over alle de rum, du har stjernemarkeret."
+    },
+    "nav": {
+      "backToDashboard": "← Tilbage til Dashboard"
+    },
+    "header": {
+      "title": "🌟 Alle dine stjernemarkerede rum 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Unavngivet rum",
+      "noDescription": "Ingen beskrivelse."
+    },
+    "empty": {
+      "message": "Du har ikke stjernemarkeret nogen rum endnu!"
+    }
+  }
+}

--- a/i18n/da/support.json
+++ b/i18n/da/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Support",
+      "description": "Sådan kommer du i kontakt, rapporterer problemer, anmoder om funktioner eller lokaler og støtter Daily Page økonomisk."
+    },
+    "contact": {
+      "h1": "★ Jeg vil gerne stille et spørgsmål, rapportere et problem eller anmode om en funktion.",
+      "p1": {
+        "before": "Hvis du foretrækker at bruge GitHub, så tjek venligst",
+        "link": "dette projekts problemer",
+        "after": "og tilføje din stemme. Pull-anmodninger er selvfølgelig også velkomne."
+      },
+      "p2": {
+        "before": "Alternativt",
+        "link": "send en e-mail",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Jeg vil gerne støtte dette projekt gennem et bidrag.",
+      "p1": {
+        "before": "På forhånd tak for finansieringen af ​​dette projekt. Send venligst betalinger sikkert igennem",
+        "paypal": "PayPal",
+        "middle": "eller, hvis du foretrækker det,",
+        "amazon": "bestil et par poser af det legetøj, jeg sælger på Amazon",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Jeg vil gerne anmode om et nyt rum.",
+      "form": {
+        "nameLabel": "Rumsnavn",
+        "topicLabel": "Emne (valgfrit)",
+        "descriptionLabel": "Beskrivelse",
+        "submit": "Indsend anmodning",
+        "success": "Anmodningen blev sendt med succes!",
+        "errorGeneric": "Kunne ikke indsende anmodning. Prøv venligst igen.",
+        "errorUnexpected": "Der opstod en uventet fejl. Prøv venligst igen."
+      }
+    }
+  }
+}

--- a/i18n/da/tags.json
+++ b/i18n/da/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Tags Oversigt",
+      "description": "Gennemse alle tags, der bruges på tværs af Daily Page, med hurtige filtre efter tid."
+    },
+    "title": "Tags Oversigt",
+    "intro": "Udforsk alle tags brugt i Daily Page.",
+    "tagCloudTitle": "Tagsky",
+    "timeframe": {
+      "last24h": "Sidste 24 timer",
+      "last7d": "Sidste 7 dage",
+      "last30d": "Sidste 30 dage",
+      "all": "Alle Tider"
+    },
+    "error": {
+      "loading": "Fejl ved indlæsning af tags-oversigt"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": "| Daily Page",
+        "description": "Indlæg tagget med"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Samlet indlæg med",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Skabt af:",
+        "inRoom": "i",
+        "unknownRoom": "Ukendt rum",
+        "onDate": "på"
+      },
+      "chart": {
+        "label": "Indlæg oprettet over tid"
+      },
+      "empty": {
+        "message": "Ingen indlæg fundet med dette tag endnu. Måske skulle du lave den første? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Fejl ved indlæsning af tagside"
+      }
+    }
+  }
+}

--- a/i18n/da/translation.json
+++ b/i18n/da/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Oversat fra",
+    "see": "se",
+    "originalBlock": "oprindelige indlæg"
+  }
+}

--- a/i18n/da/userBlocks.json
+++ b/i18n/da/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Dine indlæg",
+      "description": "Gennemse og sorter alle indlæg, du har oprettet eller samarbejdet om."
+    },
+    "header": {
+      "dashboardLink": "Dit Dashboard",
+      "profileLink": "{username}s profil",
+      "allBlocks": "Alle indlæg"
+    },
+    "empty": "Ingen indlæg endnu.",
+    "pagination": {
+      "prev": "← Forrige",
+      "next": "Næste →"
+    },
+    "titleUser": "{username}s indlæg"
+  }
+}

--- a/i18n/da/verifyEmail.json
+++ b/i18n/da/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Bekræft e-mail",
+      "description": "Bekræft din e-mailadresse for Daily Page."
+    },
+    "header": {
+      "title": "Bekræfter din e-mail..."
+    },
+    "status": {
+      "checking": "Kontrollerer token, vent venligst...",
+      "missingToken": "Bekræftelsestoken mangler eller er ugyldigt.",
+      "genericFailure": "Bekræftelse mislykkedes.",
+      "unexpectedError": "Der opstod en uventet fejl.",
+      "success": "Din konto er blevet bekræftet!",
+      "invalidOrExpired": "Ugyldigt eller udløbet bekræftelsestoken."
+    },
+    "verificationMsg": {
+      "subject": "Bekræft din Daily Page konto ✨",
+      "heading": "Velkommen til Daily Page, {username}!",
+      "body": "Bekræft venligst din e-mail ved at klikke nedenfor:",
+      "cta": "Bekræft e-mail-adresse",
+      "expires": "Dette link udløber om {hours} timer."
+    }
+  }
+}

--- a/i18n/da/voteControls.json
+++ b/i18n/da/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Stem op",
+    "downvote": "Stem ned",
+    "errors": {
+      "failed": "Kunne ikke gemme din stemme."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -78,4 +78,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'nl' }).catch(console.error), 8_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'sv' }).catch(console.error), 8_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'no' }).catch(console.error), 9_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'da' }).catch(console.error), 9_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- add complete Danish translations for all 40 English i18n namespaces
- register `da` as a fully supported UI language
- include Danish in hreflang metadata, home cache warming, and notification emails
- preserve existing DB-backed room translations for a separate rollout

## Validation

- verified Danish matches English file-for-file and key-for-key
- verified all locale JSON parses successfully
- verified interpolation placeholders are preserved
- manually tested the Danish UI
- ran test suite: 279 specs, 0 failures

## Notes

The remaining hard-coded UI text is primarily limited to the broader legacy music/iPod interface and defensive JavaScript fallbacks behind existing i18n keys.