### PR TITLE
Add full Czech UI support

### DIFF
--- a/i18n/cs/about.json
+++ b/i18n/cs/about.json
@@ -1,0 +1,37 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — O nás",
+      "description": "Co je Daily Page, jak funguje a proč vznikl jako pomalejší a laskavější kout internetu."
+    },
+    "title": "O Daily Page",
+    "tagline": "Nakrmte svou mysl, ne svůj kanál.",
+    "mission": {
+      "h2": "Poslání",
+      "p1": "Nezávislá laboratoř psaní — začala v mém obýváku a pohání ji zvědavost čtenářů.",
+      "p2": "Nevznikla proto, aby vám kazila mozek, ale aby ho živila: je to místo, kde můžete psát pomalu, chcete-li anonymně, a nemusíte si dělat starosti s tím, zda na někoho zapůsobíte."
+    },
+    "how": {
+      "h2": "Jak to funguje",
+      "features": {
+        "rooms": { "label": "Místnosti", "text": "jsou tematické prostory (představte si „přívětivější subreddit“)." },
+        "blocks": { "label": "Příspěvky", "text": "jsou prostory pro společné psaní — kdokoli (i „anonym“) je může vytvořit, upravovat do uzamčení a hlasovat o ostatních." },
+        "privacy": { "label": "Soukromí a sdílení", "text": "znamená, že veřejné příspěvky jsou ve feedu místnosti. Neveřejné koncepty zůstávají do uzamčení skryté, ale dostanete odkaz ke sdílení s přáteli." },
+        "markdown": { "label": "Markdown a média", "text": "vám umožňují psát v markdownu, vkládat obrázky a spolupracovat jako v Dokumentech Google." },
+        "trends": { "label": "Trendy a štítky", "text": "vám umožní označovat příspěvky, sledovat trendy štítků a objevovat nejlepší obsah (7 dní / 30 dní / od začátku)." },
+        "streaks": { "label": "Série", "text": "udržují vaši každodenní sérii psaní — nejlepší motivaci přijít každý den." }
+      }
+    },
+    "origin": {
+      "h2": "Jak jsme se sem dostali",
+      "p1": "V roce 2018 jsem vytvořil wiki založenou na datech pro „dnešní stránku“ a sledoval, jak z ní několik přemýšlivých autorů udělalo prostor pro své myšlenky. Nikdy se příliš nerozrostla — ale zasela semínko.",
+      "p2": "Přeskočme do současnosti: z tohoto semínka vyrostl Daily Page s mnoha místnostmi — klidná sociální síť pro introverty, idealisty a všechny, kdo touží po pomalejším tempu."
+    },
+    "next": {
+      "h2": "Co bude dál",
+      "p1": "Teprve začínáme: bohatší vkládání obsahu, podrobnější statistiky uživatelů, žebříčky reputace a více způsobů, jak odměnit promyšlenou tvorbu.",
+      "p2": "Děkujeme, že jste součástí tohoto malého nezávislého experimentu."
+    },
+    "cta": { "rooms": "Prozkoumat místnosti", "signup": "Připojit se ke komunitě" }
+  }
+}

--- a/i18n/cs/accountSecurity.json
+++ b/i18n/cs/accountSecurity.json
@@ -1,0 +1,38 @@
+{
+  "accountSecurity": {
+    "meta": { "title": "Zabezpečení účtu", "description": "Spravujte heslo a dvoufázové ověření svého účtu Daily Page." },
+    "backToDashboard": "Zpět na přehled",
+    "heading": "Zabezpečení účtu",
+    "subheading": "Chraňte svůj účet silným heslem a ověřovací aplikací.",
+    "password": {
+      "title": "Změnit heslo", "description": "Použijte jedinečné heslo o délce alespoň 8 znaků.",
+      "current": { "label": "Současné heslo" }, "new": { "label": "Nové heslo" }, "submit": "Aktualizovat heslo"
+    },
+    "twoFactor": {
+      "title": "Dvoufázové ověření", "statusOn": "Zapnuto", "statusOff": "Vypnuto",
+      "description": "Při přihlášení po zadání hesla přidejte jednorázový kód z ověřovací aplikace.",
+      "currentPassword": { "label": "Současné heslo" }, "startSetup": "Nastavit ověřovací aplikaci",
+      "qrAlt": "QR kód ověřovací aplikace", "manualKey": "Klíč pro ruční nastavení",
+      "code": { "label": "Šestimístný kód" }, "enable": "Zapnout 2FA",
+      "disableCode": { "label": "Ověřovací kód" }, "disable": "Vypnout 2FA"
+    },
+    "recoveryCodes": {
+      "title": "Uložte si obnovovací kódy",
+      "description": "Pokud ztratíte přístup k ověřovací aplikaci, přihlaste se jedním z těchto jednorázových kódů.",
+      "regenerateDescription": "Pokud jste předchozí sadu ztratili, vygenerujte novou. Všechny staré obnovovací kódy tím přestanou platit.",
+      "regenerate": "Vygenerovat nové obnovovací kódy", "warning": "Uložte je na bezpečné místo. Znovu se již nezobrazí."
+    },
+    "feedback": {
+      "passwordChanged": "Vaše heslo bylo aktualizováno.",
+      "setupReady": "Naskenujte QR kód a poté dokončete nastavení zadáním šestimístného kódu.",
+      "twoFactorEnabled": "Dvoufázové ověření je nyní zapnuto.", "twoFactorDisabled": "Dvoufázové ověření je nyní vypnuto.",
+      "recoveryCodesRegenerated": "Obnovovací kódy byly vygenerovány znovu. Nové kódy si nyní uložte.",
+      "missingFields": "Vyplňte všechna povinná pole.", "missingCurrentPassword": "Pro pokračování zadejte současné heslo.",
+      "passwordTooShort": "Nové heslo musí mít alespoň 8 znaků.", "invalidCurrentPassword": "Současné heslo nesouhlasí.",
+      "missingCode": "Zadejte šestimístný kód z ověřovací aplikace.", "invalidCode": "Tento kód nefungoval. Zkuste to znovu.",
+      "noPendingSetup": "Než zadáte kód, spusťte nastavení znovu.", "setupExpired": "Platnost této relace nastavení vypršela. Spusťte nastavení znovu a získejte nový QR kód.",
+      "twoFactorNotEnabled": "Dvoufázové ověření není pro tento účet zapnuto.",
+      "genericError": "Něco se pokazilo. Zkuste to prosím znovu.", "unexpectedError": "Došlo k neočekávané chybě. Zkuste to prosím znovu."
+    }
+  }
+}

--- a/i18n/cs/anonymousUser.json
+++ b/i18n/cs/anonymousUser.json
@@ -1,0 +1,9 @@
+{
+  "anonymousUser": {
+    "meta": { "title": "Anonymní poutník", "description": "Žádný profil. Žádná minulost. Jen atmosféra." },
+    "ascii": { "ariaLabel": "ASCII obrázek rozmarného tvora s citátem" },
+    "header": { "title": "Anonym" },
+    "body": { "line1": "Zabloudili jste do prázdna. Tady není nic k vidění —", "line2": "jen bloudící duch bez příběhu." },
+    "buttons": { "home": "← Zpět domů", "signup": "Vytvořit si identitu" }
+  }
+}

--- a/i18n/cs/archive.json
+++ b/i18n/cs/archive.json
@@ -1,0 +1,37 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Archiv", "description": "Prozkoumejte celý archiv podle měsíců.",
+      "titleRoom": "Daily Page — Archiv · {roomName}",
+      "descriptionRoom": "Procházejte starší texty v místnosti {roomName} měsíc po měsíci. Vyberte libovolné datum a podívejte se, co zde ostatní v průběhu času sdíleli."
+    },
+    "nav": { "prev": "Předchozí", "next": "Další" },
+    "title": "📚 Procházet archivy", "titleRoom": "📚 {roomName} — Archivy",
+    "roomViewing": "Prohlížíte archiv místnosti {roomName}", "viewRoomLink": "Zobrazit místnost",
+    "noContent": "Zatím není k dispozici žádný obsah.", "backToRoom": "← Zpět na přehled místnosti",
+    "calendar": {
+      "meta": {
+        "description": "Prohlédněte si všechny tvůrčí příspěvky publikované v období {month} {year} — od krátkých myšlenek po hluboké úvahy. Kliknutím na datum zjistíte, co bylo sdíleno.",
+        "descriptionRoom": "Prohlédněte si tvůrčí aktivitu v místnosti {roomName} v období {month} {year}. Vyberte datum a prozkoumejte příspěvky sdílené v daný den."
+      },
+      "title": "📆 Archiv pro {month} {year}", "prevLabel": "Archiv pro {month} {year}", "nextLabel": "Archiv pro {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Archiv pro {date}", "titleRoom": "{roomName} — Archiv pro {date}",
+        "descriptionSite": "Prozkoumejte příspěvky napsané dne {date} — od tichých poznámek po divoká přiznání.",
+        "descriptionRoom": "Dne {date} zanechali autoři v místnosti {roomName} svou stopu — projděte si úvahy, nápady a vyjádření, které toho dne sdíleli."
+      },
+      "heading": "Archiv pro {date}", "empty": "Pro toto datum nebyl nalezen žádný obsah.",
+      "labels": { "createdBy": "Vytvořil(a):", "in": "v", "on": "dne {datetime}", "unknownRoom": "Neznámá místnost" },
+      "nav": { "prevDay": "Předchozí den", "nextDay": "Další den" }
+    },
+    "index": {
+      "meta": { "titleRoom": "{roomName} — Všechny příspěvky", "descriptionRoom": "Procházejte všechny příspěvky, které kdy byly publikovány v místnosti {roomName}. Seřaďte je podle data, názvu nebo hlasů a prozkoumejte její historii." },
+      "header": { "allBlocks": "— Všechny příspěvky" },
+      "sort": { "label": "Seřadit podle", "options": { "date": "Data", "title": "Názvu", "votes": "Hlasů" }, "submit": "Použít" }
+    },
+    "pagination": { "prev": "← Předchozí", "next": "Další →" },
+    "yearMonth": { "meta": { "title": "Stránky Daily Page pro {time}" }, "empty": "V tomto období jsme žádné stránky nenašli." }
+  }
+}

--- a/i18n/cs/auth.json
+++ b/i18n/cs/auth.json
@@ -1,0 +1,19 @@
+{
+  "auth": { "login": {
+    "meta": { "title": "Daily Page — Přihlášení", "description": "Přihlaste se ke svému účtu Daily Page a pokračujte ve své cestě psaním." },
+    "heading": "Vítejte zpět!", "subheading": "Přihlaste se ke svému účtu a pokračujte ve sdílení každodenního psaní.",
+    "fields": {
+      "usernameOrEmail": { "label": "Uživatelské jméno nebo e-mail", "placeholder": "Zadejte uživatelské jméno nebo e-mail" },
+      "password": { "label": "Heslo", "placeholder": "Zadejte heslo" },
+      "totpCode": { "label": "Ověřovací nebo obnovovací kód", "placeholder": "Zadejte kód" }
+    },
+    "actions": { "submit": "Přihlásit se" },
+    "feedback": {
+      "success": "Přihlášení proběhlo úspěšně! Přesměrováváme…",
+      "twoFactorRequired": "Zadejte šestimístný kód z ověřovací aplikace nebo použijte obnovovací kód.",
+      "twoFactorFailed": "Tento kód nefungoval. Zkuste to znovu.", "failedGeneric": "Přihlášení se nezdařilo. Zkuste to znovu.",
+      "unexpected": "Došlo k neočekávané chybě. Zkuste to prosím znovu."
+    },
+    "links": { "forgotPassword": "Zapomněli jste heslo?", "noAccount": "Ještě nemáte účet?", "signupHere": "Zaregistrujte se zde!" }
+  }}
+}

--- a/i18n/cs/bestOf.json
+++ b/i18n/cs/bestOf.json
@@ -1,0 +1,13 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "To nejlepší z Daily Page",
+      "description": "Nejoblíbenější příspěvky na Daily Page — vtipné, upřímné, poetické nebo prostě podivné. Podívejte se, co vyniklo za poslední den, týden, měsíc i déle.",
+      "titleRoom": "To nejlepší z {roomName}",
+      "descriptionRoom": "Objevte výjimečné příspěvky z místnosti {roomName} — ty, které si čtenáři nejvíce oblíbili za posledních 24 hodin, 7 dní, 30 dní a za celou dobu."
+    },
+    "heading": "🏆 To nejlepší z Daily Page", "headingRoomPrefix": "🏆 To nejlepší z ", "headingRoomSuffix": "",
+    "tabs": { "24h": "🔥 24 hodin", "7d": "🚀 7 dní", "30d": "🌕 30 dní", "all": "👑 Za celou dobu" },
+    "labels": { "createdBy": "Vytvořil(a):", "inRoom": "v", "onDate": "dne {date}", "unknownRoom": "Neznámá místnost", "noBlocks": "Nebyly nalezeny žádné příspěvky.", "viewRoom": "Zobrazit místnost" }
+  }
+}

--- a/i18n/cs/blockCommon.json
+++ b/i18n/cs/blockCommon.json
@@ -1,0 +1,7 @@
+{
+  "blockCommon": {
+    "badges": { "draft": "Koncept" },
+    "deleteModal": { "title": "Smazat příspěvek?", "message": "Tuto akci nelze vrátit zpět.", "confirm": "Smazat", "cancel": "Zrušit", "closeAriaLabel": "Zavřít" },
+    "toasts": { "deleteSuccess": "Příspěvek byl úspěšně smazán!", "deleteFailed": "Příspěvek se nepodařilo smazat." }
+  }
+}

--- a/i18n/cs/blockEditor.json
+++ b/i18n/cs/blockEditor.json
@@ -1,0 +1,25 @@
+{
+  "blockEditor": {
+    "labels": { "you": "(Vy)" },
+    "meta": { "title": "Upravit příspěvek – {blockTitle}", "titleFallback": "Upravit příspěvek" },
+    "errors": { "imageUrlRequired": "Zadejte adresu URL obrázku.", "notFound": "Příspěvek nebyl nalezen nebo nepatří do této místnosti.", "loadFailed": "Při načítání editoru příspěvku došlo k chybě.", "updateTitleFailed": "Chyba při aktualizaci názvu." },
+    "roomInfo": { "label": "Místnost:" },
+    "title": { "placeholder": "Zadejte název příspěvku", "editTooltip": "Upravit název", "lock": "Uzamknout příspěvek", "delete": "Smazat příspěvek" },
+    "description": { "label": "Popis", "editTooltip": "Upravit popis", "placeholder": "Zadejte popis", "noDescriptionOwner": "Zatím bez popisu…", "noDescriptionViewer": "Nebyl uveden žádný popis…", "save": "Uložit", "cancel": "Zrušit", "expand": "Rozbalit", "collapse": "Sbalit", "updateError": "Chyba při aktualizaci popisu." },
+    "status": { "lastBackup": "Poslední záloha: {datetime}", "lastBackupUnknown": "Poslední záloha: neznámá" },
+    "peers": { "label": "Spolupracovníci:" }, "toasts": { "blockLocked": "Tento příspěvek byl uzamčen!" },
+    "editor": { "placeholder": "Prázdná stránka čeká na váš hlas; pište beze strachu." },
+    "loading": { "label": "Načítání", "quote": "Nechte svět, ať skrze vás hoří. Vrhněte žhavé bílé světlo hranolu na papír.<br>—Ray Bradbury" },
+    "inactiveWarning": { "message": "Pět minut jste nic nenapsali. Kliknutím na OK pokračujte v relaci, jinak budete přesměrováni do archivu.", "confirm": "OK" },
+    "sharing": { "label": "Odkaz ke sdílení", "copyTooltip": "Kopírovat do schránky", "copied": "Zkopírováno!" },
+    "toolbar": { "insertImage": "Vložit obrázek", "insertImageUrlPlaceholder": "Zadejte adresu URL obrázku", "insertImageAltPlaceholder": "Alternativní text (volitelné)", "insertImageConfirm": "Potvrdit", "insertImageCancel": "Zrušit" },
+    "buttons": { "downloadFile": "Stáhnout soubor" },
+    "lockModal": { "messageLine1": "Opravdu chcete tento příspěvek uzamknout?", "messageLine2": "Tím jej dokončíte a zabráníte dalším úpravám.", "confirm": "Uzamknout", "cancel": "Zrušit", "successToast": "Příspěvek byl úspěšně uzamčen.", "errorToast": "Chyba při uzamykání příspěvku." },
+    "tags": { "headerWithTags": "Štítky:", "headerNoTags": "Zatím žádné štítky! Přidejte nějaké:", "updateError": "Chyba při aktualizaci štítků." },
+    "fullBlock": {
+      "headingPrefix": "Litujeme, příspěvek „{blockTitle}“ je nyní", "headingStatus": "zcela obsazen.",
+      "retryPrefix": "Zkuste", "retryLink": "jiný příspěvek", "retrySuffix": "nebo se vraťte později.",
+      "consolationPrefix": "Během čekání si můžete přečíst", "consolationBestOf": "některé z našich oblíbených příspěvků", "consolationMiddle": "nebo procházet", "consolationArchive": "archiv."
+    }
+  }
+}

--- a/i18n/cs/blockList.json
+++ b/i18n/cs/blockList.json
@@ -1,0 +1,6 @@
+{
+  "blockList": {
+    "period": { "all": "za celou dobu", "days": "za posledních {n} dní", "day": "za posledních 24 hodin" },
+    "createdBy": "Vytvořil(a):", "on": "dne"
+  }
+}

--- a/i18n/cs/blockTags.json
+++ b/i18n/cs/blockTags.json
@@ -1,0 +1,7 @@
+{
+  "blockTags": {
+    "header": { "withTags": "Štítky:", "noTags": "Zatím žádné štítky! Přidejte nějaké:" },
+    "input": { "placeholder": "Nový štítek", "addButton": "Přidat" },
+    "buttons": { "removeTag": "x" }
+  }
+}

--- a/i18n/cs/blockView.json
+++ b/i18n/cs/blockView.json
@@ -1,0 +1,54 @@
+{
+  "blockView": {
+    "meta": { "title": "Příspěvek – {blockTitle}", "titleFallback": "Příspěvek" },
+    "labels": {
+      "room": "Místnost", "author": "Autor", "created": "Vytvořeno", "unknownAuthor": "Anonym",
+      "authorAvatarAlt": "Avatar uživatele {username}", "viewAuthorProfile": "Zobrazit profil uživatele {username}",
+      "lang": "Překlady: ", "available": "k dispozici"
+    },
+    "buttons": { "edit": "Upravit", "deleteBlock": "Smazat příspěvek", "share": "Sdílet", "flagContent": "Nahlásit obsah" },
+    "description": { "label": "Popis", "none": "Nebyl uveden žádný popis…", "expand": "Rozbalit", "collapse": "Sbalit" },
+    "editorial": {
+      "heading": "Průvodce čtením", "roleLabel": "Typ čtení", "clusterLabel": "Průvodce", "sequence": "Část {sequence}",
+      "primaryPillarHeading": "Začněte zde", "relatedHeading": "Pokračujte ve čtení", "clusterHeading": "Další v tomto průvodci",
+      "expandSection": "Zobrazit dalších {count}", "collapseSection": "Zobrazit méně",
+      "roleNames": { "pillar": "Hlavní průvodce", "companion": "Podrobný rozbor", "texture": "Souvislosti" }
+    },
+    "comments": {
+      "heading": "Komentáře", "count": "Počet komentářů: {count}",
+      "empty": "Zatím nikdo neodpověděl. Komentáře se zde objeví, až začne konverzace.",
+      "composer": {
+        "label": "Přidat komentář", "placeholder": "Napište komentář…", "submit": "Odeslat komentář", "submitting": "Odesílání…",
+        "success": "Komentář byl odeslán.", "error": "Komentář nyní nelze odeslat.",
+        "loginPrompt": "Přihlaste se a zapojte se do konverzace.", "loginCta": "Přihlásit se a komentovat",
+        "verifyPrompt": "Před odesláním komentáře ověřte svůj e-mail.", "verifyCta": "Ověřit e-mail"
+      },
+      "sort": { "label": "Řazení", "oldestFirst": "Nejstarší první", "newestFirst": "Nejnovější první" },
+      "by": "Od", "unknownAuthor": "Neznámý autor",
+      "reply": {
+        "action": "Odpovědět", "label": "Přidat odpověď", "placeholder": "Napište odpověď…", "submit": "Odeslat odpověď",
+        "submitting": "Odesílání…", "success": "Odpověď byla odeslána.", "error": "Odpověď nyní nelze odeslat.",
+        "cancel": "Zrušit", "loginPrompt": "Chcete-li odpovědět, přihlaste se."
+      },
+      "manage": {
+        "edited": "Upraveno", "editAction": "Upravit", "deleteAction": "Smazat",
+        "deleteConfirm": "Smazat tento komentář? Tím se odstraní i všechny odpovědi pod ním.",
+        "deleteSuccess": "Komentář byl smazán.", "deleteError": "Komentář nyní nelze smazat.",
+        "forbidden": "Spravovat můžete pouze své vlastní komentáře.",
+        "edit": { "label": "Upravit komentář", "save": "Uložit", "saving": "Ukládání…", "cancel": "Zrušit", "success": "Komentář byl aktualizován.", "error": "Komentář nyní nelze aktualizovat." }
+      },
+      "report": {
+        "action": "Nahlásit", "pending": "Nahlašování…", "success": "Komentář byl nahlášen.",
+        "error": "Komentář nyní nelze nahlásit.", "ownError": "Nemůžete nahlásit vlastní komentář.",
+        "hidden": "Komentář byl po nahlášení skryt.", "reported": "Nahlášeno"
+      },
+      "deepLink": { "focused": "Odkazovaný komentář", "unavailable": "Odkazovaný komentář již není k dispozici." },
+      "loadMore": "Načíst další komentáře", "loading": "Načítání…", "loadError": "Další komentáře nyní nelze načíst."
+    },
+    "share": {
+      "title": "Sdílet tento příspěvek", "shareOn": "Sdílet na:", "nativeText": "Podívejte se na tento příspěvek: {title}",
+      "alt": { "facebook": "Logo Facebooku", "reddit": "Logo Redditu", "whatsapp": "Logo WhatsAppu", "twitter": "Logo Twitteru" }
+    },
+    "errors": { "notFound": "Příspěvek nebyl nalezen nebo nepatří do této místnosti.", "loadFailed": "Chyba při načítání příspěvku." }
+  }
+}

--- a/i18n/cs/createBlock.json
+++ b/i18n/cs/createBlock.json
@@ -1,0 +1,25 @@
+{
+  "createBlock": {
+    "meta": { "title": "Vytvořit nový příspěvek — Daily Page", "description": "Začněte nový tvůrčí příspěvek s volitelnými štítky, jazykem a viditelností." },
+    "heading": "Vytvořit nový příspěvek",
+    "roomInfo": { "roomLabel": "Místnost:", "unavailable": "Informace o místnosti nejsou k dispozici.", "noDescription": "Popis není k dispozici." },
+    "form": {
+      "title": { "label": "Název:", "placeholder": { "full": "např. „Moje mistrovské dílo“, „Nejlepší nápad všech dob“, „Clickbait pro nerdy“", "short": "např. „Moje mistrovské dílo“" } },
+      "description": { "label": "Popis (volitelné):", "placeholder": "Vysvětlete svůj geniální nápad… nebo prostě improvizujte." },
+      "initialContent": { "label": "Počáteční obsah (volitelné):", "help": "Začněte psát zde nebo stiskněte „Vytvořit“ a pokračujte v plném editoru, kde můžete vkládat obrázky a spolupracovat v reálném čase.", "placeholder": "Začněte psát příspěvek zde nebo po vytvoření pokračujte v úpravách…" },
+      "visibility": { "label": "Viditelnost:" }, "submit": "Vytvořit příspěvek"
+    },
+    "visibility": {
+      "public": { "label": "Veřejný", "title": "Kdokoli jej může upravovat v reálném čase. Přihlášení není nutné.", "inline": "Kdokoli jej může upravovat v reálném čase. Přihlášení není nutné." },
+      "unlisted": { "label": "Neveřejný koncept", "title": "Během úprav je skrytý před veřejným procházením. Po uzamčení bude viditelný.", "inline": "Během úprav je skrytý před veřejným procházením. Po uzamčení bude viditelný.", "tooltip": "Neveřejné koncepty jsou během úprav skryté před veřejným procházením. Kdokoli s odkazem může spolupracovat a po uzamčení se příspěvek zveřejní." }
+    },
+    "advanced": {
+      "summary": "Pokročilé možnosti",
+      "lang": { "label": "Jazyk:", "options": {
+        "en": "English", "es": "Español", "fr": "Français", "ru": "Русский", "id": "Bahasa Indonesia", "de": "Deutsch", "it": "Italiano", "pt": "Português", "zh": "中文", "ja": "日本語", "ko": "한국어", "ar": "العربية", "hi": "हिन्दी", "tr": "Türkçe", "nl": "Nederlands", "sv": "Svenska", "no": "Norsk", "da": "Dansk", "fi": "Suomi", "pl": "Polski", "cs": "Čeština", "el": "Ελληνικά", "he": "עברית", "th": "ไทย", "vi": "Tiếng Việt"
+      } },
+      "translate": { "label": "Přeložit existující příspěvek (URL nebo ID):", "placeholder": "Vložte URL nebo ID příspěvku (volitelné)", "invalid": "Toto nevypadá jako platná URL nebo ID příspěvku.", "fetchError": "Informace o příspěvku se nepodařilo načíst." }
+    },
+    "messages": { "langExists": "Překlad do tohoto jazyka již existuje. Vyberte jiný jazyk.", "genericError": "Něco se pokazilo. Zkuste to prosím znovu." }
+  }
+}

--- a/i18n/cs/dashboard.json
+++ b/i18n/cs/dashboard.json
@@ -1,0 +1,13 @@
+{
+  "dashboard": {
+    "meta": { "title": "Přehled", "description": "Váš přehled Daily Page a souhrn účtu." },
+    "profile": { "profilePicAlt": "Profilový obrázek", "noBio": "Zatím nemáte medailonek. Kliknutím na „Upravit“ jej přidejte!", "editBio": "Upravit medailonek", "bioPlaceholder": "Napište sem svůj medailonek", "save": "Uložit", "cancel": "Zrušit" },
+    "activity": { "title": "Nedávná aktivita", "none": "Žádná nedávná aktivita.", "updatedOn": "Aktualizováno {date}", "viewAllBlocks": "Zobrazit všechny příspěvky" },
+    "drafts": { "title": "Pokračovat v psaní", "none": "Žádné otevřené koncepty.", "updatedOn": "Aktualizováno {date}", "unlisted": "Neveřejné", "viewAll": "Zobrazit všechny příspěvky" },
+    "streak": { "title": "Série psaní", "line": "{days} dní v řadě! Jen tak dál!" },
+    "starredRooms": { "title": "Oblíbené místnosti", "none": "Zatím jste žádnou místnost nepřidali do oblíbených. Začněte prozkoumávat a najděte své favority!", "viewAll": "Zobrazit všechny oblíbené místnosti", "unnamedRoom": "Místnost bez názvu" },
+    "security": { "title": "Zabezpečení účtu", "summary": "Změňte heslo a spravujte dvoufázové ověření.", "manage": "Spravovat zabezpečení" },
+    "stats": { "title": "Vaše statistiky", "totalBlocks": "Celkem vytvořených příspěvků", "collaborations": "Spolupráce", "votesGiven": "Odevzdané hlasy", "daysActive": "Aktivní dny", "viewDetailed": "Zobrazit podrobné statistiky 📊" },
+    "alerts": { "uploadFailed": "Profilový obrázek se nepodařilo nahrát. Zkuste to znovu.", "uploadUnexpected": "Došlo k neočekávané chybě. Zkuste to prosím znovu.", "bioUpdateFailed": "Chyba při aktualizaci medailonku. Zkuste to znovu." }
+  }
+}

--- a/i18n/cs/detailedStats.json
+++ b/i18n/cs/detailedStats.json
@@ -1,0 +1,8 @@
+{
+  "detailedStats": {
+    "meta": { "title": "Podrobné statistiky", "description": "Podrobný rozpis vaší aktivity na Daily Page." },
+    "nav": { "backToDashboard": "← Zpět na přehled" }, "header": { "title": "📊 Přehled vašich statistik 📊" },
+    "cards": { "totalBlocks": "Celkem vytvořených příspěvků 📝", "collaborations": "Spolupráce 🤝", "votesGiven": "Odevzdané hlasy 👍", "daysActive": "Aktivní dny 📆" },
+    "chart": { "datasetLabel": "Vaše statistiky", "labels": { "blocksCreated": "Vytvořené příspěvky", "collaborations": "Spolupráce", "votesGiven": "Odevzdané hlasy", "daysActive": "Aktivní dny" } }
+  }
+}

--- a/i18n/cs/errors.json
+++ b/i18n/cs/errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "generic": { "title": "Jejda! Něco se pokazilo.", "message": "Došlo k neočekávané chybě. Zkuste to prosím později.", "home": "Zpět domů" },
+    "notFound": { "title": "404 – Stránka nenalezena", "metaTitle": "Stránka nenalezena", "message": "Litujeme, hledanou stránku se nepodařilo najít.", "homePrefix": "Můžete se vrátit na", "homeLink": "domovskou stránku", "roomsPrefix": "nebo navštívit", "roomsLink": "seznam místností." }
+  }
+}

--- a/i18n/cs/flagModal.json
+++ b/i18n/cs/flagModal.json
@@ -1,0 +1,11 @@
+{
+  "flagModal": {
+    "title": "Nahlásit nevhodný obsah",
+    "fields": {
+      "reason": { "label": "Důvod", "options": { "spam": "Spam", "offensive": "Urážlivý obsah (nenávistné výrazy nebo nadávky)", "inappropriate": "Nevhodný obsah (nahota, drastický obsah apod.)", "other": "Jiné" } },
+      "details": { "label": "Podrobnosti (volitelné)", "placeholder": "Popište, co jste viděli…" }
+    },
+    "buttons": { "submit": "Odeslat hlášení", "cancel": "Zrušit" },
+    "toasts": { "success": "Hlášení bylo odesláno — děkujeme!", "failed": "Hlášení se nepodařilo odeslat." }
+  }
+}

--- a/i18n/cs/forgotPassword.json
+++ b/i18n/cs/forgotPassword.json
@@ -1,0 +1,9 @@
+{
+  "forgotPassword": {
+    "meta": { "title": "Obnovit heslo", "description": "Vyžádejte si odkaz pro obnovení účtu Daily Page." },
+    "header": { "title": "Zapomněli jste heslo?", "subtitle": "Zadejte svůj e-mail a my vám pošleme odkaz pro obnovení." },
+    "form": { "email": { "label": "E-mailová adresa", "placeholder": "Zadejte svůj e-mail" }, "submit": "Vyžádat obnovení hesla" },
+    "feedback": { "successGeneric": "Pokud tento e-mail existuje, byl na něj odeslán odkaz pro obnovení.", "missingEmail": "E-mail je povinný.", "genericError": "Něco se pokazilo. Zkuste to prosím znovu.", "unexpectedError": "Došlo k neočekávané chybě. Zkuste to prosím znovu." },
+    "email": { "subject": "Obnovte své heslo k Daily Page", "heading": "Žádost o obnovení hesla", "headingWithName": "Žádost o obnovení hesla, {username}", "body": "Kliknutím na odkaz níže obnovíte své heslo.", "cta": "Obnovit moje heslo", "expires": "Platnost tohoto odkazu vyprší za {hours} hod.", "ignore": "Pokud jste o obnovení hesla nežádali, můžete tento e-mail bezpečně ignorovat." }
+  }
+}

--- a/i18n/cs/home.json
+++ b/i18n/cs/home.json
@@ -1,0 +1,20 @@
+{
+  "home": {
+    "meta": { "title": "Daily Page – Oblíbené příspěvky za posledních 24 hodin", "description": "Daily Page je minimalistický nezávislý web pro psaní, kde může kdokoli zveřejňovat tvůrčí myšlenky, vzpomínky či experimenty — jeden příspěvek po druhém. Objevujte nové nápady, připojte se k místnostem a přidejte svůj hlas." },
+    "hero": { "eyebrow": "Klidné místo pro psaní, čtení a návraty", "title": "Vítejte na Daily Page!", "subtitle": "Prozkoumejte nejoblíbenější příspěvky za posledních 24 hodin.", "ctaPrefix": "Máte inspiraci?", "cta": "Připojte se k místnosti", "ctaSuffix": "a vytvořte vlastní příspěvek!" },
+    "stats": { "blocks": "Příspěvky", "rooms": "Místnosti", "tags": "Štítky", "collabsToday": "Dnešní spolupráce" },
+    "activity": {
+      "title": "Živě na Daily Page", "subtitle": "Nové konverzace a reakce na jednom místě.", "fallbackActor": "Někdo", "inRoom": "v",
+      "comments": { "title": "Nedávné komentáře", "more": "Hledat v diskusích", "commentVerb": "okomentoval(a)", "replyVerb": "odpověděl(a) u", "empty": "Zatím žádné nedávné komentáře. Další konverzace může začít u vašeho příspěvku." },
+      "reactions": { "title": "Nedávné reakce", "more": "Procházet oblíbené příspěvky", "empty": "Zatím žádné nedávné reakce. Dobrý příspěvek to může rychle změnit.", "types": { "heart": "dal(a) srdce", "leaf": "reagoval(a) lístkem na", "wow": "reagoval(a) úžasem na", "laugh": "zasmál(a) se u" } }
+    },
+    "featured": { "roomRibbon": "★ Doporučená místnost", "roomInfoDays": "Aktivita za posledních {days} dní: {blocks} příspěvků, {votes} hlasů.", "roomInfo24h": "Aktivita za posledních 24 hodin: {blocks} příspěvků, {votes} hlasů.", "checkItOut": "Podívat se", "blockRibbon": "★ Doporučený příspěvek", "votes": "Počet hlasů: {n}", "noContent": "(Nebyl uveden žádný obsah…)", "viewBlock": "Zobrazit příspěvek" },
+    "trendingTags": { "title": "Populární štítky", "suffixDays": "(posledních {days} dní)", "suffixAllTime": "(za celou dobu)", "blocks": "Počet příspěvků: {n}", "votes": "Počet hlasů: {n}", "empty": "Zatím žádné populární štítky. Buďte první, kdo označí něco skvělého!" },
+    "trendingBlocks": { "title": "Populární příspěvky", "suffixDays": "(posledních {days} dní)", "createdBy": "Vytvořil(a):", "in": "v", "on": "dne", "unknownRoom": "Neznámá místnost", "empty24h": "Za posledních 24 hodin zatím žádné příspěvky. Brzy se vraťte!" },
+    "supportWidget": {
+      "eyebrow": "Podpora webu", "title": "Měsíční podpora udržuje Daily Page online.", "text": "Každý pravidelný příspěvek pomáhá pokrýt základní náklady Daily Page.", "cta": "Podpořit web",
+      "ariaLabel": "Průběh měsíční podpory: přislíbeno {raised} z {goal}, {percent} procent.", "ariaValue": "přislíbeno {raised} z {goal}", "amountSeparator": "z", "amountSuffix": "měsíčně",
+      "goalReached": { "title": "Cíl podpory pro tento měsíc je splněn.", "text": "Děkujeme! Další podpora pomáhá Daily Page zvládnout budoucí náklady a vylepšení.", "meterLabel": "Cíl splněn", "ariaLabel": "Cíl měsíční podpory splněn: přislíbeno {raised} oproti cíli {goal}.", "ariaValue": "Cíl splněn, přislíbeno {raised} oproti {goal}" }
+    }
+  }
+}

--- a/i18n/cs/layout.json
+++ b/i18n/cs/layout.json
@@ -1,0 +1,11 @@
+{
+  "layout": {
+    "siteName": "Daily Page", "welcomeUser": "Vítejte!", "logout": "Odhlásit se", "login": "Přihlášení / Registrace",
+    "language": "Jazyk", "openMenu": "Otevřít hlavní nabídku", "closeMenu": "Zavřít hlavní nabídku", "privacy": "Zásady ochrany osobních údajů",
+    "uiFallbackNotice": "Jazyk {requested} zatím není přeložen. Prozatím zobrazujeme jazyk {current}.",
+    "copyButton": { "copy": "Kopírovat", "copied": "Zkopírováno!" }, "copyright": "© {year}",
+    "languages": { "en": "English", "es": "Español", "fr": "Français", "ru": "Русский", "id": "Bahasa Indonesia", "de": "Deutsch", "it": "Italiano", "pt": "Português", "zh": "中文", "ja": "日本語", "ko": "한국어", "ar": "العربية", "hi": "हिन्दी", "tr": "Türkçe", "nl": "Nederlands", "sv": "Svenska", "no": "Norsk", "da": "Dansk", "fi": "Suomi", "pl": "Polski", "cs": "Čeština", "el": "Ελληνικά", "he": "עברית", "th": "ไทย", "vi": "Tiếng Việt" },
+    "theme": { "label": "Motiv", "toggleToDark": "Přepnout do tmavého režimu", "toggleToLight": "Přepnout do světlého režimu" },
+    "blockImages": { "preview": "Náhled obrázku", "close": "Zavřít náhled obrázku", "open": "Otevřít náhled obrázku" }
+  }
+}

--- a/i18n/cs/modals.json
+++ b/i18n/cs/modals.json
@@ -1,0 +1,7 @@
+{
+  "modals": {
+    "login": { "title": "Přihlaste se", "message": "Chcete-li pokračovat, musíte být přihlášeni.", "messageWithAction": "Chcete-li {action}, musíte být přihlášeni.", "cta": "Přihlásit se" },
+    "actions": { "voteOnBlock": "hlasovat o příspěvku", "starRoom": "přidat tuto místnost do oblíbených", "reactToBlock": "reagovat na tento příspěvek", "commentOnBlock": "komentovat tento příspěvek", "reportComment": "nahlásit tento komentář" },
+    "errors": { "starToggleFail": "Stav oblíbené položky se nepodařilo aktualizovat. Zkuste to znovu." }
+  }
+}

--- a/i18n/cs/nav.json
+++ b/i18n/cs/nav.json
@@ -1,0 +1,6 @@
+{
+  "nav": {
+    "home": "Domů", "rooms": "Místnosti", "tags": "Štítky", "archive": "Archiv", "search": "Hledat", "bestOf": "To nejlepší", "about": "O nás", "support": "Podpora", "otherProjects": "Další projekty",
+    "auth": { "welcomePrefix": "Vítejte, ", "welcomeFallbackUser": "uživateli", "welcomeSuffix": "!" }, "dashboard": "Přehled"
+  }
+}

--- a/i18n/cs/notifications.json
+++ b/i18n/cs/notifications.json
@@ -1,0 +1,12 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Oznámení", "openMenu": "Otevřít oznámení", "loading": "Načítání oznámení…", "error": "Oznámení nyní nelze načíst.", "empty": "Zatím žádná oznámení.", "markRead": "Označit jako přečtené", "fallbackActor": "Někdo", "fallbackBlockTitle": "váš příspěvek",
+      "item": { "blockComment": "{actorUsername} okomentoval(a) váš příspěvek „{blockTitle}“.", "commentReply": "{actorUsername} odpověděl(a) na váš komentář u „{blockTitle}“.", "unknown": "Oznámení" }
+    },
+    "email": {
+      "blockComment": { "subject": "Nový komentář u „{blockTitle}“", "heading": "Nový komentář u vašeho příspěvku", "headingWithName": "Dobrý den, {username},", "body": "<strong>{actorUsername}</strong> okomentoval(a) váš příspěvek <strong>{blockTitle}</strong>.", "cta": "Zobrazit konverzaci na Daily Page", "fallbackActor": "Někdo", "fallbackBlockTitle": "váš příspěvek" },
+      "commentReply": { "subject": "Nová odpověď u „{blockTitle}“", "heading": "Nová odpověď na váš komentář", "headingWithName": "Dobrý den, {username},", "body": "<strong>{actorUsername}</strong> odpověděl(a) na váš komentář u <strong>{blockTitle}</strong>.", "cta": "Zobrazit konverzaci na Daily Page", "fallbackActor": "Někdo", "fallbackBlockTitle": "váš příspěvek" }
+    }
+  }
+}

--- a/i18n/cs/privacy.json
+++ b/i18n/cs/privacy.json
@@ -1,0 +1,14 @@
+{
+  "privacy": {
+    "meta": { "title": "Daily Page — Zásady ochrany osobních údajů", "description": "Jak Daily Page shromažďuje, používá a chrání vaše údaje, srozumitelně vysvětleno." },
+    "title": "Zásady ochrany osobních údajů", "lastUpdated": "Poslední aktualizace: {date}",
+    "intro": { "h2": "Úvod", "p1": "Daily Page („my“, „nás“ nebo „náš“) provozuje web dailypage.org (dále jen „Služba“).", "p2": "Tato stránka vás informuje o našich zásadách shromažďování, používání a zveřejňování osobních údajů při používání naší Služby." },
+    "collection": { "h2": "Shromažďování a používání informací", "p": "Shromažďujeme minimum osobních údajů potřebných ke zlepšování a poskytování naší Služby. Patří sem e-mailové adresy pro správu účtů a obsah dobrovolně poskytnutý uživateli." },
+    "usage": { "h2": "Používání údajů", "p": "Shromážděné údaje se používají výhradně k ověřování účtů, moderování obsahu a zlepšování uživatelského prostředí." },
+    "storage": { "h2": "Ukládání a zabezpečení údajů", "p": "Vaše údaje jsou bezpečně uloženy a bez výslovného souhlasu je nikdy nesdílíme ani neprodáváme třetím stranám, s výjimkou případů vyžadovaných zákonem." },
+    "cookies": { "h2": "Cookies", "p": "Cookies používáme pouze ke správě relací a zlepšování uživatelského prostředí. Cookies můžete zakázat v nastavení prohlížeče." },
+    "rights": { "h2": "Vaše práva", "p": "Kdykoli nás můžete kontaktovat a požádat o smazání nebo úpravu svých osobních údajů." },
+    "changes": { "h2": "Změny těchto zásad ochrany osobních údajů", "p": "Tyto zásady můžeme čas od času aktualizovat. Změny budou zveřejněny na této stránce." },
+    "contact": { "h2": "Kontaktujte nás", "p": "S dotazy k těmto zásadám ochrany osobních údajů nás kontaktujte na adrese:", "emailLabel": "ask@dailypage.org" }
+  }
+}

--- a/i18n/cs/profile.json
+++ b/i18n/cs/profile.json
@@ -1,0 +1,9 @@
+{
+  "profile": {
+    "meta": { "titleUser": "Profil uživatele {username}", "descriptionUser": "Prohlédněte si nedávnou aktivitu, oblíbené místnosti a statistiky uživatele {username}." },
+    "profile": { "profilePicAlt": "Profilový obrázek", "noBio": "(Medailonek není k dispozici.)" },
+    "activity": { "title": "Nedávná aktivita", "updatedOn": "Aktualizováno {date}", "none": "Žádná nedávná aktivita.", "viewAllBlocks": "Zobrazit všechny příspěvky" },
+    "starredRooms": { "title": "Oblíbené místnosti", "none": "Zatím žádné oblíbené místnosti.", "unnamedRoom": "Místnost bez názvu" },
+    "stats": { "title": "Statistiky uživatele", "totalBlocks": "Celkem vytvořených příspěvků", "collaborations": "Spolupráce", "daysActive": "Aktivní dny" }
+  }
+}

--- a/i18n/cs/random.json
+++ b/i18n/cs/random.json
@@ -1,0 +1,7 @@
+{
+  "random": {
+    "meta": { "title": "Daily Page — Další projekty", "description": "Objevte baseballový deník, náhodné experimenty s psaním a další vedlejší projekty Daily Page." },
+    "title": "Další projekty", "tagline": "Útulný kout pro experimenty a vedlejší výpravy.",
+    "links": { "baseball": "📖 Baseballový deník", "randomWriter": "🎲 Náhodný spisovatel" }, "cta": { "backToRooms": "Zpět do hlavních místností" }
+  }
+}

--- a/i18n/cs/randomWriter.json
+++ b/i18n/cs/randomWriter.json
@@ -1,0 +1,6 @@
+{
+  "randomWriter": {
+    "meta": { "title": "Daily Page — Náhodný spisovatel", "description": "Generujte nekonečný proud náhodného pseudotextu pro zábavu, inspiraci nebo chaos." },
+    "title": "Náhodný spisovatel", "buttons": { "clear": "Vymazat", "stop": "Přestat psát", "start": "Začít psát" }
+  }
+}

--- a/i18n/cs/reactions.json
+++ b/i18n/cs/reactions.json
@@ -1,0 +1,3 @@
+{
+  "reactions": { "aria": "Reakce {emoji}: {count}", "loginToReact": "Pro reakci se přihlaste", "countsLabel": "Reakce" }
+}

--- a/i18n/cs/readMore.json
+++ b/i18n/cs/readMore.json
@@ -1,0 +1,3 @@
+{
+  "readMore": { "more": "Více…", "aria": "Přečíst celý příspěvek: {title}" }
+}

--- a/i18n/cs/resetPassword.json
+++ b/i18n/cs/resetPassword.json
@@ -1,0 +1,8 @@
+{
+  "resetPassword": {
+    "meta": { "title": "Obnovit heslo", "description": "Nastavte nové heslo ke svému účtu." },
+    "header": { "title": "Obnovit heslo", "subtitle": "Zvolte nové heslo a získejte znovu přístup." },
+    "form": { "newPassword": { "label": "Nové heslo", "placeholder": "Zadejte nové heslo" }, "submit": "Nastavit nové heslo" },
+    "feedback": { "missingToken": "Token chybí nebo je neplatný.", "missingFields": "Token a nové heslo jsou povinné.", "invalidOrExpired": "Token je neplatný nebo jeho platnost vypršela.", "success": "Heslo bylo úspěšně aktualizováno!", "genericError": "Něco se pokazilo. Zkuste to prosím znovu.", "unexpectedError": "Došlo k neočekávané chybě. Zkuste to prosím znovu." }
+  }
+}

--- a/i18n/cs/roomDashboard.json
+++ b/i18n/cs/roomDashboard.json
@@ -1,0 +1,11 @@
+{
+  "roomDashboard": {
+    "meta": { "title": "Daily Page — {roomName}", "description": "Prozkoumejte nedávné a rozpracované příspěvky v místnosti {roomName}." },
+    "links": { "exploreLabel": "Prozkoumat:", "allBlocks": "🗂️ Všechny příspěvky", "browseByDate": "🗓️ Podle data", "bestOf": "🏅 To nejlepší", "searchInRoom": "🔎 Hledat" },
+    "actions": { "createBlock": "Vytvořit příspěvek", "starTitle": "Přidat místnost do oblíbených", "unstarTitle": "Odebrat místnost z oblíbených" },
+    "tabs": { "locked": "Uzamčené příspěvky", "inProgress": "Rozpracované příspěvky" },
+    "sections": { "lockedHeader": "Uzamčené příspěvky", "inProgressHeader": "Rozpracované příspěvky" },
+    "editorial": { "heading": "Doporučení průvodci", "description": "Začněte doporučenými průvodci vybranými pro tuto místnost.", "roleNames": { "pillar": "Hlavní průvodce", "companion": "Průvodce čtením", "texture": "Průvodce souvislostmi" } },
+    "empty": { "noDescription": "Popis není k dispozici.", "noLocked": "Zatím žádné uzamčené příspěvky! Příspěvky se automaticky uzamknou po 1 hodině nečinnosti.", "noInProgress": "Zatím žádné rozpracované příspěvky! Je čas jeden začít.", "noBlocks": "Zatím žádné příspěvky! Vytvořte první a zanechte svou stopu. 😎" }
+  }
+}

--- a/i18n/cs/roomsDirectory.json
+++ b/i18n/cs/roomsDirectory.json
@@ -1,0 +1,12 @@
+{
+  "roomsDirectory": {
+    "meta": { "title": "Seznam místností", "description": "Každá místnost je bránou do jiného světa. Vstupte, sdílejte svůj příběh a přidejte se k ostatním při budování něčeho krásného." },
+    "eyebrow": "Najděte svůj kout", "heading": "Seznam místností",
+    "intro": "Začněte u místností, které právě žijí, nebo procházejte témata, dokud vás něco nezaujme. Každá místnost je jinou výzvou k psaní, fandomem či společnou posedlostí, která čeká na váš hlas.",
+    "empty": "Momentálně nejsou k dispozici žádné místnosti. Vraťte se později!", "jumpToActive": "Zobrazit aktivní místnosti", "jumpToTopics": "Procházet podle tématu",
+    "statsLabel": "Přehled seznamu místností", "liveNow": "Právě živé", "recentlyActive": "Nedávno aktivní", "recentlyActiveSubtitle": "Nejrychlejší způsob, jak najít místnost, ve které jsou právě teď lidé.",
+    "browseByTopic": "Procházet podle tématu", "topicSubtitle": "Otevřete téma a prozkoumejte jeho místnosti.", "roomCount": "Počet místností: {count}",
+    "stats": { "rooms": "místností k prozkoumání", "topics": "tematických skupin", "active": "aktivních tipů" },
+    "activeUsers": "Aktivní uživatelé: {count}", "visitRoom": "Navštívit místnost", "close": "Zavřít", "noTitle": "Název není k dispozici", "noDescription": "Popis není k dispozici"
+  }
+}

--- a/i18n/cs/search.json
+++ b/i18n/cs/search.json
@@ -1,0 +1,7 @@
+{
+  "search": {
+    "meta": { "title": "Hledat", "description": "Hledejte ve veřejných příspěvcích." },
+    "title": "Hledat", "placeholder": "Hledat příspěvky…", "hint": "Pro hledání zadejte alespoň 2 znaky.", "noResults": "Nebyly nalezeny žádné výsledky.", "untitled": "Bez názvu", "votesTitle": "Hlasy", "pageLabel": "Stránka",
+    "filters": { "inRoom": "V místnosti" }, "buttons": { "search": "Hledat", "prev": "Předchozí", "next": "Další" }
+  }
+}

--- a/i18n/cs/signup.json
+++ b/i18n/cs/signup.json
@@ -1,0 +1,10 @@
+{
+  "signup": {
+    "meta": { "title": "Vytvořit účet", "description": "Zaregistrujte se na Daily Page a získejte přístup ke všem funkcím." },
+    "header": { "title": "Vytvořte si účet", "subtitle": "Připojte se k Daily Page a začněte tvořit a sdílet své každodenní psaní!" },
+    "form": {
+      "email": { "label": "E-mail", "placeholder": "Zadejte svůj e-mail" }, "username": { "label": "Uživatelské jméno", "placeholder": "Zadejte uživatelské jméno" }, "password": { "label": "Heslo", "placeholder": "Zadejte heslo" }, "submit": "Zaregistrovat se",
+      "feedback": { "success": "Formulář byl úspěšně odeslán!", "successCreatedVerify": "Účet byl úspěšně vytvořen! Zkontrolujte si e-mail a účet ověřte.", "genericError": "Účet se nepodařilo vytvořit. Zkuste to znovu.", "unexpectedError": "Došlo k neočekávané chybě. Zkuste to prosím znovu." }
+    }
+  }
+}

--- a/i18n/cs/starredRooms.json
+++ b/i18n/cs/starredRooms.json
@@ -1,0 +1,7 @@
+{
+  "starredRooms": {
+    "meta": { "title": "Všechny oblíbené místnosti", "description": "Seznam všech místností, které jste přidali do oblíbených." },
+    "nav": { "backToDashboard": "← Zpět na přehled" }, "header": { "title": "🌟 Všechny vaše oblíbené místnosti 🌟" },
+    "rooms": { "unnamedRoom": "Místnost bez názvu", "noDescription": "Bez popisu." }, "empty": { "message": "Zatím jste žádnou místnost nepřidali do oblíbených!" }
+  }
+}

--- a/i18n/cs/support.json
+++ b/i18n/cs/support.json
@@ -1,0 +1,27 @@
+{
+  "support": {
+    "meta": { "title": "Daily Page – Podpora", "description": "Podpořte Daily Page finančně, přispějte do open-source projektu, nahlaste problémy, kontaktujte nás nebo požádejte o novou místnost." },
+    "hero": { "eyebrow": "Podpořte Daily Page", "title": "Pomozte udržet tento malý prostor pro psaní online.", "tagline": "Daily Page je nezávislý open-source projekt. Několik pravidelných příspěvků výrazně pomáhá s hostingem, e-maily, úložištěm, údržbou a nenápadnou prací, díky níž zůstává užitečný." },
+    "funding": {
+      "h2": "Cíl měsíčního financování", "p1": "Současným cílem je získat každý měsíc 20 USD na pokrytí základních nákladů provozu webu.", "p2": "Ukazatel průběhu odráží potvrzenou pravidelnou měsíční podporu. Vítána je i jednorázová podpora, ukazatel však sleduje cíl měsíční udržitelnosti.",
+      "ctaMonthly": "Přispívat měsíčně", "ctaOneTime": "Přispět jednorázově", "ctaEmail": "Napsat Daily Page",
+      "meter": { "label": "Průběh tohoto měsíce", "amountSeparator": "z cíle", "amountSuffix": "měsíčně", "note": "Aktualizováno podle změn potvrzené měsíční podpory.", "ariaLabel": "Průběh měsíčního financování: vybráno {raised} z {goal}, {percent} procent.", "ariaValue": "vybráno {raised} z {goal}" },
+      "monthlyOptionsLabel": "Vyberte měsíční částku", "monthlyOptionAriaLabel": "Přispívat {amount} měsíčně",
+      "goalReached": { "h2": "Měsíční cíl je pokryt. Děkujeme!", "p1": "Pravidelná podpora nyní pokrývá měsíční základ Daily Page ve výši {goal}.", "p2": "Další podpora je stále vítána a pomáhá vytvářet rezervu na nečekané náklady, údržbu a budoucí vylepšení.", "monthlyOptionsLabel": "Pokračovat v podpoře Daily Page", "ctaMonthly": "Pokračovat v měsíční podpoře", "meterLabel": "Cíl splněn", "meterNote": "Děkujeme, že pomáháte pokrýt měsíční základ.", "meterAriaLabel": "Cíl měsíčního financování splněn: přislíbeno {raised} oproti cíli {goal}.", "meterAriaValue": "Cíl splněn, přislíbeno {raised} oproti {goal}" }
+    },
+    "openSource": {
+      "h2": "Open source", "p1": "Daily Page je vyvíjen veřejně. Můžete si přečíst kód, hlásit chyby, navrhovat funkce nebo otevřít pull request.",
+      "items": {
+        "code": { "label": "Procházet kód", "text": "a podívat se, jak web funguje a kam směřuje." },
+        "issues": { "label": "Použít issues", "text": "pro chyby, nedostatky, problémy s přístupností, mezery v překladech a nápady na nové funkce." },
+        "community": { "label": "Přispívat s rozvahou", "text": "opravami, dokumentací, překlady, vyladěním designu nebo drobnými vylepšeními, která zde usnadní psaní." }
+      },
+      "repoCta": "Zobrazit repozitář", "issuesCta": "Otevřít issues"
+    },
+    "contact": { "h2": "Dotazy a zpětná vazba", "p1": "Pro soukromé dotazy, pomoc s účtem nebo cokoli, co nepatří do veřejného issue, je stále nejlepší e-mail.", "emailCta": "Napsat Daily Page", "issueCta": "Nahlásit problém" },
+    "rooms": {
+      "h2": "Požádat o místnost", "p1": "Místnosti udržují Daily Page uspořádaný podle společných témat. Pokud byste chtěli nový prostor pro psaní, pošlete zde žádost.",
+      "form": { "nameLabel": "Název místnosti", "topicLabel": "Téma (volitelné)", "descriptionLabel": "Popis", "submit": "Odeslat žádost", "success": "Žádost byla úspěšně odeslána!", "errorGeneric": "Žádost se nepodařilo odeslat. Zkuste to znovu.", "errorUnexpected": "Došlo k neočekávané chybě. Zkuste to prosím znovu." }
+    }
+  }
+}

--- a/i18n/cs/tags.json
+++ b/i18n/cs/tags.json
@@ -1,0 +1,16 @@
+{
+  "tags": {
+    "meta": { "title": "Daily Page — Přehled štítků", "description": "Procházejte všechny štítky používané na Daily Page s rychlými filtry podle času." },
+    "title": "Přehled štítků", "intro": "Prozkoumejte všechny štítky používané na Daily Page.", "tagCloudTitle": "Mrak štítků",
+    "timeframe": { "last24h": "Posledních 24 hodin", "last7d": "Posledních 7 dní", "last30d": "Posledních 30 dní", "all": "Za celou dobu" },
+    "error": { "loading": "Chyba při načítání přehledu štítků" },
+    "detail": {
+      "meta": { "titlePrefix": "#", "titleSuffix": " | Daily Page", "description": "Příspěvky se štítkem" },
+      "header": { "label": "Štítek:", "icon": "🏷️" }, "stats": { "totalBlocks": "Celkem příspěvků se štítkem", "totalBlocksTagSeparator": ":" },
+      "blockInfo": { "createdBy": "Vytvořil(a):", "inRoom": "v", "unknownRoom": "Neznámá místnost", "onDate": "dne" },
+      "chart": { "label": "Příspěvky vytvořené v průběhu času" },
+      "empty": { "message": "Zatím nebyly nalezeny žádné příspěvky s tímto štítkem. Co takhle vytvořit první? 🔥" },
+      "error": { "loadingTagPage": "Chyba při načítání stránky štítku" }
+    }
+  }
+}

--- a/i18n/cs/translation.json
+++ b/i18n/cs/translation.json
@@ -1,0 +1,3 @@
+{
+  "translation": { "prefix": "Přeloženo z", "see": "viz", "originalBlock": "původní příspěvek" }
+}

--- a/i18n/cs/userBlocks.json
+++ b/i18n/cs/userBlocks.json
@@ -1,0 +1,7 @@
+{
+  "userBlocks": {
+    "meta": { "title": "Vaše příspěvky", "description": "Procházejte a řaďte všechny příspěvky, které jste vytvořili nebo na kterých jste spolupracovali." },
+    "header": { "dashboardLink": "Váš přehled", "profileLink": "Profil uživatele {username}", "allBlocks": "Všechny příspěvky" },
+    "empty": "Zatím žádné příspěvky.", "pagination": { "prev": "← Předchozí", "next": "Další →" }, "titleUser": "Příspěvky uživatele {username}"
+  }
+}

--- a/i18n/cs/verifyEmail.json
+++ b/i18n/cs/verifyEmail.json
@@ -1,0 +1,8 @@
+{
+  "verifyEmail": {
+    "meta": { "title": "Ověřit e-mail", "description": "Ověřte svou e-mailovou adresu pro Daily Page." },
+    "header": { "title": "Ověřujeme váš e-mail…" },
+    "status": { "checking": "Kontrolujeme token, čekejte prosím…", "missingToken": "Ověřovací token chybí nebo je neplatný.", "genericFailure": "Ověření se nezdařilo.", "unexpectedError": "Došlo k neočekávané chybě.", "success": "Váš účet byl úspěšně ověřen!", "invalidOrExpired": "Ověřovací token je neplatný nebo jeho platnost vypršela." },
+    "verificationMsg": { "subject": "Ověřte svůj účet Daily Page ✨", "heading": "Vítejte na Daily Page, {username}!", "body": "Ověřte svůj e-mail kliknutím níže:", "cta": "Ověřit e-mailovou adresu", "expires": "Platnost tohoto odkazu vyprší za {hours} hod." }
+  }
+}

--- a/i18n/cs/voteControls.json
+++ b/i18n/cs/voteControls.json
@@ -1,0 +1,3 @@
+{
+  "voteControls": { "upvote": "Hlasovat pro", "downvote": "Hlasovat proti", "errors": { "failed": "Váš hlas se nepodařilo uložit." } }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -81,4 +81,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'da' }).catch(console.error), 9_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'fi' }).catch(console.error), 10_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'pl' }).catch(console.error), 10_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'cs' }).catch(console.error), 11_000);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- add complete Czech translations for all 40 English locale files
- register `cs` as a fully translated UI language
- enable Czech hreflang entries, home-cache warming, and notification emails
- preserve existing Czech routing and language-selector support
- leave DB-backed room translations unchanged

## Validation

- verified all locale JSON parses successfully
- verified `i18n/cs` matches `i18n/en` file-for-file and key-for-key
- verified value types and interpolation placeholders match
- passed all 279 specs
- passed ESLint for the changed JavaScript files

## Follow-up

Some broader hard-coded UI and error fallback strings remain outside `i18n/`. They were intentionally left for a separate, focused cleanup.