### PR TITLE
Add multiple monthly contribution options

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,6 +110,10 @@ async function getSupportFundingViewModel() {
   const fundingPercent = Math.min(100, Math.round((monthlyRaised / monthlyGoal) * 100));
   const fundingMeterValue = Math.min(monthlyRaised, monthlyGoal);
   const monthlyDonateUrl = config.supportMonthlyDonateUrl || config.supportDonateUrl || null;
+  const monthlyDonateOptions = (config.supportMonthlyDonateOptions || []).map((option) => ({
+    ...option,
+    amountDisplay: formatUsd(option.amount),
+  }));
   const oneTimeDonateUrl = config.supportOneTimeDonateUrl || null;
 
   return {
@@ -120,6 +124,7 @@ async function getSupportFundingViewModel() {
     meterValue: fundingMeterValue,
     percent: fundingPercent,
     monthlyDonateUrl,
+    monthlyDonateOptions,
     oneTimeDonateUrl,
   };
 }

--- a/config/config.js
+++ b/config/config.js
@@ -12,6 +12,48 @@ function parseCsv(value) {
     .filter(Boolean);
 }
 
+function parseMonthlyDonateOptions(value) {
+  const optionsByAmount = new Map();
+
+  for (const [index, entry] of (value || '').split(',').entries()) {
+    const normalizedEntry = entry.trim();
+    if (!normalizedEntry) continue;
+
+    const separatorIndex = normalizedEntry.indexOf('=');
+    if (separatorIndex <= 0) {
+      console.warn(`Ignoring invalid SUPPORT_MONTHLY_DONATE_OPTIONS entry ${index + 1}: expected amount=url.`);
+      continue;
+    }
+
+    const amount = Number(normalizedEntry.slice(0, separatorIndex).trim());
+    const urlValue = normalizedEntry.slice(separatorIndex + 1).trim();
+    let donateUrl;
+
+    try {
+      donateUrl = new URL(urlValue);
+    } catch {
+      console.warn(`Ignoring invalid SUPPORT_MONTHLY_DONATE_OPTIONS entry ${index + 1}: invalid URL.`);
+      continue;
+    }
+
+    if (!Number.isFinite(amount) || amount <= 0 || donateUrl.protocol !== 'https:') {
+      console.warn(`Ignoring invalid SUPPORT_MONTHLY_DONATE_OPTIONS entry ${index + 1}: use a positive amount and HTTPS URL.`);
+      continue;
+    }
+
+    if (optionsByAmount.has(amount)) {
+      console.warn(`Duplicate SUPPORT_MONTHLY_DONATE_OPTIONS amount ${amount}; using the last entry.`);
+    }
+
+    optionsByAmount.set(amount, {
+      amount,
+      url: donateUrl.toString(),
+    });
+  }
+
+  return [...optionsByAmount.values()].sort((a, b) => a.amount - b.amount);
+}
+
 export const config = {
   // MongoDB Config
   mongoDbAddr: process.env.MONGO_DB_ADDR,
@@ -48,6 +90,7 @@ export const config = {
   supportMonthlyRaisedUsd: process.env.SUPPORT_MONTHLY_RAISED_USD,
   supportDonateUrl: process.env.SUPPORT_DONATE_URL,
   supportMonthlyDonateUrl: process.env.SUPPORT_MONTHLY_DONATE_URL,
+  supportMonthlyDonateOptions: parseMonthlyDonateOptions(process.env.SUPPORT_MONTHLY_DONATE_OPTIONS),
   supportOneTimeDonateUrl: process.env.SUPPORT_ONE_TIME_DONATE_URL,
   stripeSupportMonthlyPriceId: process.env.STRIPE_SUPPORT_MONTHLY_PRICE_ID,
   stripeSupportMonthlyPriceIds: parseCsv(process.env.STRIPE_SUPPORT_MONTHLY_PRICE_IDS || process.env.STRIPE_SUPPORT_MONTHLY_PRICE_ID),

--- a/i18n/ar/support.json
+++ b/i18n/ar/support.json
@@ -23,7 +23,9 @@
         "note": "يتم التحديث عندما يتغير الدعم الشهري المؤكد.",
         "ariaLabel": "تقدم التمويل الشهري: {raised} تم جمعها من {goal}، {percent} بالمئة.",
         "ariaValue": "{raised} تم جمعها من {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "اختر مبلغا شهريا",
+      "monthlyOptionAriaLabel": "ساهم بمبلغ {amount} شهريا"
     },
     "openSource": {
       "h2": "مفتوح المصدر",

--- a/i18n/da/support.json
+++ b/i18n/da/support.json
@@ -23,7 +23,9 @@
         "note": "Opdateres når bekræftet månedlig support ændrer sig.",
         "ariaLabel": "Månedlig finansieringsfremdrift: {raised} indsamlet af {goal}, {percent} procent.",
         "ariaValue": "{raised} indsamlet af {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Vælg et månedligt beløb",
+      "monthlyOptionAriaLabel": "Bidrag med {amount} om måneden"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/de/support.json
+++ b/i18n/de/support.json
@@ -23,7 +23,9 @@
         "note": "Wird aktualisiert, wenn sich die bestätigte monatliche Unterstützung ändert.",
         "ariaLabel": "Monatlicher Finanzierungsfortschritt: {raised} gesammelt von {goal}, {percent} Prozent.",
         "ariaValue": "{raised} gesammelt von {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Monatlichen Betrag auswählen",
+      "monthlyOptionAriaLabel": "Monatlich {amount} beitragen"
     },
     "openSource": {
       "h2": "Open Source",

--- a/i18n/en/support.json
+++ b/i18n/en/support.json
@@ -23,7 +23,9 @@
         "note": "Updated as confirmed monthly support changes.",
         "ariaLabel": "Monthly funding progress: {raised} raised of {goal}, {percent} percent.",
         "ariaValue": "{raised} raised of {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Choose a monthly amount",
+      "monthlyOptionAriaLabel": "Contribute {amount} monthly"
     },
     "openSource": {
       "h2": "Open Source",

--- a/i18n/es/support.json
+++ b/i18n/es/support.json
@@ -23,7 +23,9 @@
         "note": "Se actualiza cuando cambia el apoyo mensual confirmado.",
         "ariaLabel": "Progreso de financiación mensual: {raised} recaudados de {goal}, {percent} por ciento.",
         "ariaValue": "{raised} recaudados de {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Elige una cantidad mensual",
+      "monthlyOptionAriaLabel": "Contribuir {amount} al mes"
     },
     "openSource": {
       "h2": "Código abierto",

--- a/i18n/fi/support.json
+++ b/i18n/fi/support.json
@@ -23,7 +23,9 @@
         "note": "Päivitetään, kun vahvistettu kuukausituki muuttuu.",
         "ariaLabel": "Kuukausirahoituksen edistyminen: {raised} kerätty tavoitteesta {goal}, {percent} prosenttia.",
         "ariaValue": "{raised} kerätty tavoitteesta {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Valitse kuukausittainen summa",
+      "monthlyOptionAriaLabel": "Tue kuukausittain summalla {amount}"
     },
     "openSource": {
       "h2": "Avoin lähdekoodi",

--- a/i18n/fr/support.json
+++ b/i18n/fr/support.json
@@ -23,7 +23,9 @@
         "note": "Mis à jour lorsque le soutien mensuel confirmé change.",
         "ariaLabel": "Progression du financement mensuel : {raised} réunis sur {goal}, {percent} pour cent.",
         "ariaValue": "{raised} réunis sur {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Choisir un montant mensuel",
+      "monthlyOptionAriaLabel": "Contribuer {amount} par mois"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/hi/support.json
+++ b/i18n/hi/support.json
@@ -23,7 +23,9 @@
         "note": "पुष्टि किए गए मासिक समर्थन में बदलाव होने पर अपडेट होता है.",
         "ariaLabel": "मासिक फंडिंग प्रगति: {goal} में से {raised} जुटाए गए, {percent} प्रतिशत.",
         "ariaValue": "{goal} में से {raised} जुटाए गए"
-      }
+      },
+      "monthlyOptionsLabel": "मासिक राशि चुनें",
+      "monthlyOptionAriaLabel": "हर महीने {amount} का योगदान दें"
     },
     "openSource": {
       "h2": "ओपन सोर्स",

--- a/i18n/id/support.json
+++ b/i18n/id/support.json
@@ -23,7 +23,9 @@
         "note": "Diperbarui saat dukungan bulanan yang dikonfirmasi berubah.",
         "ariaLabel": "Progres pendanaan bulanan: {raised} terkumpul dari {goal}, {percent} persen.",
         "ariaValue": "{raised} terkumpul dari {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Pilih jumlah bulanan",
+      "monthlyOptionAriaLabel": "Berkontribusi {amount} per bulan"
     },
     "openSource": {
       "h2": "Sumber Terbuka",

--- a/i18n/it/support.json
+++ b/i18n/it/support.json
@@ -23,7 +23,9 @@
         "note": "Aggiornato quando cambia il sostegno mensile confermato.",
         "ariaLabel": "Avanzamento finanziamento mensile: {raised} raccolti su {goal}, {percent} per cento.",
         "ariaValue": "{raised} raccolti su {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Scegli un importo mensile",
+      "monthlyOptionAriaLabel": "Contribuisci {amount} al mese"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/ja/support.json
+++ b/i18n/ja/support.json
@@ -23,7 +23,9 @@
         "note": "確認済みの月間支援が変わると更新されます。",
         "ariaLabel": "月間支援の進捗: {goal} のうち {raised}、{percent} パーセント。",
         "ariaValue": "{goal} のうち {raised}"
-      }
+      },
+      "monthlyOptionsLabel": "月額を選択",
+      "monthlyOptionAriaLabel": "毎月{amount}を支援する"
     },
     "openSource": {
       "h2": "オープンソース",

--- a/i18n/ko/support.json
+++ b/i18n/ko/support.json
@@ -23,7 +23,9 @@
         "note": "확인된 월간 후원이 변경되면 업데이트됩니다.",
         "ariaLabel": "월간 후원 진행 상황: {goal} 중 {raised}, {percent} 퍼센트.",
         "ariaValue": "{goal} 중 {raised}"
-      }
+      },
+      "monthlyOptionsLabel": "월간 금액 선택",
+      "monthlyOptionAriaLabel": "매월 {amount} 후원하기"
     },
     "openSource": {
       "h2": "오픈 소스",

--- a/i18n/nl/support.json
+++ b/i18n/nl/support.json
@@ -23,7 +23,9 @@
         "note": "Bijgewerkt wanneer bevestigde maandelijkse steun verandert.",
         "ariaLabel": "Maandelijkse financieringsvoortgang: {raised} opgehaald van {goal}, {percent} procent.",
         "ariaValue": "{raised} opgehaald van {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Kies een maandelijks bedrag",
+      "monthlyOptionAriaLabel": "Draag maandelijks {amount} bij"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/no/support.json
+++ b/i18n/no/support.json
@@ -23,7 +23,9 @@
         "note": "Oppdateres når bekreftet månedlig støtte endres.",
         "ariaLabel": "Månedlig finansieringsfremdrift: {raised} samlet inn av {goal}, {percent} prosent.",
         "ariaValue": "{raised} samlet inn av {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Velg et månedlig beløp",
+      "monthlyOptionAriaLabel": "Bidra med {amount} per måned"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/pl/support.json
+++ b/i18n/pl/support.json
@@ -23,7 +23,9 @@
         "note": "Aktualizowane, gdy zmienia się potwierdzone wsparcie miesięczne.",
         "ariaLabel": "Postęp miesięcznego finansowania: {raised} zebrano z {goal}, {percent} procent.",
         "ariaValue": "{raised} zebrano z {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Wybierz miesięczną kwotę",
+      "monthlyOptionAriaLabel": "Wpłacaj {amount} miesięcznie"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/pt/support.json
+++ b/i18n/pt/support.json
@@ -23,7 +23,9 @@
         "note": "Atualizado quando o apoio mensal confirmado muda.",
         "ariaLabel": "Progresso do financiamento mensal: {raised} arrecadados de {goal}, {percent} por cento.",
         "ariaValue": "{raised} arrecadados de {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Escolha um valor mensal",
+      "monthlyOptionAriaLabel": "Contribuir com {amount} por mês"
     },
     "openSource": {
       "h2": "Código aberto",

--- a/i18n/ru/support.json
+++ b/i18n/ru/support.json
@@ -23,7 +23,9 @@
         "note": "Обновляется при изменении подтвержденной ежемесячной поддержки.",
         "ariaLabel": "Прогресс ежемесячного финансирования: {raised} собрано из {goal}, {percent} процентов.",
         "ariaValue": "{raised} собрано из {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Выберите ежемесячную сумму",
+      "monthlyOptionAriaLabel": "Поддерживать на {amount} в месяц"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/sv/support.json
+++ b/i18n/sv/support.json
@@ -23,7 +23,9 @@
         "note": "Uppdateras när bekräftat månatligt stöd ändras.",
         "ariaLabel": "Månatlig finansieringsframgång: {raised} insamlat av {goal}, {percent} procent.",
         "ariaValue": "{raised} insamlat av {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "Välj ett månadsbelopp",
+      "monthlyOptionAriaLabel": "Bidra med {amount} per månad"
     },
     "openSource": {
       "h2": "Open source",

--- a/i18n/tr/support.json
+++ b/i18n/tr/support.json
@@ -23,7 +23,9 @@
         "note": "Onaylanmış aylık destek değiştikçe güncellenir.",
         "ariaLabel": "Aylık fonlama ilerlemesi: {goal} hedefinden {raised} toplandı, yüzde {percent}.",
         "ariaValue": "{goal} hedefinden {raised} toplandı"
-      }
+      },
+      "monthlyOptionsLabel": "Aylık bir tutar seçin",
+      "monthlyOptionAriaLabel": "Aylık {amount} katkıda bulun"
     },
     "openSource": {
       "h2": "Açık Kaynak",

--- a/i18n/zh/support.json
+++ b/i18n/zh/support.json
@@ -23,7 +23,9 @@
         "note": "会在已确认的月度支持发生变化时更新。",
         "ariaLabel": "月度筹款进度：已筹集 {raised}，目标 {goal}，{percent}%。",
         "ariaValue": "已筹集 {raised}，目标 {goal}"
-      }
+      },
+      "monthlyOptionsLabel": "选择每月金额",
+      "monthlyOptionAriaLabel": "每月支持 {amount}"
     },
     "openSource": {
       "h2": "开源",

--- a/public/css/support.css
+++ b/public/css/support.css
@@ -86,6 +86,34 @@
   margin-top: 1.25rem;
 }
 
+.monthly-support-options {
+  flex: 1 0 100%;
+  min-width: 0;
+}
+
+.monthly-support-options__label {
+  margin: 0 0 0.5rem;
+  color: #5f6673;
+  font-family: 'Rubik-Medium', sans-serif;
+  font-size: 0.9rem;
+}
+
+.monthly-support-options__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.monthly-support-option {
+  min-width: 64px;
+  min-height: 40px;
+  padding: 0.55rem 0.8rem;
+}
+
+.btn.primary.monthly-support-option::after {
+  content: none;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -306,7 +334,8 @@ html[data-theme="dark"] .funding-meter__percent {
 html[data-theme="dark"] .tagline,
 html[data-theme="dark"] .funding-meter__label,
 html[data-theme="dark"] .funding-meter__amount span,
-html[data-theme="dark"] .funding-meter__note {
+html[data-theme="dark"] .funding-meter__note,
+html[data-theme="dark"] .monthly-support-options__label {
   color: var(--muted-text-color);
 }
 
@@ -400,6 +429,11 @@ html[data-theme="dark"] .form-feedback {
 @media (max-width: 380px) {
   .support-actions {
     flex-direction: column;
+  }
+
+  .monthly-support-options__links {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .btn,

--- a/views/support.pug
+++ b/views/support.pug
@@ -22,11 +22,22 @@ block content
         p= t('support.funding.p1')
         p= t('support.funding.p2')
         .support-actions
-          if funding.monthlyDonateUrl
+          if funding.monthlyDonateOptions && funding.monthlyDonateOptions.length
+            .monthly-support-options
+              p.monthly-support-options__label= t('support.funding.monthlyOptionsLabel')
+              .monthly-support-options__links
+                each option in funding.monthlyDonateOptions
+                  a.btn.primary.monthly-support-option(
+                    href=option.url
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label=t('support.funding.monthlyOptionAriaLabel', {amount: option.amountDisplay})
+                  )= option.amountDisplay
+          else if funding.monthlyDonateUrl
             a.btn.primary(href=funding.monthlyDonateUrl target="_blank" rel="noopener noreferrer")= t('support.funding.ctaMonthly')
           if funding.oneTimeDonateUrl
             a.btn.secondary(href=funding.oneTimeDonateUrl target="_blank" rel="noopener noreferrer")= t('support.funding.ctaOneTime')
-          if !funding.monthlyDonateUrl && !funding.oneTimeDonateUrl
+          if (!funding.monthlyDonateOptions || !funding.monthlyDonateOptions.length) && !funding.monthlyDonateUrl && !funding.oneTimeDonateUrl
             a.btn.secondary(href="mailto:ask@dailypage.org")= t('support.funding.ctaEmail')
 
       .funding-meter(


### PR DESCRIPTION
## Summary

- Add `SUPPORT_MONTHLY_DONATE_OPTIONS` for configurable monthly contribution links
- Parse comma-separated `amount=url` pairs with validation, deduplication, and sorting
- Display compact monthly amount choices on the Support page
- Fall back to `SUPPORT_MONTHLY_DONATE_URL` when no valid options are configured
- Preserve the existing one-time contribution option
- Add localized labels across all onboarded languages
- Support responsive two-column choices on narrow viewports

## Configuration

```bash
SUPPORT_MONTHLY_DONATE_OPTIONS=2=https://buy.stripe.com/...,5=https://buy.stripe.com/...,10=https://buy.stripe.com/...,20=https://buy.stripe.com/...
```

Each entry must contain a positive amount and an HTTPS URL.

## Testing

- Tested the configured payment options locally
- Verified option sorting and URLs containing additional `=` characters
- Verified fallback behavior without configured options
- Validated all 20 Support locale files against the English key shape
- Compiled `views/support.pug`
- Ran targeted ESLint
- Ran `node --check app.js`
- Ran `git diff --check`
