### PR TITLE
Overhaul Support page with Stripe-backed funding groundwork

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ import usePeersAPI from './server/api/v1/peers.js';
 import useReactionsAPI from './server/api/v1/reactions.js';
 import useRoomAPI from './server/api/v1/rooms.js';
 import useSearchAPI from './server/api/v1/search.js';
+import useStripeAPI from './server/api/v1/stripe.js';
 import useUserAPI from './server/api/v1/users.js';
 import useVoteAPI from './server/api/v1/votes.js';
 
@@ -41,6 +42,7 @@ import { initI18n, addI18n } from './server/services/i18n.js'
 import { startJobs } from './server/services/cron.js';
 import * as google from './server/services/google.js';
 import { timeIt } from './server/services/perf.js';
+import { getRecurringSupportMonthlyTotalUsd } from './server/db/supportFundingService.js';
 
 import { renderMarkdownContent } from './server/utils/markdownHelper.js';
 import { titleOnlyMeta } from './server/utils/unfinished.js';
@@ -129,6 +131,7 @@ const ROOM_BASED_CUTOFF = new Date('2024-12-31');
 
     app.use(express.static('public'));
     app.use(express.urlencoded({ extended: true }));
+    useStripeAPI(app);
     app.use(bodyParser.json());
     app.set('views', './views');
     app.set('view engine', 'pug');
@@ -434,12 +437,45 @@ const ROOM_BASED_CUTOFF = new Date('2024-12-31');
       });
     });
 
-    app.get('/support', addI18n(['support']), (_, res) => {
+    app.get('/support', addI18n(['support']), async (_, res) => {
       const { t } = res.locals;
+      const configuredMonthlyGoal = Number.parseFloat(config.supportMonthlyGoalUsd);
+      const monthlyGoal = configuredMonthlyGoal > 0 ? configuredMonthlyGoal : 20;
+      let monthlyRaised = Math.max(0, Number.parseFloat(config.supportMonthlyRaisedUsd) || 0);
+
+      try {
+        const stripeMonthlyRaised = await getRecurringSupportMonthlyTotalUsd();
+        if (typeof stripeMonthlyRaised === 'number') {
+          monthlyRaised = Math.max(0, stripeMonthlyRaised);
+        }
+      } catch (error) {
+        console.error('Failed to load Stripe support funding total:', error);
+      }
+
+      const fundingPercent = Math.min(100, Math.round((monthlyRaised / monthlyGoal) * 100));
+      const fundingMeterValue = Math.min(monthlyRaised, monthlyGoal);
+      const monthlyDonateUrl = config.supportMonthlyDonateUrl || config.supportDonateUrl || null;
+      const oneTimeDonateUrl = config.supportOneTimeDonateUrl || null;
+      const formatUsd = (amount) => {
+        const normalizedAmount = Number.isInteger(amount) ? amount.toFixed(0) : amount.toFixed(2);
+        return `$${normalizedAmount}`;
+      };
 
       res.render('support', {
         title: t('support.meta.title'),
-        description: t('support.meta.description')
+        description: t('support.meta.description'),
+        funding: {
+          monthlyGoal,
+          monthlyRaised,
+          monthlyGoalDisplay: formatUsd(monthlyGoal),
+          monthlyRaisedDisplay: formatUsd(monthlyRaised),
+          meterValue: fundingMeterValue,
+          percent: fundingPercent,
+          monthlyDonateUrl,
+          oneTimeDonateUrl
+        },
+        repoUrl: 'https://github.com/rcalfredson/daily-page',
+        issuesUrl: 'https://github.com/rcalfredson/daily-page/issues'
       })
     });
 

--- a/config/config.js
+++ b/config/config.js
@@ -34,5 +34,16 @@ export const config = {
   // App Config
   port: process.env.PORT || 3000,
   backendUrl: process.env.BACKEND_URL,
-  rateLimitSalt: process.env.RATE_LIMIT_SALT
+  rateLimitSalt: process.env.RATE_LIMIT_SALT,
+
+  // Support page funding display
+  supportMonthlyGoalUsd: process.env.SUPPORT_MONTHLY_GOAL_USD,
+  supportMonthlyRaisedUsd: process.env.SUPPORT_MONTHLY_RAISED_USD,
+  supportDonateUrl: process.env.SUPPORT_DONATE_URL,
+  supportMonthlyDonateUrl: process.env.SUPPORT_MONTHLY_DONATE_URL,
+  supportOneTimeDonateUrl: process.env.SUPPORT_ONE_TIME_DONATE_URL,
+  stripeSupportMonthlyPriceId: process.env.STRIPE_SUPPORT_MONTHLY_PRICE_ID,
+  stripeSupportOneTimePriceId: process.env.STRIPE_SUPPORT_ONE_TIME_PRICE_ID,
+  stripeSecretKey: process.env.STRIPE_SECRET_KEY,
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET
 };

--- a/i18n/en/support.json
+++ b/i18n/en/support.json
@@ -1,34 +1,59 @@
 {
   "support": {
     "meta": {
-      "title": "Daily Page — Support",
-      "description": "How to get in touch, report issues, request features or rooms, and support Daily Page financially."
+      "title": "Daily Page - Support",
+      "description": "Support Daily Page financially, contribute to the open-source project, report issues, get in touch, or request a new room."
+    },
+    "hero": {
+      "eyebrow": "Support Daily Page",
+      "title": "Help keep this little writing space online.",
+      "tagline": "Daily Page is an open-source, indie project. A few steady contributions go a long way toward hosting, email, storage, maintenance, and the quiet work of keeping it useful."
+    },
+    "funding": {
+      "h2": "Monthly Funding Goal",
+      "p1": "The current goal is to raise $20 each month to cover the basic costs of running the site.",
+      "p2": "The progress meter reflects confirmed recurring monthly support. One-time support is welcome too, but the meter tracks the monthly sustainability goal.",
+      "ctaMonthly": "Contribute Monthly",
+      "ctaOneTime": "Give Once",
+      "ctaEmail": "Email Daily Page",
+      "meter": {
+        "label": "Progress this month",
+        "amountSeparator": "raised of",
+        "amountSuffix": "monthly",
+        "note": "Updated as confirmed monthly support changes.",
+        "ariaLabel": "Monthly funding progress: {raised} raised of {goal}, {percent} percent.",
+        "ariaValue": "{raised} raised of {goal}"
+      }
+    },
+    "openSource": {
+      "h2": "Open Source",
+      "p1": "Daily Page is developed in public. You can read the code, report bugs, suggest features, or open a pull request.",
+      "items": {
+        "code": {
+          "label": "Browse the code",
+          "text": "to see how the site works and where it is headed."
+        },
+        "issues": {
+          "label": "Use issues",
+          "text": "for bugs, rough edges, accessibility problems, translation gaps, and feature ideas."
+        },
+        "community": {
+          "label": "Contribute carefully",
+          "text": "with fixes, documentation, translations, design polish, or small improvements that make writing here easier."
+        }
+      },
+      "repoCta": "View Repository",
+      "issuesCta": "Open Issues"
     },
     "contact": {
-      "h1": "★ I would like to pose a question, report a problem, or request a feature.",
-      "p1": {
-        "before": "If you prefer to use GitHub, please check",
-        "link": "this project's issues",
-        "after": "and add your voice. Pull requests are also welcome, of course."
-      },
-      "p2": {
-        "before": "Alternatively,",
-        "link": "send an email",
-        "after": "."
-      }
-    },
-    "contribute": {
-      "h1": "★ I would like to support this project through a contribution.",
-      "p1": {
-        "before": "Thank you in advance for funding this project. Please send payments securely through",
-        "paypal": "PayPal",
-        "middle": "or, if you prefer,",
-        "amazon": "order a few bags of the toys I am selling on Amazon",
-        "after": "."
-      }
+      "h2": "Questions and Feedback",
+      "p1": "For private questions, account help, or anything that does not belong in a public issue, email is still the best route.",
+      "emailCta": "Email Daily Page",
+      "issueCta": "Report an Issue"
     },
     "rooms": {
-      "h1": "★ I would like to request a new room.",
+      "h2": "Request a Room",
+      "p1": "Rooms keep Daily Page organized around shared topics. If there is a writing space you would like to see, send a request here.",
       "form": {
         "nameLabel": "Room Name",
         "topicLabel": "Topic (optional)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "slug": "^4.0.4",
         "sorted-cmp-array": "^2.0.1",
         "strip-bom": "^4.0.0",
+        "stripe": "^22.2.2",
         "uuid": "^14"
       },
       "devDependencies": {
@@ -12099,6 +12100,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.2.tgz",
+      "integrity": "sha512-lRXLiarjW/I2QVa6QuFfz1Ma7Dc2yBQ7vlYH6NEmp5htMJNQGfiWExmOv0McfqY5wMCGV8DLuCvsyVRIPJlUUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "slug": "^4.0.4",
     "sorted-cmp-array": "^2.0.1",
     "strip-bom": "^4.0.0",
+    "stripe": "^22.2.2",
     "uuid": "^14"
   },
   "devDependencies": {

--- a/public/css/support.css
+++ b/public/css/support.css
@@ -1,121 +1,360 @@
-.room-request-container {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-  padding: 30px 20px;
-  background-color: #f9f9f9;
-  /* Keep the container’s background */
-  border: 1px solid transparent;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
-  width: min(100%, 500px);
-  max-width: 500px;
-  margin: 20px 50px;
+.support-container {
+  max-width: 860px;
+  margin: 4rem auto;
+  padding: 0 1rem;
 }
 
-@media (max-width: 768px) {
-  .room-request-container {
-    margin: 20px auto;
-  }
+.support-hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.support-eyebrow {
+  margin: 0 0 0.65rem;
+  color: #1aa7d6;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 0.85rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.page-title {
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 2.5rem;
+  line-height: 1.15;
+  text-align: center;
+  margin: 0 0 0.25em;
+}
+
+.tagline {
+  max-width: 640px;
+  margin: 0 auto;
+  color: #777;
+  font-style: italic;
+}
+
+.support-section {
+  padding: 2rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+  background-color: #f9f9f9;
+}
+
+.support-section.dark {
+  background-color: #f0f4f8;
+}
+
+.support-funding {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(240px, 0.9fr);
+  gap: 2rem;
+  align-items: center;
+}
+
+.section-title {
+  margin: 0 0 1rem;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  color: #1aa7d6;
+  font-family: 'Rubik-Medium', sans-serif;
+}
+
+.support-section p {
+  line-height: 1.55;
+}
+
+.support-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0;
+}
+
+.support-list li {
+  margin-bottom: 0.75rem;
+  line-height: 1.45;
+}
+
+.support-list b {
+  color: #333;
+}
+
+.support-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border-radius: 6px;
+  padding: 0.7rem 1.15rem;
+  border: 1px solid transparent;
+  font-size: 1rem;
+  line-height: 1.2;
+  text-align: center;
+  text-decoration: none;
+  transition: transform 0.15s ease, opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.btn.primary {
+  background-color: #1aa7d6;
+  color: #fff;
+}
+
+.btn.primary::after {
+  content: "->";
+  margin-inline-start: 0.35rem;
+}
+
+.btn.secondary {
+  background-color: transparent;
+  color: #1aa7d6;
+  border-color: #1aa7d6;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  opacity: 0.9;
+}
+
+.funding-meter {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 1.25rem;
+  border: 1px solid rgba(26, 167, 214, 0.22);
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.funding-meter__headline {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 0.85rem;
+}
+
+.funding-meter__label {
+  color: #5f6673;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 0.95rem;
+}
+
+.funding-meter__percent {
+  color: #1aa7d6;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 1.6rem;
+}
+
+.funding-meter__track {
+  position: relative;
+  width: 100%;
+  height: 18px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #dbeaf0;
+}
+
+.funding-meter__fill {
+  min-width: 8px;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #1aa7d6, #efacb8);
+}
+
+.funding-meter__amount {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: baseline;
+  margin: 0.85rem 0 0.25rem;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-style: normal;
+  line-height: 1.35;
+}
+
+.funding-meter__amount strong {
+  color: #333;
+  font-family: 'Rubik-Medium', sans-serif;
+}
+
+.funding-meter__amount span {
+  color: #5f6673;
+  font-family: 'Rubik-Light', sans-serif;
+}
+
+.funding-meter__note {
+  margin: 0;
+  color: #5f6673;
+  font-size: 0.92rem;
+}
+
+.room-request-heading {
+  max-width: 650px;
+}
+
+.room-request-container {
+  box-sizing: border-box;
+  width: min(100%, 560px);
+  margin-top: 1.5rem;
 }
 
 .room-request-form {
   box-sizing: border-box;
   width: 100%;
-  padding: 20px;
-  border-radius: 8px; 
 }
 
 .form-group {
-  margin-bottom: 20px;
-  /* Adds consistent spacing between form elements */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+  margin-bottom: 1.1rem;
 }
 
 .room-request-form label {
-  font-size: 15px;
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0 !important;
+  border-radius: 0;
+  color: #5f6673;
+  background: transparent !important;
+  box-shadow: none;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 0.82rem;
   font-weight: 600;
-  color: #444;
-  background-color: unset;
-  border: unset;
-  margin: unset;
-  padding: unset;
-  float: unset;
-  border-radius: unset;
+  line-height: 1.25;
+  text-transform: uppercase;
+  cursor: default;
+  float: none !important;
 }
 
 .room-request-form input,
 .room-request-form textarea {
   box-sizing: border-box;
   width: 100%;
-  padding: 12px;
-  /* Add more padding for better UX */
-  font-size: 14px;
-  border: 1px solid #ddd;
-  /* Softer border color */
-  border-radius: 4px;
-  transition: border-color 0.3s ease;
-  /* Add focus effect */
-}
-
-.room-request-form input:focus,
-.room-request-form textarea:focus {
-  border-color: #007bff;
-  outline: none;
+  padding: 0.8rem 0.85rem;
+  color: #333;
+  font-size: 1rem;
+  border: 1px solid #d6dce2;
+  border-radius: 6px;
+  background: #fff;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .room-request-form textarea {
   resize: vertical;
 }
 
+.room-request-form input:focus,
+.room-request-form textarea:focus {
+  border-color: #1aa7d6;
+  box-shadow: 0 0 0 3px rgba(26, 167, 214, 0.16);
+  outline: none;
+}
+
 .submit-button {
-  padding: 12px 18px;
-  /* Increase button size */
-  font-size: 16px;
-  background-color: #007bff;
-  color: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  float: unset;
+  margin: unset;
+  padding: 0.75rem 1.25rem;
+  color: #fff;
+  font-size: 1rem;
+  background-color: #1aa7d6;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: transform 0.15s ease, opacity 0.15s ease;
 }
 
 .submit-button:hover {
-  background-color: #0056b3;
+  transform: translateY(-2px);
+  opacity: 0.9;
 }
 
-.room-request-form input:focus-visible,
-.room-request-form textarea:focus-visible,
+.form-feedback {
+  margin-top: 1rem;
+  line-height: 1.4;
+}
+
+.btn:focus-visible,
 .submit-button:focus-visible,
-.info a:focus-visible {
+.room-request-form input:focus-visible,
+.room-request-form textarea:focus-visible {
   outline: 3px solid var(--focus-ring);
   outline-offset: 3px;
 }
 
-html[data-theme="dark"] .info h1 {
+html[data-theme="dark"] .support-eyebrow,
+html[data-theme="dark"] .section-title,
+html[data-theme="dark"] .funding-meter__percent {
   color: var(--link-color);
 }
 
-html[data-theme="dark"] .info a {
-  color: var(--link-color);
-  text-decoration-color: color-mix(in srgb, var(--link-color) 65%, transparent);
+html[data-theme="dark"] .tagline,
+html[data-theme="dark"] .funding-meter__label,
+html[data-theme="dark"] .funding-meter__amount span,
+html[data-theme="dark"] .funding-meter__note {
+  color: var(--muted-text-color);
 }
 
-html[data-theme="dark"] .room-request-container {
+html[data-theme="dark"] .support-section,
+html[data-theme="dark"] .funding-meter {
   color: var(--text-color);
   background: var(--surface-bg);
   border-color: var(--border-color);
   box-shadow: var(--box-shadow);
 }
 
-html[data-theme="dark"] .room-request-form {
-  background: transparent;
+html[data-theme="dark"] .support-section.dark {
+  background: var(--surface-raised-bg);
 }
 
+html[data-theme="dark"] .support-list b,
+html[data-theme="dark"] .funding-meter__amount strong,
 html[data-theme="dark"] .room-request-form label {
   color: var(--text-color);
-  background: transparent;
+}
+
+html[data-theme="dark"] .funding-meter__track {
+  background: color-mix(in srgb, var(--highlight-color) 18%, var(--surface-bg));
+}
+
+html[data-theme="dark"] .funding-meter__fill {
+  background: linear-gradient(90deg, var(--highlight-color), #efacb8);
+}
+
+html[data-theme="dark"] .btn.primary,
+html[data-theme="dark"] .submit-button {
+  color: var(--highlight-contrast);
+  background: var(--highlight-color);
+}
+
+html[data-theme="dark"] .btn.primary:hover,
+html[data-theme="dark"] .submit-button:hover {
+  background: var(--highlight-hover);
+}
+
+html[data-theme="dark"] .btn.secondary {
+  color: var(--link-color);
+  border-color: color-mix(in srgb, var(--highlight-color) 65%, var(--border-color));
+}
+
+html[data-theme="dark"] .btn.secondary:hover {
+  color: var(--text-color);
+  background: color-mix(in srgb, var(--highlight-color) 10%, var(--surface-raised-bg));
 }
 
 html[data-theme="dark"] .room-request-form input,
@@ -128,37 +367,53 @@ html[data-theme="dark"] .room-request-form textarea {
 html[data-theme="dark"] .room-request-form input:focus,
 html[data-theme="dark"] .room-request-form textarea:focus {
   border-color: var(--highlight-color);
-}
-
-html[data-theme="dark"] .submit-button {
-  color: var(--highlight-contrast);
-  background: var(--highlight-color);
-}
-
-html[data-theme="dark"] .submit-button:hover {
-  background: var(--highlight-hover);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 html[data-theme="dark"] .form-feedback {
   color: var(--text-color);
 }
 
-@media (max-width: 600px) {
-  .info h1 {
-    padding-left: 1.15em;
-    font-size: 1.65rem;
-    overflow-wrap: anywhere;
+@media (max-width: 720px) {
+  .support-container {
+    margin: 2rem auto;
+    padding: 0;
   }
 
-  .info p {
-    margin-left: 0;
+  .support-funding {
+    grid-template-columns: 1fr;
   }
 
-  .room-request-container {
+  .page-title {
+    font-size: 2rem;
+  }
+
+  .support-section {
+    padding: 1.25rem;
+  }
+
+  .section-title {
+    font-size: 1.45rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .support-actions {
+    flex-direction: column;
+  }
+
+  .btn,
+  .submit-button {
+    width: 100%;
+  }
+
+  .funding-meter {
     padding: 1rem;
   }
 
-  .room-request-form {
-    padding: 0;
+  .funding-meter__headline {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
   }
 }

--- a/server/api/v1/stripe.js
+++ b/server/api/v1/stripe.js
@@ -1,0 +1,39 @@
+import express, { Router } from 'express';
+import { config } from '../../../config/config.js';
+import {
+  getStripeWebhookClient,
+  processStripeSupportEvent
+} from '../../db/supportFundingService.js';
+
+const router = Router();
+
+const useStripeAPI = (app) => {
+  app.use('/api/v1/stripe', router);
+
+  router.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+    const stripe = getStripeWebhookClient();
+    const signature = req.headers['stripe-signature'];
+
+    if (!stripe || !config.stripeWebhookSecret) {
+      return res.status(503).json({ error: 'Stripe webhook is not configured' });
+    }
+
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(req.body, signature, config.stripeWebhookSecret);
+    } catch (error) {
+      console.error('Stripe webhook signature verification failed:', error.message);
+      return res.status(400).json({ error: 'Invalid Stripe webhook signature' });
+    }
+
+    try {
+      const result = await processStripeSupportEvent(event);
+      return res.status(200).json({ received: true, ...result });
+    } catch (error) {
+      console.error(`Failed to process Stripe webhook ${event.id}:`, error);
+      return res.status(500).json({ error: 'Failed to process Stripe webhook' });
+    }
+  });
+};
+
+export default useStripeAPI;

--- a/server/db/models/StripeWebhookEvent.js
+++ b/server/db/models/StripeWebhookEvent.js
@@ -1,0 +1,5 @@
+import mongoose from 'mongoose';
+import stripeWebhookEventSchema from '../schemas/StripeWebhookEventSchema.js';
+
+export default mongoose.models.StripeWebhookEvent ||
+  mongoose.model('StripeWebhookEvent', stripeWebhookEventSchema);

--- a/server/db/models/SupportSubscription.js
+++ b/server/db/models/SupportSubscription.js
@@ -1,0 +1,5 @@
+import mongoose from 'mongoose';
+import supportSubscriptionSchema from '../schemas/SupportSubscriptionSchema.js';
+
+export default mongoose.models.SupportSubscription ||
+  mongoose.model('SupportSubscription', supportSubscriptionSchema);

--- a/server/db/schemas/StripeWebhookEventSchema.js
+++ b/server/db/schemas/StripeWebhookEventSchema.js
@@ -1,0 +1,17 @@
+import { Schema } from 'mongoose';
+
+const stripeWebhookEventSchema = new Schema(
+  {
+    _id: { type: String, required: true },
+    type: { type: String, required: true },
+    processedAt: { type: Date, default: Date.now },
+  },
+  {
+    strict: true,
+    timestamps: false,
+    toObject: { transform: (doc, ret) => { delete ret.__v; } },
+    toJSON: { transform: (doc, ret) => { delete ret.__v; } },
+  }
+);
+
+export default stripeWebhookEventSchema;

--- a/server/db/schemas/SupportSubscriptionSchema.js
+++ b/server/db/schemas/SupportSubscriptionSchema.js
@@ -1,0 +1,28 @@
+import { Schema } from 'mongoose';
+
+const supportSubscriptionSchema = new Schema(
+  {
+    stripeSubscriptionId: { type: String, required: true, unique: true, index: true },
+    stripeCustomerId: { type: String, default: null, index: true },
+    stripePriceId: { type: String, required: true, index: true },
+    status: { type: String, required: true, index: true },
+    currency: { type: String, default: 'usd' },
+    amountUsdMonthly: { type: Number, required: true, default: 0 },
+    quantity: { type: Number, required: true, default: 1 },
+    cancelAtPeriodEnd: { type: Boolean, default: false },
+    currentPeriodStart: { type: Date, default: null },
+    currentPeriodEnd: { type: Date, default: null },
+    latestInvoiceId: { type: String, default: null },
+    lastStripeEventId: { type: String, default: null },
+  },
+  {
+    strict: true,
+    timestamps: true,
+    toObject: { transform: (doc, ret) => { delete ret.__v; } },
+    toJSON: { transform: (doc, ret) => { delete ret.__v; } },
+  }
+);
+
+supportSubscriptionSchema.index({ stripePriceId: 1, status: 1 });
+
+export default supportSubscriptionSchema;

--- a/server/db/supportFundingService.js
+++ b/server/db/supportFundingService.js
@@ -1,0 +1,177 @@
+import Stripe from 'stripe';
+import { config } from '../../config/config.js';
+import SupportSubscription from './models/SupportSubscription.js';
+import StripeWebhookEvent from './models/StripeWebhookEvent.js';
+
+const ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing'];
+const stripe = config.stripeSecretKey ? new Stripe(config.stripeSecretKey) : null;
+
+function toDateFromSeconds(value) {
+  return value ? new Date(value * 1000) : null;
+}
+
+function objectId(value) {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  return value.id || null;
+}
+
+function getInvoiceSubscriptionId(invoice) {
+  return objectId(invoice?.subscription) ||
+    objectId(invoice?.parent?.subscription_details?.subscription);
+}
+
+function getSubscriptionItem(subscription, monthlyPriceId = config.stripeSupportMonthlyPriceId) {
+  const items = subscription?.items?.data || [];
+  return items.find((item) => item?.price?.id === monthlyPriceId) || null;
+}
+
+function getMonthlyAmountUsd(subscription, item) {
+  if (!item) return 0;
+
+  const unitAmount = item.price?.unit_amount || 0;
+  const quantity = item.quantity || 1;
+  const interval = item.price?.recurring?.interval || 'month';
+  const intervalCount = item.price?.recurring?.interval_count || 1;
+  const amount = (unitAmount * quantity) / 100;
+
+  if (interval === 'year') return amount / (12 * intervalCount);
+  if (interval === 'week') return amount * (52 / 12) / intervalCount;
+  if (interval === 'day') return amount * (365 / 12) / intervalCount;
+  return amount / intervalCount;
+}
+
+async function retrieveSubscription(subscriptionId) {
+  if (!stripe || !subscriptionId) return null;
+
+  return stripe.subscriptions.retrieve(subscriptionId, {
+    expand: ['items.data.price']
+  });
+}
+
+async function upsertSupportSubscription(subscription, eventId = null) {
+  if (!subscription?.id || !config.stripeSupportMonthlyPriceId) return { counted: false };
+
+  const item = getSubscriptionItem(subscription);
+  if (!item) return { counted: false };
+
+  const amountUsdMonthly = getMonthlyAmountUsd(subscription, item);
+
+  await SupportSubscription.findOneAndUpdate(
+    { stripeSubscriptionId: subscription.id },
+    {
+      stripeSubscriptionId: subscription.id,
+      stripeCustomerId: objectId(subscription.customer),
+      stripePriceId: item.price.id,
+      status: subscription.status,
+      currency: item.price?.currency || 'usd',
+      amountUsdMonthly,
+      quantity: item.quantity || 1,
+      cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+      currentPeriodStart: toDateFromSeconds(subscription.current_period_start),
+      currentPeriodEnd: toDateFromSeconds(subscription.current_period_end),
+      latestInvoiceId: objectId(subscription.latest_invoice),
+      lastStripeEventId: eventId,
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  ).exec();
+
+  return { counted: true };
+}
+
+async function removeSupportSubscription(subscriptionId) {
+  if (!subscriptionId) return;
+  await SupportSubscription.findOneAndUpdate(
+    { stripeSubscriptionId: subscriptionId },
+    { status: 'canceled' },
+    { new: true }
+  ).exec();
+}
+
+async function hasProcessedEvent(event) {
+  return Boolean(await StripeWebhookEvent.exists({ _id: event.id }));
+}
+
+async function markEventProcessed(event) {
+  try {
+    await StripeWebhookEvent.create({
+      _id: event.id,
+      type: event.type,
+    });
+    return true;
+  } catch (error) {
+    if (error?.code === 11000) return false;
+    throw error;
+  }
+}
+
+export async function processStripeSupportEvent(event) {
+  if (await hasProcessedEvent(event)) return { duplicate: true };
+
+  const object = event.data?.object;
+  let result;
+
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const subscriptionId = objectId(object?.subscription);
+      if (!subscriptionId) {
+        result = { handled: true, counted: false };
+        break;
+      }
+      const subscription = await retrieveSubscription(subscriptionId);
+      result = await upsertSupportSubscription(subscription, event.id);
+      break;
+    }
+    case 'customer.subscription.created':
+    case 'customer.subscription.updated': {
+      result = await upsertSupportSubscription(object, event.id);
+      break;
+    }
+    case 'customer.subscription.deleted': {
+      await removeSupportSubscription(object?.id);
+      result = { handled: true };
+      break;
+    }
+    case 'invoice.paid':
+    case 'invoice.payment_failed': {
+      const subscriptionId = getInvoiceSubscriptionId(object);
+      if (!subscriptionId) {
+        result = { handled: true, counted: false };
+        break;
+      }
+      const subscription = await retrieveSubscription(subscriptionId);
+      result = await upsertSupportSubscription(subscription, event.id);
+      break;
+    }
+    default:
+      result = { handled: false };
+  }
+
+  await markEventProcessed(event);
+  return result;
+}
+
+export async function getRecurringSupportMonthlyTotalUsd() {
+  if (!config.stripeSupportMonthlyPriceId) return null;
+
+  const rows = await SupportSubscription.aggregate([
+    {
+      $match: {
+        stripePriceId: config.stripeSupportMonthlyPriceId,
+        status: { $in: ACTIVE_SUBSCRIPTION_STATUSES },
+      }
+    },
+    {
+      $group: {
+        _id: null,
+        total: { $sum: '$amountUsdMonthly' },
+      }
+    }
+  ]).exec();
+
+  return rows[0]?.total || 0;
+}
+
+export function getStripeWebhookClient() {
+  return stripe;
+}

--- a/views/support.pug
+++ b/views/support.pug
@@ -1,51 +1,92 @@
 extends layout
+
 block nav
   include navLinks
 
 block append head
-  // (puedes dejarlo tal cual; cambio a /css si quieres más consistencia de rutas)
-  link(rel='stylesheet' href='css/support.css')
+  link(rel="stylesheet" href="/css/support.css")
 
 block scripts
-  script(src='/js/roomRequest.js')
-  
+  script(src="/js/roomRequest.js")
+
 block content
-  .info
-    h1= t('support.contact.h1')
-    p
-      | #{t('support.contact.p1.before')} 
-      a(href="https://github.com/rcalfredson/daily-page/issues" target="_blank")= t('support.contact.p1.link')
-      |  #{t('support.contact.p1.after')}
-    p
-      | #{t('support.contact.p2.before')} 
-      a(href="mailto:ask@dailypage.org")= t('support.contact.p2.link')
-      | #{t('support.contact.p2.after')}
+  .support-container
+    header.support-hero
+      p.support-eyebrow= t('support.hero.eyebrow')
+      h1.page-title= t('support.hero.title')
+      p.tagline= t('support.hero.tagline')
 
-    h1= t('support.contribute.h1')
-    p
-      | #{t('support.contribute.p1.before')} 
-      a(href="https://www.paypal.me/rcAlfredo" target="_blank")= t('support.contribute.p1.paypal')
-      |  #{t('support.contribute.p1.middle')} 
-      s
-        a(href="https://www.amazon.com/dp/B07B4XHVBL" target="_blank")= t('support.contribute.p1.amazon')
-      | #{t('support.contribute.p1.after')}
+    section.support-section.support-funding(aria-labelledby="support-funding-title")
+      .support-section__copy
+        h2#support-funding-title.section-title= t('support.funding.h2')
+        p= t('support.funding.p1')
+        p= t('support.funding.p2')
+        .support-actions
+          if funding.monthlyDonateUrl
+            a.btn.primary(href=funding.monthlyDonateUrl target="_blank" rel="noopener noreferrer")= t('support.funding.ctaMonthly')
+          if funding.oneTimeDonateUrl
+            a.btn.secondary(href=funding.oneTimeDonateUrl target="_blank" rel="noopener noreferrer")= t('support.funding.ctaOneTime')
+          if !funding.monthlyDonateUrl && !funding.oneTimeDonateUrl
+            a.btn.secondary(href="mailto:ask@dailypage.org")= t('support.funding.ctaEmail')
 
-    h1= t('support.rooms.h1')
-    .room-request-container
-      form(id="roomRequestForm" class="room-request-form" enctype="application/x-www-form-urlencoded")
-        .form-group
-          label(for="room-name")= t('support.rooms.form.nameLabel')
-          input#room-name(type="text" name="roomName" required)
-        .form-group
-          label(for="room-topic")= t('support.rooms.form.topicLabel')
-          input#room-topic(type="text" name="roomTopic")
-        .form-group
-          label(for="room-description")= t('support.rooms.form.descriptionLabel')
-          textarea#room-description(name="roomDescription" rows="4" required)
-        button(type="submit" class="submit-button")= t('support.rooms.form.submit')
-      .form-feedback(
-        style="display:none;"
-        data-msg-success=t('support.rooms.form.success')
-        data-msg-error=t('support.rooms.form.errorGeneric')
-        data-msg-unexpected=t('support.rooms.form.errorUnexpected')
-      )= t('support.rooms.form.success')
+      .funding-meter(
+        aria-label=t('support.funding.meter.ariaLabel', {raised: funding.monthlyRaisedDisplay, goal: funding.monthlyGoalDisplay, percent: funding.percent})
+      )
+        .funding-meter__headline
+          span.funding-meter__label= t('support.funding.meter.label')
+          strong.funding-meter__percent #{funding.percent}%
+        .funding-meter__track(role="progressbar" aria-valuemin="0" aria-valuemax=funding.monthlyGoal aria-valuenow=funding.meterValue aria-valuetext=t('support.funding.meter.ariaValue', {raised: funding.monthlyRaisedDisplay, goal: funding.monthlyGoalDisplay}))
+          .funding-meter__fill(style=`width: ${funding.percent}%`)
+        p.funding-meter__amount
+          strong= funding.monthlyRaisedDisplay
+          span= t('support.funding.meter.amountSeparator')
+          strong= funding.monthlyGoalDisplay
+          span= t('support.funding.meter.amountSuffix')
+        p.funding-meter__note= t('support.funding.meter.note')
+
+    section.support-section.dark(aria-labelledby="support-open-source-title")
+      h2#support-open-source-title.section-title= t('support.openSource.h2')
+      p= t('support.openSource.p1')
+      ul.support-list
+        li
+          b= t('support.openSource.items.code.label')
+          |  #{t('support.openSource.items.code.text')}
+        li
+          b= t('support.openSource.items.issues.label')
+          |  #{t('support.openSource.items.issues.text')}
+        li
+          b= t('support.openSource.items.community.label')
+          |  #{t('support.openSource.items.community.text')}
+      .support-actions
+        a.btn.secondary(href=repoUrl target="_blank" rel="noopener noreferrer")= t('support.openSource.repoCta')
+        a.btn.secondary(href=issuesUrl target="_blank" rel="noopener noreferrer")= t('support.openSource.issuesCta')
+
+    section.support-section(aria-labelledby="support-contact-title")
+      h2#support-contact-title.section-title= t('support.contact.h2')
+      p= t('support.contact.p1')
+      .support-actions
+        a.btn.secondary(href="mailto:ask@dailypage.org")= t('support.contact.emailCta')
+        a.btn.secondary(href=issuesUrl target="_blank" rel="noopener noreferrer")= t('support.contact.issueCta')
+
+    section.support-section.dark(aria-labelledby="support-room-title")
+      .room-request-heading
+        h2#support-room-title.section-title= t('support.rooms.h2')
+        p= t('support.rooms.p1')
+      .room-request-container
+        form#roomRequestForm.room-request-form(enctype="application/x-www-form-urlencoded")
+          .form-group
+            label(for="room-name")= t('support.rooms.form.nameLabel')
+            input#room-name(type="text" name="roomName" required autocomplete="off")
+          .form-group
+            label(for="room-topic")= t('support.rooms.form.topicLabel')
+            input#room-topic(type="text" name="roomTopic" autocomplete="off")
+          .form-group
+            label(for="room-description")= t('support.rooms.form.descriptionLabel')
+            textarea#room-description(name="roomDescription" rows="4" required)
+          button.submit-button(type="submit")= t('support.rooms.form.submit')
+        .form-feedback(
+          style="display:none;"
+          data-msg-success=t('support.rooms.form.success')
+          data-msg-error=t('support.rooms.form.errorGeneric')
+          data-msg-unexpected=t('support.rooms.form.errorUnexpected')
+        )= t('support.rooms.form.success')


### PR DESCRIPTION
## Summary

- Redesign the Support page to better match the newer About page style
- Add a monthly funding goal meter for the initial $20/month site support target
- Add primary monthly and secondary one-time Stripe support CTAs
- Make GitHub repository and issue links clearer in the Open Source section
- Keep the room request form on the Support page with updated responsive styling
- Add config/env support for Stripe payment links, price IDs, and webhook secrets
- Add Stripe webhook endpoint and persistence model for recurring support subscriptions
- Wire the funding meter to use Stripe-backed recurring subscription totals when available, with env fallback

## Stripe Config Vars

Required for payment links:

```bash
SUPPORT_MONTHLY_GOAL_USD=20
SUPPORT_MONTHLY_DONATE_URL=https://buy.stripe.com/00wdR2e2Rbqc9yAdPI9Zm01
SUPPORT_ONE_TIME_DONATE_URL=https://buy.stripe.com/5kQ6oAcYN3XK3acbHA9Zm00
STRIPE_SUPPORT_MONTHLY_PRICE_ID=price_1TjVrs2QnuPvR6eOQgmy4pFu
STRIPE_SUPPORT_ONE_TIME_PRICE_ID=price_1TjVrt2QnuPvR6eOKX5gZEna
```

Required once the live webhook is created:

```bash
STRIPE_SECRET_KEY=sk_live_...
STRIPE_WEBHOOK_SECRET=whsec_...
```

## Testing

- Parsed `i18n/en/support.json`
- Rendered Support page with and without configured payment links
- Verified i18n fallback keys for all supported UI languages
- Imported new Stripe webhook modules successfully
- Ran targeted ESLint on new Stripe/config/model files
- Ran `git diff --check`

Note: full repo lint still has pre-existing unrelated `app.js` archive-route lint errors.
