### PR TITLE
Support multiple recurring donation price levels

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -5,6 +5,13 @@ if (process.env.NODE_ENV !== 'production') {
   dotenv.config();
 }
 
+function parseCsv(value) {
+  return (value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export const config = {
   // MongoDB Config
   mongoDbAddr: process.env.MONGO_DB_ADDR,
@@ -43,6 +50,7 @@ export const config = {
   supportMonthlyDonateUrl: process.env.SUPPORT_MONTHLY_DONATE_URL,
   supportOneTimeDonateUrl: process.env.SUPPORT_ONE_TIME_DONATE_URL,
   stripeSupportMonthlyPriceId: process.env.STRIPE_SUPPORT_MONTHLY_PRICE_ID,
+  stripeSupportMonthlyPriceIds: parseCsv(process.env.STRIPE_SUPPORT_MONTHLY_PRICE_IDS || process.env.STRIPE_SUPPORT_MONTHLY_PRICE_ID),
   stripeSupportOneTimePriceId: process.env.STRIPE_SUPPORT_ONE_TIME_PRICE_ID,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY,
   stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET

--- a/server/db/supportFundingService.js
+++ b/server/db/supportFundingService.js
@@ -21,9 +21,14 @@ function getInvoiceSubscriptionId(invoice) {
     objectId(invoice?.parent?.subscription_details?.subscription);
 }
 
-function getSubscriptionItem(subscription, monthlyPriceId = config.stripeSupportMonthlyPriceId) {
+function getSupportMonthlyPriceIds() {
+  return config.stripeSupportMonthlyPriceIds || [];
+}
+
+function getSubscriptionItem(subscription, monthlyPriceIds = getSupportMonthlyPriceIds()) {
   const items = subscription?.items?.data || [];
-  return items.find((item) => item?.price?.id === monthlyPriceId) || null;
+  const eligiblePriceIds = new Set(monthlyPriceIds);
+  return items.find((item) => eligiblePriceIds.has(item?.price?.id)) || null;
 }
 
 function getMonthlyAmountUsd(subscription, item) {
@@ -50,7 +55,7 @@ async function retrieveSubscription(subscriptionId) {
 }
 
 async function upsertSupportSubscription(subscription, eventId = null) {
-  if (!subscription?.id || !config.stripeSupportMonthlyPriceId) return { counted: false };
+  if (!subscription?.id || getSupportMonthlyPriceIds().length === 0) return { counted: false };
 
   const item = getSubscriptionItem(subscription);
   if (!item) return { counted: false };
@@ -152,12 +157,13 @@ export async function processStripeSupportEvent(event) {
 }
 
 export async function getRecurringSupportMonthlyTotalUsd() {
-  if (!config.stripeSupportMonthlyPriceId) return null;
+  const monthlyPriceIds = getSupportMonthlyPriceIds();
+  if (monthlyPriceIds.length === 0) return null;
 
   const rows = await SupportSubscription.aggregate([
     {
       $match: {
-        stripePriceId: config.stripeSupportMonthlyPriceId,
+        stripePriceId: { $in: monthlyPriceIds },
         status: { $in: ACTIVE_SUBSCRIPTION_STATUSES },
       }
     },


### PR DESCRIPTION
## Summary

- Add support for `STRIPE_SUPPORT_MONTHLY_PRICE_IDS` as a comma-separated list of recurring Stripe price IDs
- Keep backward compatibility with the existing `STRIPE_SUPPORT_MONTHLY_PRICE_ID`
- Count subscriptions matching any configured recurring support price
- Aggregate the monthly funding total across all configured recurring price IDs

## Configuration

For multiple recurring donation levels, set:

```bash
STRIPE_SUPPORT_MONTHLY_PRICE_IDS=price_...,price_...,price_...