### PR TITLE
Fix language picker background fill on small viewports

### DIFF
--- a/public/css/block-lang-switcher.css
+++ b/public/css/block-lang-switcher.css
@@ -55,8 +55,9 @@
   padding: 0.5rem;
   list-style: none;
   min-width: 200px;
-  background: var(--surface-bg);
-  opacity: 0.98;
+  background:
+    linear-gradient(rgba(255,255,255,0.06), rgba(255,255,255,0.06)),
+    var(--surface-bg);
   backdrop-filter: blur(4px);
   border: 1px solid var(--border-color);
   box-shadow: 0 10px 30px rgba(0,0,0,0.18);
@@ -68,15 +69,6 @@
   max-height: min(60vh, 360px);
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-}
-
-.block-lang-menu::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  background: rgba(255,255,255,0.06);
-  pointer-events: none;
 }
 
 .block-lang-option {
@@ -123,13 +115,11 @@ html[data-theme="dark"] .block-lang-summary {
 }
 
 html[data-theme="dark"] .block-lang-menu {
-  background: var(--surface-bg);
+  background:
+    linear-gradient(rgba(255,255,255,0.025), rgba(255,255,255,0.025)),
+    var(--surface-bg);
   border-color: var(--border-color);
   box-shadow: var(--box-shadow);
-}
-
-html[data-theme="dark"] .block-lang-menu::before {
-  background: rgba(255,255,255,0.025);
 }
 
 html[data-theme="dark"] .block-lang-option.is-active {

--- a/public/css/ui-lang-switcher.css
+++ b/public/css/ui-lang-switcher.css
@@ -45,8 +45,9 @@
   margin: 0;
   padding: 0.5rem;
   list-style: none;
-  background: var(--primary-bg);
-  opacity: 0.98;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.06)),
+    var(--primary-bg);
   backdrop-filter: blur(4px);
   border: 1px solid var(--border-color);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
@@ -57,15 +58,6 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.35rem;
   min-width: 240px;
-}
-
-.ui-lang-menu::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
-  pointer-events: none;
 }
 
 .ui-lang-menu {


### PR DESCRIPTION
## Summary

- Move the language picker tint from an absolutely positioned pseudo-element onto the scroll container background
- Apply the same fix to the block language picker, which used the same scrollable menu pattern
- Preserve the existing translucent panel styling while preventing the background from ending at the initially visible area

## Testing

- Ran `npm run build` with Node 24 via `nvm`