### PR TITLE
Add full Finnish UI support

### DIFF
--- a/i18n/fi/about.json
+++ b/i18n/fi/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Tietoja",
+      "description": "Mikä Daily Page on, miten se toimii ja miksi se rakennettiin verkon hitaammaksi ja lempeämmäksi nurkaksi."
+    },
+    "title": "Tietoja Daily Pagesta",
+    "tagline": "Ruoki mieltäsi, älä syötettäsi.",
+    "mission": {
+      "h2": "Tehtävä",
+      "p1": "Indie-kirjoituslaboratorio, joka alkoi olohuoneessani ja saa voimansa lukijoiden uteliaisuudesta.",
+      "p2": "Sitä ei rakennettu mädättämään aivojasi vaan ravitsemaan niitä: paikka, jossa voit kirjoittaa hitaasti, halutessasi nimettömästi, eikä sinun tarvitse huolehtia vaikutuksen tekemisestä."
+    },
+    "how": {
+      "h2": "Miten se toimii",
+      "features": {
+        "rooms": {
+          "label": "Huoneet",
+          "text": "ovat aihekohtaisia tiloja (ajattele “subreddit, mutta ystävällisempi”)."
+        },
+        "blocks": {
+          "label": "Julkaisut",
+          "text": "ovat yhteisiä kirjoitustiloja. Kuka tahansa, myös “nimetön”, voi luoda sellaisen, muokata sitä lukitsemiseen asti ja äänestää muiden julkaisuja."
+        },
+        "privacy": {
+          "label": "Yksityisyys ja jakaminen",
+          "text": "tarkoittaa, että julkiset julkaisut näkyvät huoneen syötteessä. Listaamattomat luonnokset pysyvät piilossa lukitsemiseen asti, mutta saat jakolinkin ystävien kutsumista varten."
+        },
+        "markdown": {
+          "label": "Markdown ja media",
+          "text": "antaa kirjoittaa markdownilla, upottaa kuvia ja muokata yhdessä kuten Google Docsissa."
+        },
+        "trends": {
+          "label": "Trendit ja tunnisteet",
+          "text": "antavat lisätä julkaisuun tunnisteita, seurata tunnistetrendejä ja löytää parhaat sisällöt (7 pv / 30 pv / kaikkien aikojen)."
+        },
+        "streaks": {
+          "label": "Putket",
+          "text": "pitävät päivittäisen kirjoitusputkesi elossa, paras kannustin palata joka päivä."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Miten päädyimme tänne",
+      "p1": "Vuonna 2018 rakensin päivämäärään perustuvan wikin “tämän päivän sivulle” ja katselin, kuinka muutama pohdiskeleva kirjoittaja teki siitä ajatustensa kanavan. Siitä ei koskaan tullut valtavaa, mutta se kylvi siemenen.",
+      "p2": "Nyt Daily Page on kasvanut siitä siemenestä moniksi huoneiksi: hiljaiseksi sosiaaliseksi verkoksi introverteille, idealisteille ja kaikille, jotka kaipaavat hitaampaa tahtia."
+    },
+    "next": {
+      "h2": "Mitä seuraavaksi",
+      "p1": "Olemme vasta alussa: rikkaammat upotukset, syvemmät käyttäjätilastot, mainepistetaulukot ja lisää tapoja palkita harkittua luomista.",
+      "p2": "Kiitos, että olet osa tätä pientä indie-kokeilua."
+    },
+    "cta": {
+      "rooms": "Tutustu huoneisiin",
+      "signup": "Liity yhteisöön"
+    }
+  }
+}

--- a/i18n/fi/accountSecurity.json
+++ b/i18n/fi/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Tilin turvallisuus",
+      "description": "Hallinnoi Daily Page -salasanaasi ja kaksivaiheista tunnistautumista."
+    },
+    "backToDashboard": "Takaisin hallintapaneeliin",
+    "heading": "Tilin turvallisuus",
+    "subheading": "Suojaa tilisi vahvalla salasanalla ja tunnistussovelluksella.",
+    "password": {
+      "title": "Vaihda salasana",
+      "description": "Käytä yksilöllistä salasanaa, jossa on vähintään 8 merkkiä.",
+      "current": {
+        "label": "Nykyinen salasana"
+      },
+      "new": {
+        "label": "Uusi salasana"
+      },
+      "submit": "Päivitä salasana"
+    },
+    "twoFactor": {
+      "title": "Kaksivaiheinen tunnistautuminen",
+      "statusOn": "Käytössä",
+      "statusOff": "Pois käytöstä",
+      "description": "Lisää kirjautuessasi salasanan jälkeen kertakäyttökoodi tunnistussovelluksesta.",
+      "currentPassword": {
+        "label": "Nykyinen salasana"
+      },
+      "startSetup": "Ota tunnistussovellus käyttöön",
+      "qrAlt": "Tunnistussovelluksen QR-koodi",
+      "manualKey": "Manuaalinen määritysavain",
+      "code": {
+        "label": "6-numeroinen koodi"
+      },
+      "enable": "Ota 2FA käyttöön",
+      "disableCode": {
+        "label": "Tunnistuskoodi"
+      },
+      "disable": "Poista 2FA käytöstä"
+    },
+    "recoveryCodes": {
+      "title": "Tallenna palautuskoodisi",
+      "description": "Käytä jotakin näistä kertakäyttökoodeista kirjautumiseen, jos menetät pääsyn tunnistussovellukseesi.",
+      "regenerateDescription": "Luo uusi palautuskoodien sarja, jos kadotit edellisen. Tämä mitätöi kaikki vanhat palautuskoodit.",
+      "regenerate": "Luo uudet palautuskoodit",
+      "warning": "Säilytä ne turvallisessa paikassa. Niitä ei näytetä uudelleen."
+    },
+    "feedback": {
+      "passwordChanged": "Salasanasi päivitettiin.",
+      "setupReady": "Skannaa QR-koodi ja viimeistele määritys syöttämällä 6-numeroinen koodi.",
+      "twoFactorEnabled": "Kaksivaiheinen tunnistautuminen on nyt käytössä.",
+      "twoFactorDisabled": "Kaksivaiheinen tunnistautuminen on nyt poistettu käytöstä.",
+      "recoveryCodesRegenerated": "Palautuskoodisi luotiin uudelleen. Tallenna uudet koodit nyt.",
+      "missingFields": "Täytä kaikki pakolliset kentät.",
+      "missingCurrentPassword": "Jatka syöttämällä nykyinen salasanasi.",
+      "passwordTooShort": "Uuden salasanasi on oltava vähintään 8 merkkiä pitkä.",
+      "invalidCurrentPassword": "Nykyinen salasana ei täsmännyt.",
+      "missingCode": "Syötä tunnistussovelluksesi 6-numeroinen koodi.",
+      "invalidCode": "Koodi ei toiminut. Yritä uudelleen.",
+      "noPendingSetup": "Aloita määritys uudelleen ennen koodin syöttämistä.",
+      "setupExpired": "Määritysistunto vanheni. Aloita uudelleen saadaksesi uuden QR-koodin.",
+      "twoFactorNotEnabled": "Kaksivaiheinen tunnistautuminen ei ole käytössä tällä tilillä.",
+      "genericError": "Jokin meni pieleen. Yritä uudelleen.",
+      "unexpectedError": "Tapahtui odottamaton virhe. Yritä uudelleen."
+    }
+  }
+}

--- a/i18n/fi/anonymousUser.json
+++ b/i18n/fi/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Nimetön vaeltaja",
+      "description": "Ei profiilia. Ei menneisyyttä. Vain tunnelmaa."
+    },
+    "ascii": {
+      "ariaLabel": "ASCII-taidetta leikkisästä olennosta ja lainauksesta"
+    },
+    "header": {
+      "title": "Nimetön"
+    },
+    "body": {
+      "line1": "Olet kompastunut tyhjyyteen. Täällä ei ole mitään nähtävää—",
+      "line2": "vain vaeltava henki ilman tarinaa."
+    },
+    "buttons": {
+      "home": "← Palaa etusivulle",
+      "signup": "Luo identiteetti"
+    }
+  }
+}

--- a/i18n/fi/archive.json
+++ b/i18n/fi/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Arkisto",
+      "description": "Selaa koko arkistoa kuukausittain.",
+      "titleRoom": "Daily Page — Arkisto · {roomName}",
+      "descriptionRoom": "Selaa huoneen {roomName} aiempia kirjoituksia kuukausittain. Hyppää mihin tahansa päivään nähdäksesi, mitä muut ovat ajan mittaan jakaneet tässä tilassa."
+    },
+    "nav": {
+      "prev": "Edellinen",
+      "next": "Seuraava"
+    },
+    "title": "📚 Selaa arkistoja",
+    "titleRoom": "📚 {roomName} — Arkistot",
+    "roomViewing": "Näytetään huoneen {roomName} arkistoa",
+    "viewRoomLink": "Näytä huone",
+    "noContent": "Sisältöä ei ole vielä saatavilla.",
+    "backToRoom": "← Takaisin huoneen hallintapaneeliin",
+    "calendar": {
+      "meta": {
+        "description": "Näytä kaikki luovat julkaisut ajalta {month} {year}, nopeista ajatuksista syviin pohdintoihin. Napsauta mitä tahansa päivää nähdäksesi, mitä jaettiin.",
+        "descriptionRoom": "Näytä huoneen {roomName} luova toiminta ajalta {month} {year}. Valitse päivämäärä tutkiaksesi sinä päivänä jaettuja julkaisuja."
+      },
+      "title": "📆 Arkisto ajalle {month} {year}",
+      "prevLabel": "Arkisto ajalle {month} {year}",
+      "nextLabel": "Arkisto ajalle {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Arkisto päivälle {date}",
+        "titleRoom": "{roomName} — Arkisto päivälle {date}",
+        "descriptionSite": "Tutustu päivänä {date} kirjoitettuihin julkaisuihin hiljaisista muistiinpanoista villeihin tunnustuksiin.",
+        "descriptionRoom": "Päivänä {date} huoneen {roomName} kirjoittajat jättivät jälkensä. Selaa sinä päivänä jaettuja pohdintoja, ideoita ja ilmaisuja."
+      },
+      "heading": "Arkisto päivälle {date}",
+      "empty": "Tälle päivälle ei löytynyt sisältöä.",
+      "labels": {
+        "createdBy": "Luonut:",
+        "in": "huoneessa",
+        "on": "päivänä {datetime}",
+        "unknownRoom": "Tuntematon huone"
+      },
+      "nav": {
+        "prevDay": "Edellinen päivä",
+        "nextDay": "Seuraava päivä"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Kaikki julkaisut",
+        "descriptionRoom": "Selaa kaikkia huoneessa {roomName} koskaan julkaistuja julkaisuja. Järjestä päivämäärän, otsikon tai äänten mukaan tutkiaksesi sen historiaa."
+      },
+      "header": {
+        "allBlocks": "— Kaikki julkaisut"
+      },
+      "sort": {
+        "label": "Järjestä",
+        "options": {
+          "date": "Päivämäärä",
+          "title": "Otsikko",
+          "votes": "Äänet"
+        },
+        "submit": "Näytä"
+      }
+    },
+    "pagination": {
+      "prev": "← Edellinen",
+      "next": "Seuraava →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daily Page -julkaisut ajalle {time}"
+      },
+      "empty": "Emme löytäneet sivuja tuolta ajanjaksolta."
+    }
+  }
+}

--- a/i18n/fi/auth.json
+++ b/i18n/fi/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Kirjaudu sisään",
+        "description": "Kirjaudu Daily Page -tilillesi jatkaaksesi kirjoitusmatkaasi."
+      },
+      "heading": "Tervetuloa takaisin!",
+      "subheading": "Kirjaudu tilillesi jatkaaksesi päivittäisen kirjoittamisesi jakamista.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Käyttäjänimi tai sähköposti",
+          "placeholder": "Syötä käyttäjänimesi tai sähköpostisi"
+        },
+        "password": {
+          "label": "Salasana",
+          "placeholder": "Syötä salasanasi"
+        },
+        "totpCode": {
+          "label": "Tunnistus- tai palautuskoodi",
+          "placeholder": "Syötä koodi"
+        }
+      },
+      "actions": {
+        "submit": "Kirjaudu sisään"
+      },
+      "feedback": {
+        "success": "Kirjautuminen onnistui! Ohjataan...",
+        "twoFactorRequired": "Syötä tunnistussovelluksen 6-numeroinen koodi tai käytä palautuskoodia.",
+        "twoFactorFailed": "Koodi ei toiminut. Yritä uudelleen.",
+        "failedGeneric": "Kirjautuminen epäonnistui. Yritä uudelleen.",
+        "unexpected": "Tapahtui odottamaton virhe. Yritä uudelleen."
+      },
+      "links": {
+        "forgotPassword": "Unohditko salasanasi?",
+        "noAccount": "Eikö sinulla ole vielä tiliä?",
+        "signupHere": "Rekisteröidy tästä!"
+      }
+    }
+  }
+}

--- a/i18n/fi/bestOf.json
+++ b/i18n/fi/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Daily Pagen parhaat",
+      "description": "Daily Pagen rakastetuimmat julkaisut: hauskat, rehelliset, runolliset tai vain oudot. Katso, mikä erottui viime päivän, viikon, kuukauden ja pidemmän ajan aikana.",
+      "titleRoom": "Huoneen {roomName} parhaat",
+      "descriptionRoom": "Löydä huoneen {roomName} erottuvat julkaisut, joista lukijat pitivät eniten viimeisen 24 tunnin, 7 päivän, 30 päivän ja kaikkien aikojen aikana."
+    },
+    "heading": "🏆 Daily Pagen parhaat",
+    "headingRoomPrefix": "🏆 Parhaat: ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 tuntia",
+      "7d": "🚀 7 päivää",
+      "30d": "🌕 30 päivää",
+      "all": "👑 Kaikkien aikojen"
+    },
+    "labels": {
+      "createdBy": "Luonut:",
+      "inRoom": "huoneessa",
+      "onDate": "{date}",
+      "unknownRoom": "Tuntematon huone",
+      "noBlocks": "Julkaisuja ei löytynyt.",
+      "viewRoom": "Näytä huone"
+    }
+  }
+}

--- a/i18n/fi/blockCommon.json
+++ b/i18n/fi/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Luonnos"
+    },
+    "deleteModal": {
+      "title": "Poistetaanko julkaisu?",
+      "message": "Tätä toimintoa ei voi perua.",
+      "confirm": "Poista",
+      "cancel": "Peruuta",
+      "closeAriaLabel": "Sulje"
+    },
+    "toasts": {
+      "deleteSuccess": "Julkaisu poistettiin onnistuneesti!",
+      "deleteFailed": "Julkaisun poistaminen epäonnistui."
+    }
+  }
+}

--- a/i18n/fi/blockEditor.json
+++ b/i18n/fi/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Sinä)"
+    },
+    "meta": {
+      "title": "Muokkaa julkaisua - {blockTitle}",
+      "titleFallback": "Muokkaa julkaisua"
+    },
+    "errors": {
+      "imageUrlRequired": "Syötä kuvan URL-osoite.",
+      "notFound": "Julkaisua ei löytynyt tai se ei kuulu tähän huoneeseen.",
+      "loadFailed": "Julkaisueditoria ladattaessa tapahtui virhe.",
+      "updateTitleFailed": "Otsikon päivittäminen epäonnistui."
+    },
+    "roomInfo": {
+      "label": "Huone:"
+    },
+    "title": {
+      "placeholder": "Syötä julkaisun otsikko",
+      "editTooltip": "Muokkaa otsikkoa",
+      "lock": "Lukitse julkaisu",
+      "delete": "Poista julkaisu"
+    },
+    "description": {
+      "label": "Kuvaus",
+      "editTooltip": "Muokkaa kuvausta",
+      "placeholder": "Syötä kuvaus",
+      "noDescriptionOwner": "Ei kuvausta vielä...",
+      "noDescriptionViewer": "Kuvausta ei annettu...",
+      "save": "Tallenna",
+      "cancel": "Peruuta",
+      "expand": "Laajenna",
+      "collapse": "Supista",
+      "updateError": "Kuvauksen päivittäminen epäonnistui."
+    },
+    "status": {
+      "lastBackup": "Viimeisin varmuuskopio: {datetime}",
+      "lastBackupUnknown": "Viimeisin varmuuskopio: tuntematon"
+    },
+    "peers": {
+      "label": "Muut käyttäjät:"
+    },
+    "toasts": {
+      "blockLocked": "Tämä julkaisu on lukittu!"
+    },
+    "editor": {
+      "placeholder": "Tyhjä sivu odottaa ääntäsi; kirjoita pelottomasti."
+    },
+    "loading": {
+      "label": "Ladataan",
+      "quote": "Anna maailman palaa lävitsesi. Heitä prisman valo, valkohehkuisena, paperille.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Et ole kirjoittanut mitään 5 minuuttiin. Jatka istuntoa napsauttamalla OK, muuten sinut ohjataan arkistoon.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Jakolinkki",
+      "copyTooltip": "Kopioi leikepöydälle",
+      "copied": "Kopioitu!"
+    },
+    "toolbar": {
+      "insertImage": "Lisää kuva",
+      "insertImageUrlPlaceholder": "Syötä kuvan URL-osoite",
+      "insertImageAltPlaceholder": "Vaihtoehtoinen teksti (valinnainen)",
+      "insertImageConfirm": "Vahvista",
+      "insertImageCancel": "Peruuta"
+    },
+    "buttons": {
+      "downloadFile": "Lataa tiedosto"
+    },
+    "lockModal": {
+      "messageLine1": "Haluatko varmasti lukita tämän julkaisun?",
+      "messageLine2": "Tämä viimeistelee sen ja estää lisämuokkaukset.",
+      "confirm": "Lukitse",
+      "cancel": "Peruuta",
+      "successToast": "Julkaisu lukittiin onnistuneesti.",
+      "errorToast": "Julkaisun lukitseminen epäonnistui."
+    },
+    "tags": {
+      "headerWithTags": "Tunnisteet:",
+      "headerNoTags": "Ei tunnisteita vielä! Lisää muutama:",
+      "updateError": "Tunnisteiden päivittäminen epäonnistui."
+    },
+    "fullBlock": {
+      "headingPrefix": "Valitettavasti julkaisu \"{blockTitle}\" on nyt",
+      "headingStatus": "täynnä.",
+      "retryPrefix": "Ole hyvä ja",
+      "retryLink": "kokeile toista julkaisua",
+      "retrySuffix": "tai palaa myöhemmin.",
+      "consolationPrefix": "Odottaessasi voit lukea",
+      "consolationBestOf": "joitakin suosikkijulkaisuistamme",
+      "consolationMiddle": "tai selata",
+      "consolationArchive": "arkistoa."
+    }
+  }
+}

--- a/i18n/fi/blockList.json
+++ b/i18n/fi/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "kaikkien aikojen",
+      "days": "viimeisten {n} päivän aikana",
+      "day": "viimeisten 24 tunnin aikana"
+    },
+    "createdBy": "Luonut:",
+    "on": "päivänä"
+  }
+}

--- a/i18n/fi/blockTags.json
+++ b/i18n/fi/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tunnisteet:",
+      "noTags": "Ei tunnisteita vielä! Lisää muutama:"
+    },
+    "input": {
+      "placeholder": "Uusi tunniste",
+      "addButton": "Lisää"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/fi/blockView.json
+++ b/i18n/fi/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Julkaisu - {blockTitle}",
+      "titleFallback": "Julkaisu"
+    },
+    "labels": {
+      "room": "Huone",
+      "author": "Tekijä",
+      "created": "Luotu",
+      "unknownAuthor": "Nimetön",
+      "authorAvatarAlt": "Käyttäjän {username} avatar",
+      "viewAuthorProfile": "Näytä käyttäjän {username} profiili",
+      "lang": "Käännökset: ",
+      "available": "saatavilla"
+    },
+    "buttons": {
+      "edit": "Muokkaa",
+      "deleteBlock": "Poista julkaisu",
+      "share": "Jaa",
+      "flagContent": "Ilmianna sisältö"
+    },
+    "description": {
+      "label": "Kuvaus",
+      "none": "Kuvausta ei annettu...",
+      "expand": "Laajenna",
+      "collapse": "Supista"
+    },
+    "editorial": {
+      "heading": "Lukuopas",
+      "roleLabel": "Lukutyyppi",
+      "clusterLabel": "Opas",
+      "sequence": "Osa {sequence}",
+      "primaryPillarHeading": "Aloita tästä",
+      "relatedHeading": "Jatka lukemista",
+      "clusterHeading": "Lisää tässä oppaassa",
+      "expandSection": "Näytä {count} lisää",
+      "collapseSection": "Näytä vähemmän",
+      "roleNames": {
+        "pillar": "Ydinopas",
+        "companion": "Syväsukellus",
+        "texture": "Tausta"
+      }
+    },
+    "comments": {
+      "heading": "Kommentit",
+      "count": "{count} kommenttia",
+      "empty": "Kukaan ei ole vielä vastannut. Kommentit ilmestyvät tänne, kun keskustelu alkaa.",
+      "composer": {
+        "label": "Lisää kommentti",
+        "placeholder": "Kirjoita kommentti...",
+        "submit": "Julkaise kommentti",
+        "submitting": "Julkaistaan...",
+        "success": "Kommentti julkaistiin.",
+        "error": "Kommentin julkaiseminen ei onnistu juuri nyt.",
+        "loginPrompt": "Kirjaudu sisään liittyäksesi keskusteluun.",
+        "loginCta": "Kirjaudu kommentoidaksesi",
+        "verifyPrompt": "Vahvista sähköpostisi ennen kommentin julkaisemista.",
+        "verifyCta": "Vahvista sähköposti"
+      },
+      "sort": {
+        "label": "Järjestä",
+        "oldestFirst": "Vanhimmat ensin",
+        "newestFirst": "Uusimmat ensin"
+      },
+      "by": "Tekijä",
+      "unknownAuthor": "Tuntematon",
+      "reply": {
+        "action": "Vastaa",
+        "label": "Lisää vastaus",
+        "placeholder": "Kirjoita vastaus...",
+        "submit": "Julkaise vastaus",
+        "submitting": "Julkaistaan...",
+        "success": "Vastaus julkaistiin.",
+        "error": "Vastauksen julkaiseminen ei onnistu juuri nyt.",
+        "cancel": "Peruuta",
+        "loginPrompt": "Kirjaudu vastataksesi."
+      },
+      "manage": {
+        "edited": "Muokattu",
+        "editAction": "Muokkaa",
+        "deleteAction": "Poista",
+        "deleteConfirm": "Poistetaanko tämä kommentti? Myös sen alla olevat vastaukset poistetaan.",
+        "deleteSuccess": "Kommentti poistettiin.",
+        "deleteError": "Kommentin poistaminen ei onnistu juuri nyt.",
+        "forbidden": "Voit hallita vain omia kommenttejasi.",
+        "edit": {
+          "label": "Muokkaa kommenttia",
+          "save": "Tallenna",
+          "saving": "Tallennetaan...",
+          "cancel": "Peruuta",
+          "success": "Kommentti päivitettiin.",
+          "error": "Kommentin päivittäminen ei onnistu juuri nyt."
+        }
+      },
+      "report": {
+        "action": "Ilmoita",
+        "pending": "Ilmoitetaan...",
+        "success": "Kommentti ilmoitettu.",
+        "error": "Kommentin ilmoittaminen ei onnistu juuri nyt.",
+        "ownError": "Et voi ilmoittaa omaa kommenttiasi.",
+        "hidden": "Kommentti piilotettu ilmoituksen jälkeen.",
+        "reported": "Ilmoitettu"
+      },
+      "deepLink": {
+        "focused": "Linkitetty kommentti",
+        "unavailable": "Linkitetty kommentti ei ole enää saatavilla."
+      },
+      "loadMore": "Lataa lisää kommentteja",
+      "loading": "Ladataan...",
+      "loadError": "Lisää kommentteja ei voi ladata juuri nyt."
+    },
+    "share": {
+      "title": "Jaa tämä julkaisu",
+      "shareOn": "Jaa palvelussa:",
+      "nativeText": "Katso tämä julkaisu: {title}",
+      "alt": {
+        "facebook": "Facebook-logo",
+        "reddit": "Reddit-logo",
+        "whatsapp": "WhatsApp-logo",
+        "twitter": "Twitter-logo"
+      }
+    },
+    "errors": {
+      "notFound": "Julkaisua ei löytynyt tai se ei kuulu tähän huoneeseen.",
+      "loadFailed": "Julkaisunäkymän lataaminen epäonnistui."
+    }
+  }
+}

--- a/i18n/fi/createBlock.json
+++ b/i18n/fi/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Luo uusi julkaisu — Daily Page",
+      "description": "Aloita uusi luova julkaisu valinnaisilla tunnisteilla, kielellä ja näkyvyydellä."
+    },
+    "heading": "Luo uusi julkaisu",
+    "roomInfo": {
+      "roomLabel": "Huone:",
+      "unavailable": "Huoneen tietoja ei ole saatavilla.",
+      "noDescription": "Kuvausta ei ole saatavilla."
+    },
+    "form": {
+      "title": {
+        "label": "Otsikko:",
+        "placeholder": {
+          "full": "esim. 'Mestariteokseni', 'Paras idea ikinä', 'Klikkiotsikko nörteille'",
+          "short": "esim. 'Mestariteokseni'"
+        }
+      },
+      "description": {
+        "label": "Kuvaus (valinnainen):",
+        "placeholder": "Selitä neroutesi… tai improvisoi."
+      },
+      "initialContent": {
+        "label": "Alustava sisältö (valinnainen):",
+        "help": "Aloita kirjoittaminen tässä tai jatka koko editorisivulle painamalla “Luo”, missä voit upottaa kuvia ja tehdä yhteistyötä reaaliajassa.",
+        "placeholder": "Aloita julkaisu tässä tai jatka muokkaamista luomisen jälkeen…"
+      },
+      "visibility": {
+        "label": "Näkyvyys:"
+      },
+      "submit": "Luo julkaisu"
+    },
+    "visibility": {
+      "public": {
+        "label": "Julkinen",
+        "title": "Kuka tahansa voi muokata reaaliajassa. Kirjautumista ei tarvita.",
+        "inline": "Kuka tahansa voi muokata reaaliajassa. Kirjautumista ei tarvita."
+      },
+      "unlisted": {
+        "label": "Listaamaton luonnos",
+        "title": "Piilotettu julkiselta selaamiselta muokattavana ollessaan. Näkyy lukitsemisen jälkeen.",
+        "inline": "Piilotettu julkiselta selaamiselta muokattavana ollessaan. Näkyy lukitsemisen jälkeen.",
+        "tooltip": "Listaamattomat luonnokset piilotetaan julkiselta selaamiselta muokkauksen ajaksi. Kuka tahansa linkin saanut voi osallistua, ja julkaisu muuttuu julkiseksi, kun se lukitaan."
+      }
+    },
+    "advanced": {
+      "summary": "Lisäasetukset",
+      "lang": {
+        "label": "Kieli:",
+        "options": {
+          "en": "englanti",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Käännä olemassa oleva julkaisu (URL tai tunnus):",
+        "placeholder": "Liitä julkaisun URL tai tunnus (valinnainen)",
+        "invalid": "Tämä ei näytä kelvolliselta julkaisun URL-osoitteelta tai tunnukselta.",
+        "fetchError": "Julkaisun tietoja ei voitu hakea."
+      }
+    },
+    "messages": {
+      "langExists": "Tälle kielelle on jo käännös. Valitse toinen kieli.",
+      "genericError": "Jokin meni pieleen. Yritä uudelleen."
+    }
+  }
+}

--- a/i18n/fi/dashboard.json
+++ b/i18n/fi/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Hallintapaneeli",
+      "description": "Daily Page -hallintapaneelisi ja tilin yleiskatsaus."
+    },
+    "profile": {
+      "profilePicAlt": "Profiilikuva",
+      "noBio": "Ei esittelyä vielä. Lisää sellainen napsauttamalla \"Muokkaa\"!",
+      "editBio": "Muokkaa esittelyä",
+      "bioPlaceholder": "Kirjoita esittelysi tähän",
+      "save": "Tallenna",
+      "cancel": "Peruuta"
+    },
+    "activity": {
+      "title": "Viimeaikainen toiminta",
+      "none": "Ei viimeaikaista toimintaa.",
+      "updatedOn": "Päivitetty {date}",
+      "viewAllBlocks": "Näytä kaikki julkaisut"
+    },
+    "drafts": {
+      "title": "Jatka kirjoittamista",
+      "none": "Ei avoimia luonnoksia.",
+      "updatedOn": "Päivitetty {date}",
+      "unlisted": "Listaamaton",
+      "viewAll": "Näytä kaikki julkaisut"
+    },
+    "streak": {
+      "title": "Kirjoitusputki",
+      "line": "{days} päivää peräkkäin! Jatka samaan malliin!"
+    },
+    "starredRooms": {
+      "title": "Tähdellä merkityt huoneet",
+      "none": "Et ole vielä merkinnyt huoneita tähdellä. Aloita tutkiminen löytääksesi suosikkisi!",
+      "viewAll": "Näytä kaikki tähdellä merkityt huoneet",
+      "unnamedRoom": "Nimetön huone"
+    },
+    "security": {
+      "title": "Tilin turvallisuus",
+      "summary": "Vaihda salasanasi ja hallinnoi kaksivaiheista tunnistautumista.",
+      "manage": "Hallitse turvallisuutta"
+    },
+    "stats": {
+      "title": "Tilastosi",
+      "totalBlocks": "Luotuja julkaisuja yhteensä",
+      "collaborations": "Yhteistyöt",
+      "votesGiven": "Annetut äänet",
+      "daysActive": "Aktiiviset päivät",
+      "viewDetailed": "Näytä tarkat tilastot 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Profiilikuvan lataaminen epäonnistui. Yritä uudelleen.",
+      "uploadUnexpected": "Tapahtui odottamaton virhe. Yritä uudelleen.",
+      "bioUpdateFailed": "Esittelyn päivittäminen epäonnistui. Yritä uudelleen."
+    }
+  }
+}

--- a/i18n/fi/detailedStats.json
+++ b/i18n/fi/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Tarkat tilastot",
+      "description": "Yksityiskohtainen erittely Daily Page -toiminnastasi."
+    },
+    "nav": {
+      "backToDashboard": "← Takaisin hallintapaneeliin"
+    },
+    "header": {
+      "title": "📊 Tilastojesi yleiskatsaus 📊"
+    },
+    "cards": {
+      "totalBlocks": "Luotuja julkaisuja yhteensä 📝",
+      "collaborations": "Yhteistyöt 🤝",
+      "votesGiven": "Annetut äänet 👍",
+      "daysActive": "Aktiiviset päivät 📆"
+    },
+    "chart": {
+      "datasetLabel": "Tilastosi",
+      "labels": {
+        "blocksCreated": "Luodut julkaisut",
+        "collaborations": "Yhteistyöt",
+        "votesGiven": "Annetut äänet",
+        "daysActive": "Aktiiviset päivät"
+      }
+    }
+  }
+}

--- a/i18n/fi/errors.json
+++ b/i18n/fi/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Hups! Jokin meni pieleen.",
+      "message": "Tapahtui odottamaton virhe. Yritä myöhemmin uudelleen.",
+      "home": "Takaisin etusivulle"
+    },
+    "notFound": {
+      "title": "404 - Sivua ei löydy",
+      "metaTitle": "Sivua ei löydy",
+      "message": "Valitettavasti emme löytäneet etsimääsi sivua.",
+      "homePrefix": "Voit palata",
+      "homeLink": "etusivulle",
+      "roomsPrefix": "tai tutustua",
+      "roomsLink": "huonehakemistoon."
+    }
+  }
+}

--- a/i18n/fi/flagModal.json
+++ b/i18n/fi/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Ilmoita sopimattomasta sisällöstä",
+    "fields": {
+      "reason": {
+        "label": "Syy",
+        "options": {
+          "spam": "Roskaposti",
+          "offensive": "Loukkaava (vihapuhe tai halventavat ilmaukset)",
+          "inappropriate": "Sopimaton (alastomuus, graafinen sisältö jne.)",
+          "other": "Muu"
+        }
+      },
+      "details": {
+        "label": "Lisätiedot (valinnainen)",
+        "placeholder": "Kuvaile, mitä näit…"
+      }
+    },
+    "buttons": {
+      "submit": "Lähetä ilmoitus",
+      "cancel": "Peruuta"
+    },
+    "toasts": {
+      "success": "Ilmoitus lähetetty, kiitos!",
+      "failed": "Ilmoituksen lähettäminen epäonnistui."
+    }
+  }
+}

--- a/i18n/fi/forgotPassword.json
+++ b/i18n/fi/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Nollaa salasana",
+      "description": "Pyydä nollauslinkki Daily Page -tilillesi."
+    },
+    "header": {
+      "title": "Unohditko salasanasi?",
+      "subtitle": "Syötä sähköpostisi, niin lähetämme sinulle nollauslinkin."
+    },
+    "form": {
+      "email": {
+        "label": "Sähköpostiosoite",
+        "placeholder": "Syötä sähköpostisi"
+      },
+      "submit": "Pyydä salasanan nollausta"
+    },
+    "feedback": {
+      "successGeneric": "Jos sähköposti on olemassa, nollauslinkki on lähetetty.",
+      "missingEmail": "Sähköposti vaaditaan.",
+      "genericError": "Jokin meni pieleen. Yritä uudelleen.",
+      "unexpectedError": "Tapahtui odottamaton virhe. Yritä uudelleen."
+    },
+    "email": {
+      "subject": "Nollaa Daily Page -salasanasi",
+      "heading": "Salasanan nollauspyyntö",
+      "headingWithName": "Salasanan nollauspyyntö, {username}",
+      "body": "Nollaa salasanasi napsauttamalla alla olevaa linkkiä.",
+      "cta": "Nollaa salasanani",
+      "expires": "Tämä linkki vanhenee {hours} tunnin kuluttua.",
+      "ignore": "Jos et pyytänyt salasanan nollausta, voit turvallisesti ohittaa tämän sähköpostin."
+    }
+  }
+}

--- a/i18n/fi/home.json
+++ b/i18n/fi/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Suositut julkaisut viimeiseltä 24 tunnilta",
+      "description": "Daily Page on minimalistinen indie-kirjoitussivusto, jossa kuka tahansa voi julkaista luovia ajatuksia, muistoja tai kokeiluja, yksi julkaisu kerrallaan. Tutki uusia ideoita, liity huoneisiin ja tuo äänesi mukaan."
+    },
+    "hero": {
+      "eyebrow": "Hiljainen paikka kirjoittamiseen, lukemiseen ja palaamiseen",
+      "title": "Tervetuloa Daily Pageen!",
+      "subtitle": "Tutustu viimeisen 24 tunnin suosituimpiin julkaisuihin.",
+      "ctaPrefix": "Inspiroiko?",
+      "cta": "Liity huoneeseen",
+      "ctaSuffix": "ja luo oma julkaisusi!"
+    },
+    "stats": {
+      "blocks": "Julkaisut",
+      "rooms": "Huoneet",
+      "tags": "Tunnisteet",
+      "collabsToday": "Yhteistöitä tänään"
+    },
+    "activity": {
+      "title": "Elossa Daily Pagessa",
+      "subtitle": "Tuoreet keskustelut ja reaktiot yhdellä silmäyksellä.",
+      "fallbackActor": "Joku",
+      "inRoom": "huoneessa",
+      "comments": {
+        "title": "Viimeisimmät kommentit",
+        "more": "Hae keskusteluista",
+        "commentVerb": "kommentoi julkaisua",
+        "replyVerb": "vastasi julkaisussa",
+        "empty": "Ei vielä viimeaikaisia kommentteja. Seuraava keskustelu voi alkaa sinun julkaisustasi."
+      },
+      "reactions": {
+        "title": "Viimeisimmät reaktiot",
+        "more": "Selaa suosittuja julkaisuja",
+        "empty": "Ei vielä viimeaikaisia reaktioita. Hyvä julkaisu voi herättää tämän nopeasti.",
+        "types": {
+          "heart": "tykkäsi sydämellä",
+          "leaf": "reagoi lehdellä julkaisuun",
+          "wow": "reagoi ihmetellen julkaisuun",
+          "laugh": "nauroi julkaisulle"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Esittelyssä oleva huone",
+      "roomInfoDays": "Toiminta viimeisten {days} päivän aikana: {blocks} julkaisua, {votes} ääntä.",
+      "roomInfo24h": "Toiminta viimeisen 24 tunnin aikana: {blocks} julkaisua, {votes} ääntä.",
+      "checkItOut": "Tutustu",
+      "blockRibbon": "★ Esittelyssä oleva julkaisu",
+      "votes": "{n} ääntä",
+      "noContent": "(Sisältöä ei annettu...)",
+      "viewBlock": "Näytä julkaisu"
+    },
+    "trendingTags": {
+      "title": "Nousussa olevat tunnisteet",
+      "suffixDays": "(viimeiset {days} päivää)",
+      "suffixAllTime": "(kaikkien aikojen)",
+      "blocks": "{n} julkaisua",
+      "votes": "{n} ääntä",
+      "empty": "Ei vielä nousevia tunnisteita. Ole ensimmäinen, joka lisää tunnisteen johonkin hienoon!"
+    },
+    "trendingBlocks": {
+      "title": "Nousussa olevat julkaisut",
+      "suffixDays": "(viimeiset {days} päivää)",
+      "createdBy": "Luonut:",
+      "in": "huoneessa",
+      "on": "päivänä",
+      "unknownRoom": "Tuntematon huone",
+      "empty24h": "Ei julkaisuja viimeisen 24 tunnin aikana. Tarkista pian uudelleen!"
+    }
+  }
+}

--- a/i18n/fi/layout.json
+++ b/i18n/fi/layout.json
@@ -1,0 +1,55 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Tervetuloa, käyttäjä!",
+    "logout": "Kirjaudu ulos",
+    "login": "Kirjaudu / Rekisteröidy",
+    "language": "Kieli",
+    "openMenu": "Avaa päävalikko",
+    "closeMenu": "Sulje päävalikko",
+    "privacy": "Tietosuojakäytäntö",
+    "uiFallbackNotice": "{requested} ei ole vielä käännetty. Näytetään toistaiseksi {current}.",
+    "copyButton": {
+      "copy": "Kopioi",
+      "copied": "Kopioitu!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "englanti",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "עברית",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Teema",
+      "toggleToDark": "Vaihda tummaan tilaan",
+      "toggleToLight": "Vaihda vaaleaan tilaan"
+    },
+    "blockImages": {
+      "preview": "Kuvan esikatselu",
+      "close": "Sulje kuvan esikatselu",
+      "open": "Avaa kuvan esikatselu"
+    }
+  }
+}

--- a/i18n/fi/modals.json
+++ b/i18n/fi/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Kirjaudu sisään",
+      "message": "Sinun on kirjauduttava sisään jatkaaksesi.",
+      "messageWithAction": "Sinun on kirjauduttava sisään voidaksesi {action}.",
+      "cta": "Kirjaudu sisään"
+    },
+    "actions": {
+      "voteOnBlock": "äänestää julkaisua",
+      "starRoom": "merkitä tämän huoneen tähdellä",
+      "reactToBlock": "reagoida tähän julkaisuun",
+      "commentOnBlock": "kommentoida tätä julkaisua",
+      "reportComment": "ilmoittaa tästä kommentista"
+    },
+    "errors": {
+      "starToggleFail": "Tähtimerkinnän päivittäminen epäonnistui. Yritä uudelleen."
+    }
+  }
+}

--- a/i18n/fi/nav.json
+++ b/i18n/fi/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Etusivu",
+    "rooms": "Huoneet",
+    "tags": "Tunnisteet",
+    "archive": "Arkisto",
+    "search": "Haku",
+    "bestOf": "Parhaat",
+    "about": "Tietoja",
+    "support": "Tuki",
+    "otherProjects": "Muut projektit",
+    "auth": {
+      "welcomePrefix": "Tervetuloa, ",
+      "welcomeFallbackUser": "sinä",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Hallintapaneeli"
+  }
+}

--- a/i18n/fi/notifications.json
+++ b/i18n/fi/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Ilmoitukset",
+      "openMenu": "Avaa ilmoitukset",
+      "loading": "Ladataan ilmoituksia...",
+      "error": "Ilmoituksia ei voi ladata juuri nyt.",
+      "empty": "Ei ilmoituksia vielä.",
+      "markRead": "Merkitse luetuksi",
+      "fallbackActor": "Joku",
+      "fallbackBlockTitle": "julkaisusi",
+      "item": {
+        "blockComment": "{actorUsername} kommentoi julkaisuasi \"{blockTitle}\".",
+        "commentReply": "{actorUsername} vastasi kommenttiisi julkaisussa \"{blockTitle}\".",
+        "unknown": "Ilmoitus"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Uusi kommentti julkaisuun \"{blockTitle}\"",
+        "heading": "Uusi kommentti julkaisuusi",
+        "headingWithName": "Hei {username},",
+        "body": "<strong>{actorUsername}</strong> kommentoi julkaisuasi <strong>{blockTitle}</strong>.",
+        "cta": "Näytä keskustelu Daily Pagessa",
+        "fallbackActor": "Joku",
+        "fallbackBlockTitle": "julkaisusi"
+      },
+      "commentReply": {
+        "subject": "Uusi vastaus julkaisuun \"{blockTitle}\"",
+        "heading": "Uusi vastaus kommenttiisi",
+        "headingWithName": "Hei {username},",
+        "body": "<strong>{actorUsername}</strong> vastasi kommenttiisi julkaisussa <strong>{blockTitle}</strong>.",
+        "cta": "Näytä keskustelu Daily Pagessa",
+        "fallbackActor": "Joku",
+        "fallbackBlockTitle": "julkaisusi"
+      }
+    }
+  }
+}

--- a/i18n/fi/privacy.json
+++ b/i18n/fi/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Tietosuojakäytäntö",
+      "description": "Selkeästi kerrottuna, miten Daily Page kerää, käyttää ja suojaa tietojasi."
+    },
+    "title": "Tietosuojakäytäntö",
+    "lastUpdated": "Viimeksi päivitetty: {date}",
+    "intro": {
+      "h2": "Johdanto",
+      "p1": "Daily Page (\"me\") ylläpitää dailypage.org-sivustoa (jäljempänä \"Palvelu\").",
+      "p2": "Tämä sivu kertoo käytännöistämme henkilötietojen keräämisessä, käytössä ja luovuttamisessa, kun käytät Palveluamme."
+    },
+    "collection": {
+      "h2": "Tietojen kerääminen ja käyttö",
+      "p": "Keräämme vain vähän henkilötietoja Palvelumme parantamiseksi ja tarjoamiseksi. Näihin kuuluvat tilinhallintaan käytettävät sähköpostiosoitteet ja käyttäjien vapaaehtoisesti lähettämä sisältö."
+    },
+    "usage": {
+      "h2": "Tietojen käyttö",
+      "p": "Kerättyjä tietoja käytetään vain tilin tunnistamiseen, sisällön moderointiin ja käyttökokemuksen parantamiseen."
+    },
+    "storage": {
+      "h2": "Tietojen säilytys ja turvallisuus",
+      "p": "Tietosi säilytetään turvallisesti, eikä niitä koskaan jaeta tai myydä kolmansille osapuolille ilman nimenomaista suostumustasi, ellei laki sitä vaadi."
+    },
+    "cookies": {
+      "h2": "Evästeet",
+      "p": "Käytämme evästeitä vain istuntojen hallintaan ja käyttökokemuksen parantamiseen. Voit poistaa evästeet käytöstä selaimesi asetuksista."
+    },
+    "rights": {
+      "h2": "Oikeutesi",
+      "p": "Voit pyytää henkilötietojesi poistamista tai muuttamista milloin tahansa ottamalla meihin yhteyttä."
+    },
+    "changes": {
+      "h2": "Muutokset tähän tietosuojakäytäntöön",
+      "p": "Saatamme päivittää tietosuojakäytäntöämme aika ajoin. Muutokset julkaistaan tällä sivulla."
+    },
+    "contact": {
+      "h2": "Ota yhteyttä",
+      "p": "Jos sinulla on kysyttävää tästä tietosuojakäytännöstä, ota yhteyttä:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/fi/profile.json
+++ b/i18n/fi/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Käyttäjän {username} profiili",
+      "descriptionUser": "Näytä käyttäjän {username} viimeaikainen toiminta, tähdellä merkityt huoneet ja tilastot."
+    },
+    "profile": {
+      "profilePicAlt": "Profiilikuva",
+      "noBio": "(Esittelyä ei ole saatavilla.)"
+    },
+    "activity": {
+      "title": "Viimeaikainen toiminta",
+      "updatedOn": "Päivitetty {date}",
+      "none": "Ei viimeaikaista toimintaa.",
+      "viewAllBlocks": "Näytä kaikki julkaisut"
+    },
+    "starredRooms": {
+      "title": "Tähdellä merkityt huoneet",
+      "none": "Ei tähdellä merkittyjä huoneita vielä.",
+      "unnamedRoom": "Nimetön huone"
+    },
+    "stats": {
+      "title": "Käyttäjätilastot",
+      "totalBlocks": "Luotuja julkaisuja yhteensä",
+      "collaborations": "Yhteistyöt",
+      "daysActive": "Aktiiviset päivät"
+    }
+  }
+}

--- a/i18n/fi/random.json
+++ b/i18n/fi/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Muut projektit",
+      "description": "Tutustu baseball-päiväkirjaan, satunnaisiin kirjoituskokeiluihin ja muihin Daily Pagen sivuprojekteihin."
+    },
+    "title": "Muut projektit",
+    "tagline": "Kotoisa nurkka kokeiluille ja sivuseikkailuille.",
+    "links": {
+      "baseball": "📖 Baseball-päiväkirja",
+      "randomWriter": "🎲 Satunnaiskirjoittaja"
+    },
+    "cta": {
+      "backToRooms": "Takaisin päähuoneisiin"
+    }
+  }
+}

--- a/i18n/fi/randomWriter.json
+++ b/i18n/fi/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Satunnaiskirjoittaja",
+      "description": "Luo loputon virta satunnaista pseudotekstiä huviksi, inspiraatioksi tai kaaokseksi."
+    },
+    "title": "Satunnaiskirjoittaja",
+    "buttons": {
+      "clear": "Tyhjennä",
+      "stop": "Lopeta kirjoittaminen",
+      "start": "Aloita kirjoittaminen"
+    }
+  }
+}

--- a/i18n/fi/reactions.json
+++ b/i18n/fi/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} reaktiota: {count}",
+    "loginToReact": "Kirjaudu reagoidaksesi",
+    "countsLabel": "Reaktiot"
+  }
+}

--- a/i18n/fi/readMore.json
+++ b/i18n/fi/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Lisää...",
+    "aria": "Lue koko julkaisu: {title}"
+  }
+}

--- a/i18n/fi/resetPassword.json
+++ b/i18n/fi/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Nollaa salasanasi",
+      "description": "Aseta tilillesi uusi salasana."
+    },
+    "header": {
+      "title": "Nollaa salasanasi",
+      "subtitle": "Valitse uusi salasana saadaksesi käyttöoikeuden takaisin."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Uusi salasana",
+        "placeholder": "Syötä uusi salasana"
+      },
+      "submit": "Aseta uusi salasana"
+    },
+    "feedback": {
+      "missingToken": "Tunnus puuttuu tai on virheellinen.",
+      "missingFields": "Tunnus ja uusi salasana vaaditaan.",
+      "invalidOrExpired": "Virheellinen tai vanhentunut tunnus.",
+      "success": "Salasana päivitettiin onnistuneesti!",
+      "genericError": "Jokin meni pieleen. Yritä uudelleen.",
+      "unexpectedError": "Tapahtui odottamaton virhe. Yritä uudelleen."
+    }
+  }
+}

--- a/i18n/fi/roomDashboard.json
+++ b/i18n/fi/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Tutustu huoneen {roomName} viimeaikaisiin ja keskeneräisiin julkaisuihin."
+    },
+    "links": {
+      "exploreLabel": "Tutki:",
+      "allBlocks": "🗂️ Kaikki julkaisut",
+      "browseByDate": "🗓️ Päivämäärän mukaan",
+      "bestOf": "🏅 Parhaat",
+      "searchInRoom": "🔎 Haku"
+    },
+    "actions": {
+      "createBlock": "Luo julkaisu",
+      "starTitle": "Merkitse tämä huone tähdellä",
+      "unstarTitle": "Poista tähti tästä huoneesta"
+    },
+    "tabs": {
+      "locked": "Lukitut julkaisut",
+      "inProgress": "Keskeneräiset julkaisut"
+    },
+    "sections": {
+      "lockedHeader": "Lukitut julkaisut",
+      "inProgressHeader": "Keskeneräiset julkaisut"
+    },
+    "editorial": {
+      "heading": "Esittelyssä olevat oppaat",
+      "description": "Aloita tästä tähän huoneeseen kuratoiduilla oppailla.",
+      "roleNames": {
+        "pillar": "Ydinopas",
+        "companion": "Lukuopas",
+        "texture": "Taustaopas"
+      }
+    },
+    "empty": {
+      "noDescription": "Kuvausta ei ole saatavilla.",
+      "noLocked": "Ei lukittuja julkaisuja vielä! Julkaisut lukittuvat automaattisesti 1 tunnin käyttämättömyyden jälkeen.",
+      "noInProgress": "Ei keskeneräisiä julkaisuja vielä! Aika aloittaa yksi.",
+      "noBlocks": "Ei julkaisuja vielä! Luo ensimmäinen ja jätä jälkesi. 😎"
+    }
+  }
+}

--- a/i18n/fi/roomsDirectory.json
+++ b/i18n/fi/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Huonehakemisto",
+      "description": "Jokainen huone on ovi erilaiseen maailmaan. Astu sisään, jaa tarinasi ja rakenna muiden kanssa jotain kaunista."
+    },
+    "eyebrow": "Löydä oma nurkkasi",
+    "heading": "Huonehakemisto",
+    "intro": "Aloita huoneista, jotka tuntuvat juuri nyt eläviltä, tai vaella aiheittain, kunnes jokin kolahtaa. Jokainen huone on erilainen kirjoitusvirike, fanikunta tai jaettu intohimo, joka odottaa ääntäsi.",
+    "empty": "Huoneita ei ole tällä hetkellä saatavilla. Tarkista myöhemmin uudelleen!",
+    "jumpToActive": "Näytä aktiiviset huoneet",
+    "jumpToTopics": "Selaa aiheittain",
+    "statsLabel": "Huonehakemiston kohokohdat",
+    "liveNow": "Käynnissä nyt",
+    "recentlyActive": "Äskettäin aktiiviset",
+    "recentlyActiveSubtitle": "Nopein tapa löytää huone, jossa on ihmisiä juuri nyt.",
+    "browseByTopic": "Selaa aiheittain",
+    "topicSubtitle": "Avaa aihe tutkiaksesi sen huoneita.",
+    "roomCount": "{count} huonetta",
+    "stats": {
+      "rooms": "huonetta tutkittavaksi",
+      "topics": "aiheryhmää",
+      "active": "aktiivista valintaa"
+    },
+    "activeUsers": "Aktiiviset käyttäjät: {count}",
+    "visitRoom": "Vieraile huoneessa",
+    "close": "Sulje",
+    "noTitle": "Otsikkoa ei ole saatavilla",
+    "noDescription": "Kuvausta ei ole saatavilla"
+  }
+}

--- a/i18n/fi/search.json
+++ b/i18n/fi/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Haku",
+      "description": "Hae julkisista julkaisuista."
+    },
+    "title": "Haku",
+    "placeholder": "Hae julkaisuja...",
+    "hint": "Kirjoita vähintään 2 merkkiä hakeaksesi.",
+    "noResults": "Tuloksia ei löytynyt.",
+    "untitled": "Otsikoton",
+    "votesTitle": "Äänet",
+    "pageLabel": "Sivu",
+    "filters": {
+      "inRoom": "Huoneessa"
+    },
+    "buttons": {
+      "search": "Haku",
+      "prev": "Edellinen",
+      "next": "Seuraava"
+    }
+  }
+}

--- a/i18n/fi/signup.json
+++ b/i18n/fi/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Luo tili",
+      "description": "Rekisteröidy Daily Pageen käyttääksesi kaikkia ominaisuuksia."
+    },
+    "header": {
+      "title": "Luo tilisi",
+      "subtitle": "Liity Daily Pageen aloittaaksesi päivittäisen kirjoittamisesi luomisen ja jakamisen!"
+    },
+    "form": {
+      "email": {
+        "label": "Sähköposti",
+        "placeholder": "Syötä sähköpostisi"
+      },
+      "username": {
+        "label": "Käyttäjänimi",
+        "placeholder": "Syötä käyttäjänimesi"
+      },
+      "password": {
+        "label": "Salasana",
+        "placeholder": "Syötä salasana"
+      },
+      "submit": "Rekisteröidy",
+      "feedback": {
+        "success": "Lomakkeen lähetys onnistui!",
+        "successCreatedVerify": "Tili luotiin onnistuneesti! Tarkista sähköpostisi vahvistaaksesi tilisi.",
+        "genericError": "Tilin luominen epäonnistui. Yritä uudelleen.",
+        "unexpectedError": "Tapahtui odottamaton virhe. Yritä uudelleen."
+      }
+    }
+  }
+}

--- a/i18n/fi/starredRooms.json
+++ b/i18n/fi/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Kaikki tähdellä merkityt huoneet",
+      "description": "Luettelo kaikista huoneista, jotka olet merkinnyt tähdellä."
+    },
+    "nav": {
+      "backToDashboard": "← Takaisin hallintapaneeliin"
+    },
+    "header": {
+      "title": "🌟 Kaikki tähdellä merkitsemäsi huoneet 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Nimetön huone",
+      "noDescription": "Ei kuvausta."
+    },
+    "empty": {
+      "message": "Et ole vielä merkinnyt yhtään huonetta tähdellä!"
+    }
+  }
+}

--- a/i18n/fi/support.json
+++ b/i18n/fi/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Tuki",
+      "description": "Miten ottaa yhteyttä, ilmoittaa ongelmista, pyytää ominaisuuksia tai huoneita ja tukea Daily Pagea taloudellisesti."
+    },
+    "contact": {
+      "h1": "★ Haluan esittää kysymyksen, ilmoittaa ongelmasta tai pyytää ominaisuutta.",
+      "p1": {
+        "before": "Jos käytät mieluummin GitHubia, katso",
+        "link": "tämän projektin ongelmat",
+        "after": "ja lisää oma äänesi. Myös pull requestit ovat tietenkin tervetulleita."
+      },
+      "p2": {
+        "before": "Vaihtoehtoisesti",
+        "link": "lähetä sähköpostia",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Haluan tukea tätä projektia lahjoituksella.",
+      "p1": {
+        "before": "Kiitos jo etukäteen tämän projektin rahoittamisesta. Lähetä maksut turvallisesti palvelun kautta",
+        "paypal": "PayPal",
+        "middle": "tai halutessasi",
+        "amazon": "tilaa muutama pussillinen Amazonissa myymiäni leluja",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Haluan pyytää uutta huonetta.",
+      "form": {
+        "nameLabel": "Huoneen nimi",
+        "topicLabel": "Aihe (valinnainen)",
+        "descriptionLabel": "Kuvaus",
+        "submit": "Lähetä pyyntö",
+        "success": "Pyyntö lähetettiin onnistuneesti!",
+        "errorGeneric": "Pyynnön lähettäminen epäonnistui. Yritä uudelleen.",
+        "errorUnexpected": "Tapahtui odottamaton virhe. Yritä uudelleen."
+      }
+    }
+  }
+}

--- a/i18n/fi/tags.json
+++ b/i18n/fi/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Tunnisteiden yleiskatsaus",
+      "description": "Selaa kaikkia Daily Pagessa käytettyjä tunnisteita nopeilla aikasuodattimilla."
+    },
+    "title": "Tunnisteiden yleiskatsaus",
+    "intro": "Tutustu kaikkiin Daily Pagessa käytettyihin tunnisteisiin.",
+    "tagCloudTitle": "Tunnistepilvi",
+    "timeframe": {
+      "last24h": "Viimeiset 24 tuntia",
+      "last7d": "Viimeiset 7 päivää",
+      "last30d": "Viimeiset 30 päivää",
+      "all": "Kaikkien aikojen"
+    },
+    "error": {
+      "loading": "Tunnisteiden yleiskatsauksen lataaminen epäonnistui"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Julkaisut tunnisteella"
+      },
+      "header": {
+        "label": "Tunniste:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Julkaisuja yhteensä tunnisteella",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Luonut:",
+        "inRoom": "huoneessa",
+        "unknownRoom": "Tuntematon huone",
+        "onDate": ""
+      },
+      "chart": {
+        "label": "Ajan mittaan luodut julkaisut"
+      },
+      "empty": {
+        "message": "Tällä tunnisteella ei löytynyt vielä julkaisuja. Ehkä sinun kannattaa luoda ensimmäinen? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Tunnistesivun lataaminen epäonnistui"
+      }
+    }
+  }
+}

--- a/i18n/fi/translation.json
+++ b/i18n/fi/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Käännetty kielestä",
+    "see": "katso",
+    "originalBlock": "alkuperäinen julkaisu"
+  }
+}

--- a/i18n/fi/userBlocks.json
+++ b/i18n/fi/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Julkaisusi",
+      "description": "Selaa ja järjestä kaikkia julkaisuja, jotka olet luonut tai joissa olet ollut mukana."
+    },
+    "header": {
+      "dashboardLink": "Hallintapaneelisi",
+      "profileLink": "Käyttäjän {username} profiili",
+      "allBlocks": "Kaikki julkaisut"
+    },
+    "empty": "Ei julkaisuja vielä.",
+    "pagination": {
+      "prev": "← Edellinen",
+      "next": "Seuraava →"
+    },
+    "titleUser": "Käyttäjän {username} julkaisut"
+  }
+}

--- a/i18n/fi/verifyEmail.json
+++ b/i18n/fi/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Vahvista sähköposti",
+      "description": "Vahvista sähköpostiosoitteesi Daily Pagea varten."
+    },
+    "header": {
+      "title": "Vahvistetaan sähköpostiasi..."
+    },
+    "status": {
+      "checking": "Tarkistetaan tunnusta, odota...",
+      "missingToken": "Vahvistustunnus puuttuu tai on virheellinen.",
+      "genericFailure": "Vahvistus epäonnistui.",
+      "unexpectedError": "Tapahtui odottamaton virhe.",
+      "success": "Tilisi on vahvistettu onnistuneesti!",
+      "invalidOrExpired": "Virheellinen tai vanhentunut vahvistustunnus."
+    },
+    "verificationMsg": {
+      "subject": "Vahvista Daily Page -tilisi ✨",
+      "heading": "Tervetuloa Daily Pageen, {username}!",
+      "body": "Vahvista sähköpostisi napsauttamalla alla:",
+      "cta": "Vahvista sähköpostiosoite",
+      "expires": "Tämä linkki vanhenee {hours} tunnin kuluttua."
+    }
+  }
+}

--- a/i18n/fi/voteControls.json
+++ b/i18n/fi/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Ylä-ääni",
+    "downvote": "Ala-ääni",
+    "errors": {
+      "failed": "Ääntäsi ei voitu tallentaa."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -79,4 +79,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'sv' }).catch(console.error), 8_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'no' }).catch(console.error), 9_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'da' }).catch(console.error), 9_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'fi' }).catch(console.error), 10_000);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary
- Add a complete `i18n/fi` locale translated from the English source files
- Register `fi` as a fully supported UI language for routing, hreflang, email notifications, and home cache warming
- Leave DB-backed room metadata translations untouched

## Validation
- Parsed all locale JSON successfully
- Verified `i18n/fi` matches `i18n/en` file-for-file and key-for-key
- Checked for remaining non-i18n UI strings; no small Finnish-rollout-specific changes were needed