### PR TITLE
Add full Polish UI support

### DIFF
--- a/i18n/pl/about.json
+++ b/i18n/pl/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — O nas",
+      "description": "Czym jest Daily Page, jak działa i dlaczego powstało jako wolniejszy, życzliwszy zakątek internetu."
+    },
+    "title": "O Daily Page",
+    "tagline": "Karm swój umysł, nie swój feed.",
+    "mission": {
+      "h2": "Misja",
+      "p1": "Niezależne laboratorium pisania, które zaczęło się w moim salonie i żyje dzięki ciekawości czytelników.",
+      "p2": "Powstało nie po to, by męczyć umysł, ale by go karmić: to miejsce, gdzie możesz pisać powoli, anonimowo, jeśli chcesz, i nie martwić się robieniem na kimkolwiek wrażenia."
+    },
+    "how": {
+      "h2": "Jak to działa",
+      "features": {
+        "rooms": {
+          "label": "Pokoje",
+          "text": "to tematyczne przestrzenie (pomyśl: „subreddit, ale bardziej przyjazny”)."
+        },
+        "blocks": {
+          "label": "Posty",
+          "text": "to wspólne przestrzenie pisania — każdy, nawet osoba anonimowa, może je tworzyć, edytować do momentu zablokowania i głosować na inne."
+        },
+        "privacy": {
+          "label": "Prywatność i udostępnianie",
+          "text": "oznacza, że publiczne posty trafiają do kanału pokoju. Niepubliczne wersje robocze są ukryte do czasu zablokowania, ale dostajesz link do zaproszenia znajomych."
+        },
+        "markdown": {
+          "label": "Markdown i multimedia",
+          "text": "pozwalają pisać w Markdownie, osadzać obrazy i współedytować jak w Google Docs."
+        },
+        "trends": {
+          "label": "Trendy i tagi",
+          "text": "pozwalają tagować posty, śledzić trendy tagów i odkrywać najlepsze treści (7 dni / 30 dni / od początku)."
+        },
+        "streaks": {
+          "label": "Serie",
+          "text": "pomagają utrzymać codzienną serię pisania — najlepszą zachętę, by wracać każdego dnia."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Jak tu dotarliśmy",
+      "p1": "W 2018 roku zbudowałem wiki oparte na datach dla „dzisiejszej strony” i obserwowałem, jak kilku introspektywnych autorów zmienia je w ujście dla swoich myśli. Nigdy nie urosło ogromnie, ale zasadziło ziarno.",
+      "p2": "Dziś Daily Page jest tym ziarnem, które rozrosło się w wiele pokoi — cichą sieć społeczną dla introwertyków, idealistów i każdego, kto tęskni za wolniejszym tempem."
+    },
+    "next": {
+      "h2": "Co dalej",
+      "p1": "Dopiero zaczynamy: bogatsze osadzanie treści, głębsze statystyki użytkowników, rankingi reputacji i więcej sposobów nagradzania przemyślanej twórczości.",
+      "p2": "Dziękujemy, że jesteś częścią tego małego niezależnego eksperymentu."
+    },
+    "cta": {
+      "rooms": "Odkryj pokoje",
+      "signup": "Dołącz do społeczności"
+    }
+  }
+}

--- a/i18n/pl/accountSecurity.json
+++ b/i18n/pl/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Bezpieczeństwo konta",
+      "description": "Zarządzaj hasłem Daily Page i uwierzytelnianiem dwuskładnikowym."
+    },
+    "backToDashboard": "Wróć do panelu",
+    "heading": "Bezpieczeństwo konta",
+    "subheading": "Chroń konto silnym hasłem i aplikacją uwierzytelniającą.",
+    "password": {
+      "title": "Zmień hasło",
+      "description": "Użyj unikalnego hasła z co najmniej 8 znakami.",
+      "current": {
+        "label": "Obecne hasło"
+      },
+      "new": {
+        "label": "Nowe hasło"
+      },
+      "submit": "Zaktualizuj hasło"
+    },
+    "twoFactor": {
+      "title": "Uwierzytelnianie dwuskładnikowe",
+      "statusOn": "Włączone",
+      "statusOff": "Wyłączone",
+      "description": "Podczas logowania po haśle dodaj jednorazowy kod z aplikacji uwierzytelniającej.",
+      "currentPassword": {
+        "label": "Obecne hasło"
+      },
+      "startSetup": "Skonfiguruj aplikację uwierzytelniającą",
+      "qrAlt": "Kod QR aplikacji uwierzytelniającej",
+      "manualKey": "Klucz konfiguracji ręcznej",
+      "code": {
+        "label": "6-cyfrowy kod"
+      },
+      "enable": "Włącz 2FA",
+      "disableCode": {
+        "label": "Kod uwierzytelniający"
+      },
+      "disable": "Wyłącz 2FA"
+    },
+    "recoveryCodes": {
+      "title": "Zapisz kody odzyskiwania",
+      "description": "Użyj jednego z tych jednorazowych kodów, aby się zalogować, jeśli stracisz dostęp do aplikacji uwierzytelniającej.",
+      "regenerateDescription": "Wygeneruj nowy zestaw kodów odzyskiwania, jeśli poprzedni został utracony. Stare kody przestaną działać.",
+      "regenerate": "Wygeneruj nowe kody odzyskiwania",
+      "warning": "Przechowuj je w bezpiecznym miejscu. Nie zostaną pokazane ponownie."
+    },
+    "feedback": {
+      "passwordChanged": "Hasło zostało zaktualizowane.",
+      "setupReady": "Zeskanuj kod QR, a następnie wpisz 6-cyfrowy kod, aby zakończyć konfigurację.",
+      "twoFactorEnabled": "Uwierzytelnianie dwuskładnikowe jest teraz włączone.",
+      "twoFactorDisabled": "Uwierzytelnianie dwuskładnikowe jest teraz wyłączone.",
+      "recoveryCodesRegenerated": "Kody odzyskiwania zostały wygenerowane ponownie. Zapisz teraz nowe kody.",
+      "missingFields": "Wypełnij wszystkie wymagane pola.",
+      "missingCurrentPassword": "Wpisz obecne hasło, aby kontynuować.",
+      "passwordTooShort": "Nowe hasło musi mieć co najmniej 8 znaków.",
+      "invalidCurrentPassword": "Obecne hasło się nie zgadza.",
+      "missingCode": "Wpisz 6-cyfrowy kod z aplikacji uwierzytelniającej.",
+      "invalidCode": "Ten kod nie zadziałał. Spróbuj ponownie.",
+      "noPendingSetup": "Rozpocznij konfigurację ponownie przed wpisaniem kodu.",
+      "setupExpired": "Ta sesja konfiguracji wygasła. Rozpocznij konfigurację ponownie, aby otrzymać nowy kod QR.",
+      "twoFactorNotEnabled": "Uwierzytelnianie dwuskładnikowe nie jest włączone dla tego konta.",
+      "genericError": "Coś poszło nie tak. Spróbuj ponownie.",
+      "unexpectedError": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+    }
+  }
+}

--- a/i18n/pl/anonymousUser.json
+++ b/i18n/pl/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Anonimowy wędrowiec",
+      "description": "Bez profilu. Bez przeszłości. Tylko klimat."
+    },
+    "ascii": {
+      "ariaLabel": "Sztuka ASCII fantazyjnej postaci z cytatem"
+    },
+    "header": {
+      "title": "Anonimowy"
+    },
+    "body": {
+      "line1": "Trafiasz w pustkę. Nie ma tu nic do zobaczenia —",
+      "line2": "tylko wędrujący duch bez historii."
+    },
+    "buttons": {
+      "home": "← Wróć na stronę główną",
+      "signup": "Utwórz tożsamość"
+    }
+  }
+}

--- a/i18n/pl/archive.json
+++ b/i18n/pl/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Archiwum",
+      "description": "Przeglądaj pełne archiwum według miesięcy.",
+      "titleRoom": "Daily Page — Archiwum · {roomName}",
+      "descriptionRoom": "Przeglądaj dawne teksty w pokoju {roomName} miesiąc po miesiącu. Przejdź do dowolnej daty, aby zobaczyć, co inni udostępniali tu z czasem."
+    },
+    "nav": {
+      "prev": "Poprzednie",
+      "next": "Następne"
+    },
+    "title": "📚 Przeglądaj archiwa",
+    "titleRoom": "📚 {roomName} — Archiwa",
+    "roomViewing": "Przeglądasz archiwum pokoju {roomName}",
+    "viewRoomLink": "Zobacz pokój",
+    "noContent": "Brak dostępnych treści.",
+    "backToRoom": "← Wróć do panelu pokoju",
+    "calendar": {
+      "meta": {
+        "description": "Zobacz wszystkie twórcze posty opublikowane w {month} {year} — od krótkich myśli po głębokie refleksje. Kliknij dowolną datę, aby odkryć, co udostępniono.",
+        "descriptionRoom": "Zobacz twórczą aktywność w pokoju {roomName} w {month} {year}. Wybierz datę, aby przejrzeć posty udostępnione tego dnia."
+      },
+      "title": "📆 Archiwum za {month} {year}",
+      "prevLabel": "Archiwum za {month} {year}",
+      "nextLabel": "Archiwum za {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Archiwum z {date}",
+        "titleRoom": "{roomName} — Archiwum z {date}",
+        "descriptionSite": "Przeglądaj posty napisane {date} — od cichych notatek po odważne wyznania.",
+        "descriptionRoom": "{date} autorzy w pokoju {roomName} zostawili swój ślad — przewiń refleksje, pomysły i wypowiedzi udostępnione tego dnia."
+      },
+      "heading": "Archiwum z {date}",
+      "empty": "Nie znaleziono treści dla tej daty.",
+      "labels": {
+        "createdBy": "Utworzone przez:",
+        "in": "w",
+        "on": "{datetime}",
+        "unknownRoom": "Nieznany pokój"
+      },
+      "nav": {
+        "prevDay": "Poprzedni dzień",
+        "nextDay": "Następny dzień"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Wszystkie posty",
+        "descriptionRoom": "Przeglądaj każdy post opublikowany w pokoju {roomName}. Sortuj według daty, tytułu lub głosów, aby poznać jego historię."
+      },
+      "header": {
+        "allBlocks": "— Wszystkie posty"
+      },
+      "sort": {
+        "label": "Sortuj według",
+        "options": {
+          "date": "Data",
+          "title": "Tytuł",
+          "votes": "Głosy"
+        },
+        "submit": "Idź"
+      }
+    },
+    "pagination": {
+      "prev": "← Poprzednia",
+      "next": "Następna →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daily Pages dla {time}"
+      },
+      "empty": "Nie znaleźliśmy żadnych stron w tym okresie."
+    }
+  }
+}

--- a/i18n/pl/auth.json
+++ b/i18n/pl/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Logowanie",
+        "description": "Zaloguj się na konto Daily Page, aby kontynuować swoją pisarską podróż."
+      },
+      "heading": "Witaj ponownie!",
+      "subheading": "Zaloguj się na konto, aby dalej dzielić się codziennym pisaniem.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Nazwa użytkownika lub e-mail",
+          "placeholder": "Wpisz nazwę użytkownika lub e-mail"
+        },
+        "password": {
+          "label": "Hasło",
+          "placeholder": "Wpisz hasło"
+        },
+        "totpCode": {
+          "label": "Kod uwierzytelniający lub odzyskiwania",
+          "placeholder": "Wpisz kod"
+        }
+      },
+      "actions": {
+        "submit": "Zaloguj się"
+      },
+      "feedback": {
+        "success": "Logowanie udane! Przekierowywanie...",
+        "twoFactorRequired": "Wpisz 6-cyfrowy kod z aplikacji uwierzytelniającej albo użyj kodu odzyskiwania.",
+        "twoFactorFailed": "Ten kod nie zadziałał. Spróbuj ponownie.",
+        "failedGeneric": "Logowanie nie powiodło się. Spróbuj ponownie.",
+        "unexpected": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+      },
+      "links": {
+        "forgotPassword": "Nie pamiętasz hasła?",
+        "noAccount": "Nie masz jeszcze konta?",
+        "signupHere": "Zarejestruj się tutaj!"
+      }
+    }
+  }
+}

--- a/i18n/pl/bestOf.json
+++ b/i18n/pl/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Najlepsze z Daily Page",
+      "description": "Najbardziej lubiane posty na Daily Page — zabawne, szczere, poetyckie albo po prostu dziwne. Zobacz, co wyróżniało się w ostatnim dniu, tygodniu, miesiącu i dłużej.",
+      "titleRoom": "Najlepsze z {roomName}",
+      "descriptionRoom": "Odkryj wyróżniające się posty z pokoju {roomName} — te, które czytelnicy najbardziej polubili w ostatnich 24 godzinach, 7 dniach, 30 dniach i od początku."
+    },
+    "heading": "🏆 Najlepsze z Daily Page",
+    "headingRoomPrefix": "🏆 Najlepsze z ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 godziny",
+      "7d": "🚀 7 dni",
+      "30d": "🌕 30 dni",
+      "all": "👑 Od początku"
+    },
+    "labels": {
+      "createdBy": "Utworzone przez:",
+      "inRoom": "w",
+      "onDate": "{date}",
+      "unknownRoom": "Nieznany pokój",
+      "noBlocks": "Nie znaleziono postów.",
+      "viewRoom": "Zobacz pokój"
+    }
+  }
+}

--- a/i18n/pl/blockCommon.json
+++ b/i18n/pl/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Wersja robocza"
+    },
+    "deleteModal": {
+      "title": "Usunąć post?",
+      "message": "Tej czynności nie można cofnąć.",
+      "confirm": "Usuń",
+      "cancel": "Anuluj",
+      "closeAriaLabel": "Zamknij"
+    },
+    "toasts": {
+      "deleteSuccess": "Post został usunięty.",
+      "deleteFailed": "Nie udało się usunąć posta."
+    }
+  }
+}

--- a/i18n/pl/blockEditor.json
+++ b/i18n/pl/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Ty)"
+    },
+    "meta": {
+      "title": "Edytuj post - {blockTitle}",
+      "titleFallback": "Edytuj post"
+    },
+    "errors": {
+      "imageUrlRequired": "Wpisz adres URL obrazu.",
+      "notFound": "Nie znaleziono posta albo nie należy on do tego pokoju.",
+      "loadFailed": "Wystąpił błąd podczas ładowania edytora posta.",
+      "updateTitleFailed": "Błąd podczas aktualizacji tytułu."
+    },
+    "roomInfo": {
+      "label": "Pokój:"
+    },
+    "title": {
+      "placeholder": "Wpisz tytuł posta",
+      "editTooltip": "Edytuj tytuł",
+      "lock": "Zablokuj post",
+      "delete": "Usuń post"
+    },
+    "description": {
+      "label": "Opis",
+      "editTooltip": "Edytuj opis",
+      "placeholder": "Wpisz opis",
+      "noDescriptionOwner": "Brak opisu...",
+      "noDescriptionViewer": "Nie podano opisu...",
+      "save": "Zapisz",
+      "cancel": "Anuluj",
+      "expand": "Rozwiń",
+      "collapse": "Zwiń",
+      "updateError": "Błąd podczas aktualizacji opisu."
+    },
+    "status": {
+      "lastBackup": "Ostatnia kopia zapasowa: {datetime}",
+      "lastBackupUnknown": "Ostatnia kopia zapasowa: nieznana"
+    },
+    "peers": {
+      "label": "Współautorzy:"
+    },
+    "toasts": {
+      "blockLocked": "Ten post został zablokowany!"
+    },
+    "editor": {
+      "placeholder": "Pusta strona czeka na Twój głos; pisz bez lęku."
+    },
+    "loading": {
+      "label": "Ładowanie",
+      "quote": "Pozwól światu przepłynąć przez siebie jak ogień. Rzuć pryzmatyczne światło, rozpalone do bieli, na papier.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Nie napisano nic przez 5 minut. Kliknij OK, aby kontynuować sesję; w przeciwnym razie nastąpi przekierowanie do archiwum.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Link do udostępniania",
+      "copyTooltip": "Kopiuj do schowka",
+      "copied": "Skopiowano!"
+    },
+    "toolbar": {
+      "insertImage": "Wstaw obraz",
+      "insertImageUrlPlaceholder": "Wpisz adres URL obrazu",
+      "insertImageAltPlaceholder": "Tekst alternatywny (opcjonalnie)",
+      "insertImageConfirm": "Potwierdź",
+      "insertImageCancel": "Anuluj"
+    },
+    "buttons": {
+      "downloadFile": "Pobierz plik"
+    },
+    "lockModal": {
+      "messageLine1": "Czy na pewno chcesz zablokować ten post?",
+      "messageLine2": "To go sfinalizuje i uniemożliwi dalszą edycję.",
+      "confirm": "Zablokuj",
+      "cancel": "Anuluj",
+      "successToast": "Post został zablokowany.",
+      "errorToast": "Błąd podczas blokowania posta."
+    },
+    "tags": {
+      "headerWithTags": "Tagi:",
+      "headerNoTags": "Nie ma jeszcze tagów. Dodaj kilka:",
+      "updateError": "Błąd podczas aktualizacji tagów."
+    },
+    "fullBlock": {
+      "headingPrefix": "Przepraszamy; post „{blockTitle}” jest teraz",
+      "headingStatus": "w pełni zajęty.",
+      "retryPrefix": "Proszę",
+      "retryLink": "spróbuj innego posta",
+      "retrySuffix": "albo wróć innym razem.",
+      "consolationPrefix": "W oczekiwaniu możesz przeczytać",
+      "consolationBestOf": "kilka naszych ulubionych postów",
+      "consolationMiddle": "albo przejrzeć",
+      "consolationArchive": "archiwum."
+    }
+  }
+}

--- a/i18n/pl/blockList.json
+++ b/i18n/pl/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "od początku",
+      "days": "w ciągu ostatnich {n} dni",
+      "day": "w ciągu ostatnich 24 godzin"
+    },
+    "createdBy": "Utworzone przez:",
+    "on": "w dniu"
+  }
+}

--- a/i18n/pl/blockTags.json
+++ b/i18n/pl/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "Tagi:",
+      "noTags": "Nie ma jeszcze tagów. Dodaj kilka:"
+    },
+    "input": {
+      "placeholder": "Nowy tag",
+      "addButton": "Dodaj"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/pl/blockView.json
+++ b/i18n/pl/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Post - {blockTitle}",
+      "titleFallback": "Post"
+    },
+    "labels": {
+      "room": "Pokój",
+      "author": "Autor",
+      "created": "Utworzono",
+      "unknownAuthor": "Anonimowy",
+      "authorAvatarAlt": "Awatar użytkownika {username}",
+      "viewAuthorProfile": "Zobacz profil użytkownika {username}",
+      "lang": "Tłumaczenia: ",
+      "available": "dostępne"
+    },
+    "buttons": {
+      "edit": "Edytuj",
+      "deleteBlock": "Usuń post",
+      "share": "Udostępnij",
+      "flagContent": "Zgłoś treść"
+    },
+    "description": {
+      "label": "Opis",
+      "none": "Nie podano opisu...",
+      "expand": "Rozwiń",
+      "collapse": "Zwiń"
+    },
+    "editorial": {
+      "heading": "Przewodnik czytania",
+      "roleLabel": "Typ czytania",
+      "clusterLabel": "Przewodnik",
+      "sequence": "Część {sequence}",
+      "primaryPillarHeading": "Zacznij tutaj",
+      "relatedHeading": "Czytaj dalej",
+      "clusterHeading": "Więcej w tym przewodniku",
+      "expandSection": "Pokaż jeszcze {count}",
+      "collapseSection": "Pokaż mniej",
+      "roleNames": {
+        "pillar": "Główny przewodnik",
+        "companion": "Dogłębna lektura",
+        "texture": "Tło"
+      }
+    },
+    "comments": {
+      "heading": "Komentarze",
+      "count": "Komentarze: {count}",
+      "empty": "Nikt jeszcze nie odpowiedział. Komentarze pojawią się tutaj, gdy rozmowa się zacznie.",
+      "composer": {
+        "label": "Dodaj komentarz",
+        "placeholder": "Napisz komentarz...",
+        "submit": "Opublikuj komentarz",
+        "submitting": "Publikowanie...",
+        "success": "Komentarz opublikowany.",
+        "error": "Nie można teraz opublikować komentarza.",
+        "loginPrompt": "Zaloguj się, aby dołączyć do rozmowy.",
+        "loginCta": "Zaloguj się, aby komentować",
+        "verifyPrompt": "Zweryfikuj e-mail przed opublikowaniem komentarza.",
+        "verifyCta": "Zweryfikuj e-mail"
+      },
+      "sort": {
+        "label": "Sortuj",
+        "oldestFirst": "Najstarsze najpierw",
+        "newestFirst": "Najnowsze najpierw"
+      },
+      "by": "Przez",
+      "unknownAuthor": "Nieznany",
+      "reply": {
+        "action": "Odpowiedz",
+        "label": "Dodaj odpowiedź",
+        "placeholder": "Napisz odpowiedź...",
+        "submit": "Opublikuj odpowiedź",
+        "submitting": "Publikowanie...",
+        "success": "Odpowiedź opublikowana.",
+        "error": "Nie można teraz opublikować odpowiedzi.",
+        "cancel": "Anuluj",
+        "loginPrompt": "Zaloguj się, aby odpowiedzieć."
+      },
+      "manage": {
+        "edited": "Edytowano",
+        "editAction": "Edytuj",
+        "deleteAction": "Usuń",
+        "deleteConfirm": "Usunąć ten komentarz? Spowoduje to także usunięcie odpowiedzi pod nim.",
+        "deleteSuccess": "Komentarz usunięty.",
+        "deleteError": "Nie można teraz usunąć komentarza.",
+        "forbidden": "Możesz zarządzać tylko własnymi komentarzami.",
+        "edit": {
+          "label": "Edytuj komentarz",
+          "save": "Zapisz",
+          "saving": "Zapisywanie...",
+          "cancel": "Anuluj",
+          "success": "Komentarz zaktualizowany.",
+          "error": "Nie można teraz zaktualizować komentarza."
+        }
+      },
+      "report": {
+        "action": "Zgłoś",
+        "pending": "Zgłaszanie...",
+        "success": "Komentarz zgłoszony.",
+        "error": "Nie można teraz zgłosić komentarza.",
+        "ownError": "Nie możesz zgłosić własnego komentarza.",
+        "hidden": "Komentarz ukryty po zgłoszeniu.",
+        "reported": "Zgłoszono"
+      },
+      "deepLink": {
+        "focused": "Powiązany komentarz",
+        "unavailable": "Powiązany komentarz nie jest już dostępny."
+      },
+      "loadMore": "Załaduj więcej komentarzy",
+      "loading": "Ładowanie...",
+      "loadError": "Nie można teraz załadować więcej komentarzy."
+    },
+    "share": {
+      "title": "Udostępnij ten post",
+      "shareOn": "Udostępnij na:",
+      "nativeText": "Zobacz ten post: {title}",
+      "alt": {
+        "facebook": "Logo Facebooka",
+        "reddit": "Logo Reddita",
+        "whatsapp": "Logo WhatsAppa",
+        "twitter": "Logo Twittera"
+      }
+    },
+    "errors": {
+      "notFound": "Nie znaleziono posta albo nie należy on do tego pokoju.",
+      "loadFailed": "Błąd podczas ładowania widoku posta."
+    }
+  }
+}

--- a/i18n/pl/createBlock.json
+++ b/i18n/pl/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Utwórz nowy post — Daily Page",
+      "description": "Rozpocznij nowy twórczy post z opcjonalnymi tagami, językiem i widocznością."
+    },
+    "heading": "Utwórz nowy post",
+    "roomInfo": {
+      "roomLabel": "Pokój:",
+      "unavailable": "Informacje o pokoju są niedostępne.",
+      "noDescription": "Brak opisu."
+    },
+    "form": {
+      "title": {
+        "label": "Tytuł:",
+        "placeholder": {
+          "full": "np. „Moje arcydzieło”, „Najlepszy pomysł świata”, „Clickbait dla nerdów”",
+          "short": "np. „Moje arcydzieło”"
+        }
+      },
+      "description": {
+        "label": "Opis (opcjonalnie):",
+        "placeholder": "Wyjaśnij swój geniusz… albo po prostu improwizuj."
+      },
+      "initialContent": {
+        "label": "Treść początkowa (opcjonalnie):",
+        "help": "Zacznij pisać tutaj albo naciśnij „Utwórz”, aby kontynuować na pełnej stronie edytora, gdzie możesz osadzać obrazy i współpracować w czasie rzeczywistym.",
+        "placeholder": "Zacznij post tutaj albo kontynuuj edycję po utworzeniu…"
+      },
+      "visibility": {
+        "label": "Widoczność:"
+      },
+      "submit": "Utwórz post"
+    },
+    "visibility": {
+      "public": {
+        "label": "Publiczny",
+        "title": "Edytowalny przez każdego w czasie rzeczywistym. Logowanie nie jest potrzebne.",
+        "inline": "Edytowalny przez każdego w czasie rzeczywistym. Logowanie nie jest potrzebne."
+      },
+      "unlisted": {
+        "label": "Niepubliczna wersja robocza",
+        "title": "Ukryta przed publicznym przeglądaniem podczas edycji. Widoczna po zablokowaniu.",
+        "inline": "Ukryta przed publicznym przeglądaniem podczas edycji. Widoczna po zablokowaniu.",
+        "tooltip": "Niepubliczne wersje robocze są ukryte przed publicznym przeglądaniem podczas edycji. Każdy z linkiem może współpracować, a post staje się publiczny po zablokowaniu."
+      }
+    },
+    "advanced": {
+      "summary": "Opcje zaawansowane",
+      "lang": {
+        "label": "Język:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Przetłumacz istniejący post (URL lub ID):",
+        "placeholder": "Wklej adres URL lub ID posta (opcjonalnie)",
+        "invalid": "To nie wygląda na prawidłowy adres URL ani ID posta.",
+        "fetchError": "Nie udało się pobrać informacji o poście."
+      }
+    },
+    "messages": {
+      "langExists": "Tłumaczenie dla tego języka już istnieje. Wybierz inny język.",
+      "genericError": "Coś poszło nie tak. Spróbuj ponownie."
+    }
+  }
+}

--- a/i18n/pl/dashboard.json
+++ b/i18n/pl/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Panel",
+      "description": "Twój panel Daily Page i przegląd konta."
+    },
+    "profile": {
+      "profilePicAlt": "Zdjęcie profilowe",
+      "noBio": "Nie ma jeszcze biogramu. Kliknij „Edytuj”, aby go dodać!",
+      "editBio": "Edytuj biogram",
+      "bioPlaceholder": "Wpisz tutaj swój biogram",
+      "save": "Zapisz",
+      "cancel": "Anuluj"
+    },
+    "activity": {
+      "title": "Ostatnia aktywność",
+      "none": "Brak ostatniej aktywności.",
+      "updatedOn": "Zaktualizowano {date}",
+      "viewAllBlocks": "Zobacz wszystkie posty"
+    },
+    "drafts": {
+      "title": "Kontynuuj pisanie",
+      "none": "Brak otwartych wersji roboczych.",
+      "updatedOn": "Zaktualizowano {date}",
+      "unlisted": "Niepubliczny",
+      "viewAll": "Zobacz wszystkie posty"
+    },
+    "streak": {
+      "title": "Seria pisania",
+      "line": "{days} dni z rzędu! Tak trzymaj!"
+    },
+    "starredRooms": {
+      "title": "Wyróżnione pokoje",
+      "none": "Nie masz jeszcze wyróżnionych pokoi. Zacznij odkrywać, aby znaleźć ulubione!",
+      "viewAll": "Zobacz wszystkie wyróżnione pokoje",
+      "unnamedRoom": "Pokój bez nazwy"
+    },
+    "security": {
+      "title": "Bezpieczeństwo konta",
+      "summary": "Zmień hasło i zarządzaj uwierzytelnianiem dwuskładnikowym.",
+      "manage": "Zarządzaj bezpieczeństwem"
+    },
+    "stats": {
+      "title": "Twoje statystyki",
+      "totalBlocks": "Łączna liczba utworzonych postów",
+      "collaborations": "Współprace",
+      "votesGiven": "Oddane głosy",
+      "daysActive": "Aktywne dni",
+      "viewDetailed": "Zobacz szczegółowe statystyki 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Nie udało się przesłać zdjęcia profilowego. Spróbuj ponownie.",
+      "uploadUnexpected": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie.",
+      "bioUpdateFailed": "Błąd podczas aktualizacji biogramu. Spróbuj ponownie."
+    }
+  }
+}

--- a/i18n/pl/detailedStats.json
+++ b/i18n/pl/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Szczegółowe statystyki",
+      "description": "Szczegółowy podział Twojej aktywności w Daily Page."
+    },
+    "nav": {
+      "backToDashboard": "← Wróć do panelu"
+    },
+    "header": {
+      "title": "📊 Przegląd Twoich statystyk 📊"
+    },
+    "cards": {
+      "totalBlocks": "Łącznie utworzone posty 📝",
+      "collaborations": "Współprace 🤝",
+      "votesGiven": "Oddane głosy 👍",
+      "daysActive": "Aktywne dni 📆"
+    },
+    "chart": {
+      "datasetLabel": "Twoje statystyki",
+      "labels": {
+        "blocksCreated": "Utworzone posty",
+        "collaborations": "Współprace",
+        "votesGiven": "Oddane głosy",
+        "daysActive": "Aktywne dni"
+      }
+    }
+  }
+}

--- a/i18n/pl/errors.json
+++ b/i18n/pl/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ups! Coś poszło nie tak.",
+      "message": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.",
+      "home": "Wróć na stronę główną"
+    },
+    "notFound": {
+      "title": "404 - Nie znaleziono strony",
+      "metaTitle": "Nie znaleziono strony",
+      "message": "Przepraszamy, nie mogliśmy znaleźć strony, której szukasz.",
+      "homePrefix": "Możesz wrócić do",
+      "homeLink": "strony głównej",
+      "roomsPrefix": "albo zajrzeć do",
+      "roomsLink": "katalogu pokoi."
+    }
+  }
+}

--- a/i18n/pl/flagModal.json
+++ b/i18n/pl/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Zgłoś nieodpowiednią treść",
+    "fields": {
+      "reason": {
+        "label": "Powód",
+        "options": {
+          "spam": "Spam",
+          "offensive": "Obraźliwe (mowa nienawiści lub obelgi)",
+          "inappropriate": "Nieodpowiednie (nagość, drastyczne treści itd.)",
+          "other": "Inne"
+        }
+      },
+      "details": {
+        "label": "Szczegóły (opcjonalnie)",
+        "placeholder": "Opisz, co zobaczono…"
+      }
+    },
+    "buttons": {
+      "submit": "Wyślij zgłoszenie",
+      "cancel": "Anuluj"
+    },
+    "toasts": {
+      "success": "Zgłoszenie wysłane — dziękujemy!",
+      "failed": "Nie udało się wysłać zgłoszenia."
+    }
+  }
+}

--- a/i18n/pl/forgotPassword.json
+++ b/i18n/pl/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Resetowanie hasła",
+      "description": "Poproś o link resetujący hasło do konta Daily Page."
+    },
+    "header": {
+      "title": "Nie pamiętasz hasła?",
+      "subtitle": "Wpisz swój e-mail, a wyślemy link resetujący."
+    },
+    "form": {
+      "email": {
+        "label": "Adres e-mail",
+        "placeholder": "Wpisz e-mail"
+      },
+      "submit": "Poproś o reset hasła"
+    },
+    "feedback": {
+      "successGeneric": "Jeśli ten e-mail istnieje, link resetujący został wysłany.",
+      "missingEmail": "E-mail jest wymagany.",
+      "genericError": "Coś poszło nie tak. Spróbuj ponownie.",
+      "unexpectedError": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+    },
+    "email": {
+      "subject": "Zresetuj hasło Daily Page",
+      "heading": "Prośba o reset hasła",
+      "headingWithName": "Prośba o reset hasła, {username}",
+      "body": "Kliknij poniższy link, aby zresetować hasło.",
+      "cta": "Zresetuj moje hasło",
+      "expires": "Ten link wygasa za {hours} godz.",
+      "ignore": "Jeśli nie proszono o reset hasła, możesz bezpiecznie zignorować tę wiadomość."
+    }
+  }
+}

--- a/i18n/pl/home.json
+++ b/i18n/pl/home.json
@@ -1,0 +1,73 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Popularne posty z ostatnich 24 godzin",
+      "description": "Daily Page to minimalistyczny, niezależny serwis do pisania, gdzie każdy może publikować twórcze myśli, wspomnienia lub eksperymenty — po jednym poście naraz. Odkrywaj nowe pomysły, dołączaj do pokoi i dodaj swój głos."
+    },
+    "hero": {
+      "eyebrow": "Ciche miejsce do pisania, czytania i powracania",
+      "title": "Witaj w Daily Page!",
+      "subtitle": "Odkryj najpopularniejsze posty z ostatnich 24 godzin.",
+      "ctaPrefix": "Masz inspirację?",
+      "cta": "Dołącz do pokoju",
+      "ctaSuffix": "i utwórz własny post!"
+    },
+    "stats": {
+      "blocks": "Posty",
+      "rooms": "Pokoje",
+      "tags": "Tagi",
+      "collabsToday": "Dzisiejsze współprace"
+    },
+    "activity": {
+      "title": "Na żywo w Daily Page",
+      "subtitle": "Świeże rozmowy i reakcje w jednym widoku.",
+      "fallbackActor": "Ktoś",
+      "inRoom": "w",
+      "comments": {
+        "title": "Ostatnie komentarze",
+        "more": "Szukaj dyskusji",
+        "commentVerb": "skomentował(a)",
+        "replyVerb": "odpowiedział(a) w",
+        "empty": "Nie ma jeszcze ostatnich komentarzy. Następna rozmowa może zacząć się od Twojego posta."
+      },
+      "reactions": {
+        "title": "Ostatnie reakcje",
+        "more": "Przeglądaj popularne posty",
+        "empty": "Nie ma jeszcze ostatnich reakcji. Dobry post może szybko to ożywić.",
+        "types": {
+          "heart": "polubił(a) sercem",
+          "leaf": "zareagował(a) liściem na",
+          "wow": "zareagował(a) zachwytem na",
+          "laugh": "zaśmiał(a) się z"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Wyróżniony pokój",
+      "roomInfoDays": "Aktywność z ostatnich {days} dni: {blocks} postów, {votes} głosów.",
+      "roomInfo24h": "Aktywność z ostatnich 24 godzin: {blocks} postów, {votes} głosów.",
+      "checkItOut": "Sprawdź",
+      "blockRibbon": "★ Wyróżniony post",
+      "votes": "Głosy: {n}",
+      "noContent": "(Nie podano treści...)",
+      "viewBlock": "Zobacz post"
+    },
+    "trendingTags": {
+      "title": "Popularne tagi",
+      "suffixDays": "(ostatnie {days} dni)",
+      "suffixAllTime": "(od początku)",
+      "blocks": "Posty: {n}",
+      "votes": "Głosy: {n}",
+      "empty": "Nie ma jeszcze popularnych tagów. Otaguj coś ciekawego jako pierwszy!"
+    },
+    "trendingBlocks": {
+      "title": "Popularne posty",
+      "suffixDays": "(ostatnie {days} dni)",
+      "createdBy": "Utworzone przez:",
+      "in": "w",
+      "on": "w dniu",
+      "unknownRoom": "Nieznany pokój",
+      "empty24h": "Brak postów w ostatnich 24 godzinach. Zajrzyj wkrótce!"
+    }
+  }
+}

--- a/i18n/pl/layout.json
+++ b/i18n/pl/layout.json
@@ -1,0 +1,55 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Witaj, użytkowniku!",
+    "logout": "Wyloguj",
+    "login": "Zaloguj / Zarejestruj",
+    "language": "Język",
+    "openMenu": "Otwórz menu główne",
+    "closeMenu": "Zamknij menu główne",
+    "privacy": "Polityka prywatności",
+    "uiFallbackNotice": "{requested} nie jest jeszcze przetłumaczony. Na razie wyświetlamy {current}.",
+    "copyButton": {
+      "copy": "Kopiuj",
+      "copied": "Skopiowano!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "English",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "עברית",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "Motyw",
+      "toggleToDark": "Przełącz na tryb ciemny",
+      "toggleToLight": "Przełącz na tryb jasny"
+    },
+    "blockImages": {
+      "preview": "Podgląd obrazu",
+      "close": "Zamknij podgląd obrazu",
+      "open": "Otwórz podgląd obrazu"
+    }
+  }
+}

--- a/i18n/pl/modals.json
+++ b/i18n/pl/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Zaloguj się",
+      "message": "Musisz się zalogować, aby kontynuować.",
+      "messageWithAction": "Musisz się zalogować, aby {action}.",
+      "cta": "Zaloguj się"
+    },
+    "actions": {
+      "voteOnBlock": "zagłosować na post",
+      "starRoom": "wyróżnić ten pokój",
+      "reactToBlock": "zareagować na ten post",
+      "commentOnBlock": "skomentować ten post",
+      "reportComment": "zgłosić ten komentarz"
+    },
+    "errors": {
+      "starToggleFail": "Nie udało się zaktualizować wyróżnienia. Spróbuj ponownie."
+    }
+  }
+}

--- a/i18n/pl/nav.json
+++ b/i18n/pl/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Strona główna",
+    "rooms": "Pokoje",
+    "tags": "Tagi",
+    "archive": "Archiwum",
+    "search": "Szukaj",
+    "bestOf": "Najlepsze",
+    "about": "O nas",
+    "support": "Wsparcie",
+    "otherProjects": "Inne projekty",
+    "auth": {
+      "welcomePrefix": "Witaj, ",
+      "welcomeFallbackUser": "Ty",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Panel"
+  }
+}

--- a/i18n/pl/notifications.json
+++ b/i18n/pl/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Powiadomienia",
+      "openMenu": "Otwórz powiadomienia",
+      "loading": "Ładowanie powiadomień...",
+      "error": "Nie można teraz załadować powiadomień.",
+      "empty": "Brak powiadomień.",
+      "markRead": "Oznacz jako przeczytane",
+      "fallbackActor": "Ktoś",
+      "fallbackBlockTitle": "Twój post",
+      "item": {
+        "blockComment": "{actorUsername} skomentował(a) Twój post „{blockTitle}”.",
+        "commentReply": "{actorUsername} odpowiedział(a) na Twój komentarz do „{blockTitle}”.",
+        "unknown": "Powiadomienie"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Nowy komentarz do „{blockTitle}”",
+        "heading": "Nowy komentarz do Twojego posta",
+        "headingWithName": "Cześć {username},",
+        "body": "<strong>{actorUsername}</strong> skomentował(a) Twój post <strong>{blockTitle}</strong>.",
+        "cta": "Zobacz rozmowę w Daily Page",
+        "fallbackActor": "Ktoś",
+        "fallbackBlockTitle": "Twój post"
+      },
+      "commentReply": {
+        "subject": "Nowa odpowiedź w „{blockTitle}”",
+        "heading": "Nowa odpowiedź na Twój komentarz",
+        "headingWithName": "Cześć {username},",
+        "body": "<strong>{actorUsername}</strong> odpowiedział(a) na Twój komentarz do <strong>{blockTitle}</strong>.",
+        "cta": "Zobacz rozmowę w Daily Page",
+        "fallbackActor": "Ktoś",
+        "fallbackBlockTitle": "Twój post"
+      }
+    }
+  }
+}

--- a/i18n/pl/privacy.json
+++ b/i18n/pl/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Polityka prywatności",
+      "description": "Prosto o tym, jak Daily Page zbiera, wykorzystuje i chroni Twoje dane."
+    },
+    "title": "Polityka prywatności",
+    "lastUpdated": "Ostatnia aktualizacja: {date}",
+    "intro": {
+      "h2": "Wprowadzenie",
+      "p1": "Daily Page („my”, „nas” lub „nasze”) prowadzi stronę dailypage.org (dalej „Usługa”).",
+      "p2": "Ta strona informuje o naszych zasadach dotyczących zbierania, wykorzystywania i ujawniania danych osobowych podczas korzystania z Usługi."
+    },
+    "collection": {
+      "h2": "Zbieranie i wykorzystywanie informacji",
+      "p": "Zbieramy minimalne dane osobowe, aby ulepszać i świadczyć Usługę. Obejmuje to adresy e-mail do zarządzania kontem oraz treści dobrowolnie przesłane przez użytkowników."
+    },
+    "usage": {
+      "h2": "Wykorzystanie danych",
+      "p": "Zebrane dane są używane wyłącznie do uwierzytelniania kont, moderacji treści i ulepszania doświadczenia użytkownika."
+    },
+    "storage": {
+      "h2": "Przechowywanie danych i bezpieczeństwo",
+      "p": "Twoje dane są bezpiecznie przechowywane i nigdy nie są udostępniane ani sprzedawane stronom trzecim bez wyraźnej zgody, z wyjątkiem sytuacji wymaganych prawem."
+    },
+    "cookies": {
+      "h2": "Pliki cookie",
+      "p": "Używamy plików cookie wyłącznie do zarządzania sesją i ulepszania doświadczenia użytkownika. Możesz wyłączyć pliki cookie w ustawieniach przeglądarki."
+    },
+    "rights": {
+      "h2": "Twoje prawa",
+      "p": "Możesz w każdej chwili poprosić o usunięcie lub zmianę swoich danych osobowych, kontaktując się z nami."
+    },
+    "changes": {
+      "h2": "Zmiany w tej polityce prywatności",
+      "p": "Możemy od czasu do czasu aktualizować Politykę prywatności. Zmiany będą publikowane na tej stronie."
+    },
+    "contact": {
+      "h2": "Kontakt",
+      "p": "W sprawach dotyczących tej Polityki prywatności skontaktuj się z nami pod adresem:",
+      "emailLabel": "ask@dailypage.org"
+    }
+  }
+}

--- a/i18n/pl/profile.json
+++ b/i18n/pl/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Profil użytkownika {username}",
+      "descriptionUser": "Zobacz ostatnią aktywność, wyróżnione pokoje i statystyki użytkownika {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Zdjęcie profilowe",
+      "noBio": "(Brak biogramu.)"
+    },
+    "activity": {
+      "title": "Ostatnia aktywność",
+      "updatedOn": "Zaktualizowano {date}",
+      "none": "Brak ostatniej aktywności.",
+      "viewAllBlocks": "Zobacz wszystkie posty"
+    },
+    "starredRooms": {
+      "title": "Wyróżnione pokoje",
+      "none": "Brak wyróżnionych pokoi.",
+      "unnamedRoom": "Pokój bez nazwy"
+    },
+    "stats": {
+      "title": "Statystyki użytkownika",
+      "totalBlocks": "Łączna liczba utworzonych postów",
+      "collaborations": "Współprace",
+      "daysActive": "Aktywne dni"
+    }
+  }
+}

--- a/i18n/pl/random.json
+++ b/i18n/pl/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Inne projekty",
+      "description": "Odkryj baseballowy dziennik, losowe eksperymenty pisarskie i inne poboczne projekty Daily Page."
+    },
+    "title": "Inne projekty",
+    "tagline": "Przytulny kąt na eksperymenty i poboczne wyprawy.",
+    "links": {
+      "baseball": "📖 Dziennik baseballowy",
+      "randomWriter": "🎲 Losowy pisarz"
+    },
+    "cta": {
+      "backToRooms": "Wróć do głównych pokoi"
+    }
+  }
+}

--- a/i18n/pl/randomWriter.json
+++ b/i18n/pl/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Losowy pisarz",
+      "description": "Generuj nieskończony strumień losowego pseudotekstu dla zabawy, inspiracji albo chaosu."
+    },
+    "title": "Losowy pisarz",
+    "buttons": {
+      "clear": "Wyczyść",
+      "stop": "Zatrzymaj pisanie",
+      "start": "Zacznij pisać"
+    }
+  }
+}

--- a/i18n/pl/reactions.json
+++ b/i18n/pl/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "{emoji} reakcje: {count}",
+    "loginToReact": "Zaloguj się, aby zareagować",
+    "countsLabel": "Reakcje"
+  }
+}

--- a/i18n/pl/readMore.json
+++ b/i18n/pl/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Więcej...",
+    "aria": "Przeczytaj cały post: {title}"
+  }
+}

--- a/i18n/pl/resetPassword.json
+++ b/i18n/pl/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Zresetuj hasło",
+      "description": "Ustaw nowe hasło do konta."
+    },
+    "header": {
+      "title": "Zresetuj hasło",
+      "subtitle": "Wybierz nowe hasło, aby odzyskać dostęp."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Nowe hasło",
+        "placeholder": "Wpisz nowe hasło"
+      },
+      "submit": "Ustaw nowe hasło"
+    },
+    "feedback": {
+      "missingToken": "Brak tokenu albo token jest nieprawidłowy.",
+      "missingFields": "Token i nowe hasło są wymagane.",
+      "invalidOrExpired": "Token jest nieprawidłowy albo wygasł.",
+      "success": "Hasło zostało zaktualizowane.",
+      "genericError": "Coś poszło nie tak. Spróbuj ponownie.",
+      "unexpectedError": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+    }
+  }
+}

--- a/i18n/pl/roomDashboard.json
+++ b/i18n/pl/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Przeglądaj ostatnie i trwające posty w {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Odkryj:",
+      "allBlocks": "🗂️ Wszystkie posty",
+      "browseByDate": "🗓️ Według daty",
+      "bestOf": "🏅 Najlepsze",
+      "searchInRoom": "🔎 Szukaj"
+    },
+    "actions": {
+      "createBlock": "Utwórz post",
+      "starTitle": "Wyróżnij ten pokój",
+      "unstarTitle": "Usuń wyróżnienie tego pokoju"
+    },
+    "tabs": {
+      "locked": "Zablokowane posty",
+      "inProgress": "Posty w toku"
+    },
+    "sections": {
+      "lockedHeader": "Zablokowane posty",
+      "inProgressHeader": "Posty w toku"
+    },
+    "editorial": {
+      "heading": "Wyróżnione przewodniki",
+      "description": "Zacznij od wyróżnionych przewodników przygotowanych dla tego pokoju.",
+      "roleNames": {
+        "pillar": "Główny przewodnik",
+        "companion": "Przewodnik czytania",
+        "texture": "Przewodnik tła"
+      }
+    },
+    "empty": {
+      "noDescription": "Brak opisu.",
+      "noLocked": "Brak zablokowanych postów. Posty blokują się automatycznie po 1 godzinie bezczynności.",
+      "noInProgress": "Brak postów w toku. Czas zacząć pierwszy.",
+      "noBlocks": "Brak postów. Utwórz pierwszy i zostaw swój ślad. 😎"
+    }
+  }
+}

--- a/i18n/pl/roomsDirectory.json
+++ b/i18n/pl/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Katalog pokoi",
+      "description": "Każdy pokój jest wejściem do innego świata. Wejdź, podziel się historią i dołącz do innych w tworzeniu czegoś pięknego."
+    },
+    "eyebrow": "Znajdź swój kąt",
+    "heading": "Katalog pokoi",
+    "intro": "Zacznij od pokoi, które teraz tętnią życiem, albo wędruj po tematach, aż coś zaskoczy. Każdy pokój to inna podpowiedź do pisania, fandom lub wspólna pasja czekająca na Twój głos.",
+    "empty": "W tej chwili nie ma dostępnych pokoi. Zajrzyj później!",
+    "jumpToActive": "Zobacz aktywne pokoje",
+    "jumpToTopics": "Przeglądaj według tematu",
+    "statsLabel": "Najważniejsze informacje katalogu pokoi",
+    "liveNow": "Teraz aktywne",
+    "recentlyActive": "Ostatnio aktywne",
+    "recentlyActiveSubtitle": "Najszybszy sposób, by znaleźć pokój, w którym teraz są ludzie.",
+    "browseByTopic": "Przeglądaj według tematu",
+    "topicSubtitle": "Otwórz temat, aby poznać jego pokoje.",
+    "roomCount": "Pokoje: {count}",
+    "stats": {
+      "rooms": "pokoje do odkrycia",
+      "topics": "grupy tematów",
+      "active": "aktywne wybory"
+    },
+    "activeUsers": "Aktywni użytkownicy: {count}",
+    "visitRoom": "Odwiedź pokój",
+    "close": "Zamknij",
+    "noTitle": "Brak tytułu",
+    "noDescription": "Brak opisu"
+  }
+}

--- a/i18n/pl/search.json
+++ b/i18n/pl/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Szukaj",
+      "description": "Szukaj publicznych postów."
+    },
+    "title": "Szukaj",
+    "placeholder": "Szukaj postów...",
+    "hint": "Wpisz co najmniej 2 znaki, aby wyszukać.",
+    "noResults": "Nie znaleziono wyników.",
+    "untitled": "Bez tytułu",
+    "votesTitle": "Głosy",
+    "pageLabel": "Strona",
+    "filters": {
+      "inRoom": "W pokoju"
+    },
+    "buttons": {
+      "search": "Szukaj",
+      "prev": "Poprzednia",
+      "next": "Następne"
+    }
+  }
+}

--- a/i18n/pl/signup.json
+++ b/i18n/pl/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Utwórz konto",
+      "description": "Zarejestruj się w Daily Page, aby korzystać ze wszystkich funkcji."
+    },
+    "header": {
+      "title": "Utwórz swoje konto",
+      "subtitle": "Dołącz do Daily Page, aby zacząć tworzyć i udostępniać codzienne pisanie!"
+    },
+    "form": {
+      "email": {
+        "label": "E-mail",
+        "placeholder": "Wpisz e-mail"
+      },
+      "username": {
+        "label": "Nazwa użytkownika",
+        "placeholder": "Wpisz nazwę użytkownika"
+      },
+      "password": {
+        "label": "Hasło",
+        "placeholder": "Wpisz hasło"
+      },
+      "submit": "Zarejestruj się",
+      "feedback": {
+        "success": "Formularz wysłany pomyślnie!",
+        "successCreatedVerify": "Konto zostało utworzone. Sprawdź e-mail, aby je zweryfikować.",
+        "genericError": "Nie udało się utworzyć konta. Spróbuj ponownie.",
+        "unexpectedError": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+      }
+    }
+  }
+}

--- a/i18n/pl/starredRooms.json
+++ b/i18n/pl/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Wszystkie wyróżnione pokoje",
+      "description": "Lista wszystkich pokoi, które wyróżniono."
+    },
+    "nav": {
+      "backToDashboard": "← Wróć do panelu"
+    },
+    "header": {
+      "title": "🌟 Wszystkie Twoje wyróżnione pokoje 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Pokój bez nazwy",
+      "noDescription": "Brak opisu."
+    },
+    "empty": {
+      "message": "Nie wyróżniono jeszcze żadnych pokoi!"
+    }
+  }
+}

--- a/i18n/pl/support.json
+++ b/i18n/pl/support.json
@@ -1,0 +1,43 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page — Wsparcie",
+      "description": "Jak się skontaktować, zgłosić problemy, poprosić o funkcje lub pokoje i wesprzeć Daily Page finansowo."
+    },
+    "contact": {
+      "h1": "★ Chcę zadać pytanie, zgłosić problem albo poprosić o funkcję.",
+      "p1": {
+        "before": "Jeśli wolisz użyć GitHuba, sprawdź",
+        "link": "zgłoszenia tego projektu",
+        "after": "i dodaj swój głos. Pull requesty są oczywiście mile widziane."
+      },
+      "p2": {
+        "before": "Alternatywnie",
+        "link": "wyślij e-mail",
+        "after": "."
+      }
+    },
+    "contribute": {
+      "h1": "★ Chcę wesprzeć ten projekt wpłatą.",
+      "p1": {
+        "before": "Z góry dziękujemy za finansowe wsparcie projektu. Płatności prosimy wysyłać bezpiecznie przez",
+        "paypal": "PayPal",
+        "middle": "albo, jeśli wolisz,",
+        "amazon": "zamów kilka torebek zabawek, które sprzedaję na Amazonie",
+        "after": "."
+      }
+    },
+    "rooms": {
+      "h1": "★ Chcę poprosić o nowy pokój.",
+      "form": {
+        "nameLabel": "Nazwa pokoju",
+        "topicLabel": "Temat (opcjonalnie)",
+        "descriptionLabel": "Opis",
+        "submit": "Wyślij prośbę",
+        "success": "Prośba została wysłana.",
+        "errorGeneric": "Nie udało się wysłać prośby. Spróbuj ponownie.",
+        "errorUnexpected": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+      }
+    }
+  }
+}

--- a/i18n/pl/tags.json
+++ b/i18n/pl/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Przegląd tagów",
+      "description": "Przeglądaj wszystkie tagi używane w Daily Page, z szybkimi filtrami czasu."
+    },
+    "title": "Przegląd tagów",
+    "intro": "Odkryj wszystkie tagi używane w Daily Page.",
+    "tagCloudTitle": "Chmura tagów",
+    "timeframe": {
+      "last24h": "Ostatnie 24 godziny",
+      "last7d": "Ostatnie 7 dni",
+      "last30d": "Ostatnie 30 dni",
+      "all": "Od początku"
+    },
+    "error": {
+      "loading": "Błąd podczas ładowania przeglądu tagów"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": " | Daily Page",
+        "description": "Posty otagowane"
+      },
+      "header": {
+        "label": "Tag:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Łączna liczba postów z",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Utworzone przez:",
+        "inRoom": "w",
+        "unknownRoom": "Nieznany pokój",
+        "onDate": "w dniu"
+      },
+      "chart": {
+        "label": "Posty utworzone w czasie"
+      },
+      "empty": {
+        "message": "Nie znaleziono jeszcze postów z tym tagiem. Może utworzysz pierwszy? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Błąd podczas ładowania strony tagu"
+      }
+    }
+  }
+}

--- a/i18n/pl/translation.json
+++ b/i18n/pl/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Przetłumaczono z",
+    "see": "zobacz",
+    "originalBlock": "oryginalny post"
+  }
+}

--- a/i18n/pl/userBlocks.json
+++ b/i18n/pl/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Twoje posty",
+      "description": "Przeglądaj i sortuj wszystkie posty, które utworzono lub współtworzono."
+    },
+    "header": {
+      "dashboardLink": "Twój panel",
+      "profileLink": "Profil użytkownika {username}",
+      "allBlocks": "Wszystkie posty"
+    },
+    "empty": "Brak postów.",
+    "pagination": {
+      "prev": "← Poprzednia",
+      "next": "Następna →"
+    },
+    "titleUser": "Posty użytkownika {username}"
+  }
+}

--- a/i18n/pl/verifyEmail.json
+++ b/i18n/pl/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Zweryfikuj e-mail",
+      "description": "Zweryfikuj swój adres e-mail w Daily Page."
+    },
+    "header": {
+      "title": "Weryfikowanie e-maila..."
+    },
+    "status": {
+      "checking": "Sprawdzanie tokenu, proszę czekać...",
+      "missingToken": "Brak tokenu weryfikacyjnego albo token jest nieprawidłowy.",
+      "genericFailure": "Weryfikacja nie powiodła się.",
+      "unexpectedError": "Wystąpił nieoczekiwany błąd.",
+      "success": "Konto zostało pomyślnie zweryfikowane.",
+      "invalidOrExpired": "Token weryfikacyjny jest nieprawidłowy albo wygasł."
+    },
+    "verificationMsg": {
+      "subject": "Zweryfikuj konto Daily Page ✨",
+      "heading": "Witaj w Daily Page, {username}!",
+      "body": "Zweryfikuj e-mail, klikając poniżej:",
+      "cta": "Zweryfikuj adres e-mail",
+      "expires": "Ten link wygasa za {hours} godz."
+    }
+  }
+}

--- a/i18n/pl/voteControls.json
+++ b/i18n/pl/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "Głos w górę",
+    "downvote": "Głos w dół",
+    "errors": {
+      "failed": "Nie udało się zapisać głosu."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -80,4 +80,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'no' }).catch(console.error), 9_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'da' }).catch(console.error), 9_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'fi' }).catch(console.error), 10_000);
+  setTimeout(() => warmHomeCache({ preferredLang: 'pl' }).catch(console.error), 10_500);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- Adds a complete `i18n/pl` locale translated from the English source JSON files
- Registers `pl` as a fully supported UI locale for routing, hreflang, homepage cache warming, and localized comment notification emails
- Leaves DB-backed room name/description translations untouched for the separate room i18n workflow

## Validation

- Parsed all locale JSON successfully
- Verified `i18n/pl` matches `i18n/en` file-for-file and key-for-key
- Verified placeholders are preserved
- Ran `node --check` on the changed server modules

## Notes

`npm run lint` was attempted, but it currently fails on pre-existing unrelated lint issues outside this change.