### PR TITLE
Add full Vietnamese UI support

### DIFF
--- a/i18n/vi/about.json
+++ b/i18n/vi/about.json
@@ -1,0 +1,58 @@
+{
+  "about": {
+    "meta": {
+      "title": "Daily Page — Giới thiệu",
+      "description": "Daily Page là gì, nó hoạt động như thế nào và tại sao nó được xây dựng như một góc chậm hơn, tử tế hơn trên web."
+    },
+    "title": "Giới thiệu về Daily Page",
+    "tagline": "Hãy nuôi dưỡng tâm trí của bạn, không phải thức ăn của bạn.",
+    "mission": {
+      "h2": "Nhiệm vụ",
+      "p1": "Một phòng thí nghiệm viết lách độc lập—bắt đầu từ phòng khách của tôi, được thúc đẩy bởi sự tò mò của độc giả.",
+      "p2": "Nó được xây dựng không phải để làm bộ não bạn mục nát mà để nuôi dưỡng nó: một nơi mà bạn có thể viết chậm rãi, ẩn danh nếu muốn và không bao giờ lo lắng về việc gây ấn tượng với bất kỳ ai."
+    },
+    "how": {
+      "h2": "Nó hoạt động như thế nào",
+      "features": {
+        "rooms": {
+          "label": "Phòng",
+          "text": "là các chủ đề riêng biệt (hãy nghĩ “subreddit, nhưng thân thiện hơn”)."
+        },
+        "blocks": {
+          "label": "bài viết",
+          "text": "là không gian viết lách cộng tác—bất kỳ ai (kể cả “ẩn danh”) đều có thể tạo một không gian, chỉnh sửa nó cho đến khi nó bị khóa và bỏ phiếu cho những người khác."
+        },
+        "privacy": {
+          "label": "Quyền riêng tư và chia sẻ",
+          "text": "có nghĩa là các bài đăng công khai hiển thị trong nguồn cấp dữ liệu của phòng. Các bản nháp không công khai sẽ ẩn cho đến khi bị khóa nhưng bạn sẽ nhận được liên kết chia sẻ để mời bạn bè."
+        },
+        "markdown": {
+          "label": "Đánh dấu & Truyền thông",
+          "text": "cho phép bạn viết bằng markdown, nhúng hình ảnh và đồng chỉnh sửa như trong Google Docs."
+        },
+        "trends": {
+          "label": "Xu hướng & Thẻ",
+          "text": "cho phép bạn gắn thẻ bài đăng của mình, theo dõi xu hướng thẻ và khám phá nội dung hàng đầu (7 ngày / 30 ngày / mọi lúc)."
+        },
+        "streaks": {
+          "label": "Vệt",
+          "text": "duy trì chuỗi bài viết hàng ngày của bạn—động lực tốt nhất để bạn xuất hiện mỗi ngày."
+        }
+      }
+    },
+    "origin": {
+      "h2": "Làm thế nào chúng tôi đến được đây",
+      "p1": "Năm 2018, tôi xây dựng một wiki theo ngày cho “trang hôm nay” và chứng kiến vài người viết hướng nội biến nó thành nơi giãi bày suy nghĩ. Nó chưa bao giờ trở nên lớn mạnh—nhưng đã gieo một hạt giống.",
+      "p2": "Chuyển nhanh đến thời điểm hiện tại và Daily Page là hạt giống đã được trồng thành nhiều phòng—một mạng xã hội yên tĩnh dành cho những người hướng nội, những người theo chủ nghĩa lý tưởng và bất kỳ ai khao khát tốc độ chậm hơn."
+    },
+    "next": {
+      "h2": "Điều gì tiếp theo",
+      "p1": "Chúng tôi chỉ mới bắt đầu: nội dung nhúng phong phú hơn, số liệu thống kê người dùng sâu hơn, bảng xếp hạng danh tiếng và nhiều cách khác để khen thưởng sự sáng tạo chu đáo.",
+      "p2": "Cảm ơn bạn đã tham gia thử nghiệm indie nhỏ này."
+    },
+    "cta": {
+      "rooms": "Khám phá phòng",
+      "signup": "Tham gia cộng đồng"
+    }
+  }
+}

--- a/i18n/vi/accountSecurity.json
+++ b/i18n/vi/accountSecurity.json
@@ -1,0 +1,67 @@
+{
+  "accountSecurity": {
+    "meta": {
+      "title": "Bảo mật tài khoản",
+      "description": "Quản lý mật khẩu Daily Page của bạn và xác thực hai yếu tố."
+    },
+    "backToDashboard": "Quay lại trang tổng quan",
+    "heading": "Bảo mật tài khoản",
+    "subheading": "Giữ tài khoản của bạn được bảo vệ bằng mật khẩu mạnh và ứng dụng xác thực.",
+    "password": {
+      "title": "Thay đổi mật khẩu",
+      "description": "Sử dụng mật khẩu duy nhất có ít nhất 8 ký tự.",
+      "current": {
+        "label": "Mật khẩu hiện tại"
+      },
+      "new": {
+        "label": "Mật khẩu mới"
+      },
+      "submit": "Cập nhật mật khẩu"
+    },
+    "twoFactor": {
+      "title": "Xác thực hai yếu tố",
+      "statusOn": "Đã bật",
+      "statusOff": "Tắt",
+      "description": "Thêm mã một lần từ ứng dụng xác thực sau mật khẩu của bạn khi bạn đăng nhập.",
+      "currentPassword": {
+        "label": "Mật khẩu hiện tại"
+      },
+      "startSetup": "Thiết lập ứng dụng Authenticator",
+      "qrAlt": "Mã QR ứng dụng xác thực",
+      "manualKey": "Phím thiết lập thủ công",
+      "code": {
+        "label": "mã 6 chữ số"
+      },
+      "enable": "Kích hoạt 2FA",
+      "disableCode": {
+        "label": "Mã xác thực"
+      },
+      "disable": "Vô hiệu hóa 2FA"
+    },
+    "recoveryCodes": {
+      "title": "Lưu mã khôi phục của bạn",
+      "description": "Sử dụng một trong các mã một lần này để đăng nhập nếu bạn mất quyền truy cập vào ứng dụng xác thực của mình.",
+      "regenerateDescription": "Tạo bộ mã khôi phục mới nếu bạn làm mất bộ mã trước đó. Điều này làm mất hiệu lực mọi mã khôi phục cũ.",
+      "regenerate": "Tạo mã khôi phục mới",
+      "warning": "Hãy cất giữ chúng ở nơi nào đó an toàn. Chúng sẽ không được hiển thị lại."
+    },
+    "feedback": {
+      "passwordChanged": "Mật khẩu của bạn đã được cập nhật.",
+      "setupReady": "Quét mã QR, sau đó nhập mã gồm 6 chữ số để hoàn tất thiết lập.",
+      "twoFactorEnabled": "Xác thực hai yếu tố hiện đã được bật.",
+      "twoFactorDisabled": "Xác thực hai yếu tố hiện đã bị vô hiệu hóa.",
+      "recoveryCodesRegenerated": "Mã khôi phục của bạn đã được tạo lại. Lưu mã mới ngay bây giờ.",
+      "missingFields": "Vui lòng điền vào tất cả các trường bắt buộc.",
+      "missingCurrentPassword": "Nhập mật khẩu hiện tại của bạn để tiếp tục.",
+      "passwordTooShort": "Mật khẩu mới của bạn phải có ít nhất 8 ký tự.",
+      "invalidCurrentPassword": "Mật khẩu hiện tại không khớp.",
+      "missingCode": "Nhập mã gồm 6 chữ số từ ứng dụng xác thực của bạn.",
+      "invalidCode": "Mã đó không hoạt động. Vui lòng thử lại.",
+      "noPendingSetup": "Bắt đầu thiết lập lại trước khi nhập mã.",
+      "setupExpired": "Phiên thiết lập đó đã hết hạn. Bắt đầu thiết lập lại để nhận mã QR mới.",
+      "twoFactorNotEnabled": "Xác thực hai yếu tố không được kích hoạt cho tài khoản này.",
+      "genericError": "Đã xảy ra lỗi. Vui lòng thử lại.",
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+    }
+  }
+}

--- a/i18n/vi/anonymousUser.json
+++ b/i18n/vi/anonymousUser.json
@@ -1,0 +1,22 @@
+{
+  "anonymousUser": {
+    "meta": {
+      "title": "Kẻ lang thang vô danh",
+      "description": "Không có hồ sơ. Không có quá khứ. Chỉ là rung cảm."
+    },
+    "ascii": {
+      "ariaLabel": "Nghệ thuật ASCII về sinh vật kỳ quái kèm theo câu trích dẫn"
+    },
+    "header": {
+      "title": "Người ẩn danh"
+    },
+    "body": {
+      "line1": "Bạn đã vấp vào khoảng trống. Chẳng có gì để xem ở đây cả—",
+      "line2": "chỉ là một linh hồn lang thang không có câu chuyện."
+    },
+    "buttons": {
+      "home": "← Trở về nhà",
+      "signup": "Tạo danh tính"
+    }
+  }
+}

--- a/i18n/vi/archive.json
+++ b/i18n/vi/archive.json
@@ -1,0 +1,77 @@
+{
+  "archive": {
+    "meta": {
+      "title": "Daily Page — Lưu trữ",
+      "description": "Khám phá kho lưu trữ đầy đủ theo tháng.",
+      "titleRoom": "Daily Page — Lưu trữ · {roomName}",
+      "descriptionRoom": "Khám phá các bài viết trước đây trong phòng {roomName}—từng tháng. Chuyển đến bất kỳ ngày nào để xem những gì người khác đã chia sẻ trong không gian này theo thời gian."
+    },
+    "nav": {
+      "prev": "Trước đó",
+      "next": "Tiếp theo"
+    },
+    "title": "📚 Duyệt qua kho lưu trữ",
+    "titleRoom": "📚 {roomName} — Lưu trữ",
+    "roomViewing": "Xem kho lưu trữ của phòng {roomName}",
+    "viewRoomLink": "Xem phòng",
+    "noContent": "Chưa có nội dung nào.",
+    "backToRoom": "← Quay lại Bảng điều khiển phòng",
+    "calendar": {
+      "meta": {
+        "description": "Xem tất cả các bài đăng sáng tạo được xuất bản trong {month} {year}—từ những suy nghĩ nhanh chóng đến những suy ngẫm sâu sắc. Nhấp vào bất kỳ ngày nào để khám phá những gì đã được chia sẻ.",
+        "descriptionRoom": "Xem hoạt động sáng tạo trong {roomName} trong {month} {year}. Chọn một ngày để khám phá các bài viết được chia sẻ ngày hôm đó."
+      },
+      "title": "📆 Lưu trữ cho {month} {year}",
+      "prevLabel": "Lưu trữ cho {month} {year}",
+      "nextLabel": "Lưu trữ cho {month} {year}"
+    },
+    "date": {
+      "meta": {
+        "titleSite": "Lưu trữ cho {date}",
+        "titleRoom": "{roomName} — Lưu trữ cho {date}",
+        "descriptionSite": "Khám phá các bài đăng được viết trên {date}—từ những ghi chú thầm lặng đến những lời thú nhận hoang dã.",
+        "descriptionRoom": "Trên {date}, những người viết trong phòng {roomName} đã để lại dấu ấn của mình—xem qua những phản ánh, ý tưởng và cách diễn đạt được chia sẻ ngày hôm đó."
+      },
+      "heading": "Lưu trữ cho {date}",
+      "empty": "Không tìm thấy nội dung cho ngày này.",
+      "labels": {
+        "createdBy": "Được tạo bởi:",
+        "in": "trong",
+        "on": "trên {datetime}",
+        "unknownRoom": "Phòng không xác định"
+      },
+      "nav": {
+        "prevDay": "Ngày hôm trước",
+        "nextDay": "Ngày hôm sau"
+      }
+    },
+    "index": {
+      "meta": {
+        "titleRoom": "{roomName} — Tất cả bài viết",
+        "descriptionRoom": "Duyệt qua mọi bài đăng từng được xuất bản trong phòng {roomName}. Sắp xếp theo ngày, tiêu đề hoặc phiếu bầu để khám phá lịch sử của nó."
+      },
+      "header": {
+        "allBlocks": "— Tất cả bài viết"
+      },
+      "sort": {
+        "label": "Sắp xếp theo",
+        "options": {
+          "date": "Ngày",
+          "title": "Tiêu đề",
+          "votes": "Phiếu bầu"
+        },
+        "submit": "Áp dụng"
+      }
+    },
+    "pagination": {
+      "prev": "← Trước đó",
+      "next": "Tiếp theo →"
+    },
+    "yearMonth": {
+      "meta": {
+        "title": "Daily Page cho {time}"
+      },
+      "empty": "Chúng tôi không thể tìm thấy bất kỳ trang nào trong khoảng thời gian đó."
+    }
+  }
+}

--- a/i18n/vi/auth.json
+++ b/i18n/vi/auth.json
@@ -1,0 +1,41 @@
+{
+  "auth": {
+    "login": {
+      "meta": {
+        "title": "Daily Page — Đăng nhập",
+        "description": "Đăng nhập vào tài khoản Daily Page của bạn để tiếp tục hành trình viết lách của mình."
+      },
+      "heading": "Chào mừng trở lại!",
+      "subheading": "Đăng nhập vào tài khoản của bạn để tiếp tục chia sẻ bài viết hàng ngày của bạn.",
+      "fields": {
+        "usernameOrEmail": {
+          "label": "Tên người dùng hoặc Email",
+          "placeholder": "Nhập tên người dùng hoặc email của bạn"
+        },
+        "password": {
+          "label": "Mật khẩu",
+          "placeholder": "Nhập mật khẩu của bạn"
+        },
+        "totpCode": {
+          "label": "Mã xác thực hoặc mã khôi phục",
+          "placeholder": "Nhập mã"
+        }
+      },
+      "actions": {
+        "submit": "Đăng nhập"
+      },
+      "feedback": {
+        "success": "Đăng nhập thành công! Đang chuyển hướng...",
+        "twoFactorRequired": "Nhập mã gồm 6 chữ số từ ứng dụng xác thực của bạn hoặc sử dụng mã khôi phục.",
+        "twoFactorFailed": "Mã đó không hoạt động. Vui lòng thử lại.",
+        "failedGeneric": "Đăng nhập không thành công. Vui lòng thử lại.",
+        "unexpected": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+      },
+      "links": {
+        "forgotPassword": "Bạn quên mật khẩu?",
+        "noAccount": "Bạn chưa có tài khoản?",
+        "signupHere": "Đăng ký tại đây!"
+      }
+    }
+  }
+}

--- a/i18n/vi/bestOf.json
+++ b/i18n/vi/bestOf.json
@@ -1,0 +1,27 @@
+{
+  "bestOf": {
+    "meta": {
+      "title": "Trang hay nhất hàng ngày",
+      "description": "Các bài đăng được yêu thích nhất trên Trang Hàng ngày—hài hước, chân thật, thơ mộng hoặc đơn giản là kỳ lạ. Xem những gì nổi bật trong ngày, tuần, tháng qua và hơn thế nữa.",
+      "titleRoom": "Bài viết hay nhất trong {roomName}",
+      "descriptionRoom": "Khám phá những bài viết nổi bật trong phòng {roomName}—được độc giả yêu thích nhất trong 24 giờ, 7 ngày, 30 ngày qua và từ trước đến nay."
+    },
+    "heading": "🏆 Trang hay nhất hàng ngày",
+    "headingRoomPrefix": "🏆 Hay nhất tại ",
+    "headingRoomSuffix": "",
+    "tabs": {
+      "24h": "🔥 24 giờ qua",
+      "7d": "🚀 7 ngày",
+      "30d": "🌕 30 ngày",
+      "all": "👑 Mọi lúc"
+    },
+    "labels": {
+      "createdBy": "Được tạo bởi:",
+      "inRoom": "trong",
+      "onDate": "trên {date}",
+      "unknownRoom": "Phòng không xác định",
+      "noBlocks": "Không tìm thấy bài viết nào",
+      "viewRoom": "Xem phòng"
+    }
+  }
+}

--- a/i18n/vi/blockCommon.json
+++ b/i18n/vi/blockCommon.json
@@ -1,0 +1,18 @@
+{
+  "blockCommon": {
+    "badges": {
+      "draft": "Bản nháp"
+    },
+    "deleteModal": {
+      "title": "Xóa bài đăng?",
+      "message": "Không thể hoàn tác hành động này.",
+      "confirm": "Xóa bỏ",
+      "cancel": "Hủy",
+      "closeAriaLabel": "Đóng"
+    },
+    "toasts": {
+      "deleteSuccess": "Bài viết đã được xóa thành công!",
+      "deleteFailed": "Không thể xóa bài đăng."
+    }
+  }
+}

--- a/i18n/vi/blockEditor.json
+++ b/i18n/vi/blockEditor.json
@@ -1,0 +1,98 @@
+{
+  "blockEditor": {
+    "labels": {
+      "you": "(Bạn)"
+    },
+    "meta": {
+      "title": "Chỉnh sửa bài viết - {blockTitle}",
+      "titleFallback": "Chỉnh sửa bài đăng"
+    },
+    "errors": {
+      "imageUrlRequired": "Vui lòng nhập URL hình ảnh.",
+      "notFound": "Không tìm thấy bài đăng hoặc không thuộc về phòng này.",
+      "loadFailed": "Đã xảy ra lỗi khi tải trình chỉnh sửa bài đăng.",
+      "updateTitleFailed": "Lỗi cập nhật tiêu đề."
+    },
+    "roomInfo": {
+      "label": "Phòng:"
+    },
+    "title": {
+      "placeholder": "Nhập tiêu đề bài viết",
+      "editTooltip": "Chỉnh sửa tiêu đề",
+      "lock": "Khóa bài",
+      "delete": "Xóa bài đăng"
+    },
+    "description": {
+      "label": "Mô tả",
+      "editTooltip": "Chỉnh sửa mô tả",
+      "placeholder": "Nhập mô tả",
+      "noDescriptionOwner": "Chưa có mô tả nào...",
+      "noDescriptionViewer": "Chưa có mô tả...",
+      "save": "Lưu",
+      "cancel": "Hủy",
+      "expand": "Mở rộng",
+      "collapse": "Thu gọn",
+      "updateError": "Lỗi cập nhật mô tả."
+    },
+    "status": {
+      "lastBackup": "Lần sao lưu cuối cùng: {datetime}",
+      "lastBackupUnknown": "Lần sao lưu cuối cùng: Không xác định"
+    },
+    "peers": {
+      "label": "Người cùng chỉnh sửa:"
+    },
+    "toasts": {
+      "blockLocked": "Bài đăng này đã bị khóa!"
+    },
+    "editor": {
+      "placeholder": "Trang trống đang chờ giọng nói của bạn; viết một cách không sợ hãi."
+    },
+    "loading": {
+      "label": "Đang tải",
+      "quote": "Hãy để thế giới bùng cháy trong bạn. Ném ánh sáng lăng kính, nóng trắng, lên giấy.<br>—Ray Bradbury"
+    },
+    "inactiveWarning": {
+      "message": "Bạn đã không viết bất cứ điều gì trong 5 phút. Bấm OK để tiếp tục phiên; nếu không, bạn sẽ được chuyển hướng đến kho lưu trữ.",
+      "confirm": "OK"
+    },
+    "sharing": {
+      "label": "Liên kết chia sẻ",
+      "copyTooltip": "Sao chép vào Clipboard",
+      "copied": "Đã sao chép!"
+    },
+    "toolbar": {
+      "insertImage": "Chèn hình ảnh",
+      "insertImageUrlPlaceholder": "Nhập URL hình ảnh",
+      "insertImageAltPlaceholder": "Văn bản thay thế (tùy chọn)",
+      "insertImageConfirm": "Xác nhận",
+      "insertImageCancel": "Hủy"
+    },
+    "buttons": {
+      "downloadFile": "Tải tập tin xuống"
+    },
+    "lockModal": {
+      "messageLine1": "Bạn có chắc chắn muốn khóa bài viết này?",
+      "messageLine2": "Điều này sẽ hoàn thiện nó và ngăn chặn việc chỉnh sửa thêm.",
+      "confirm": "Khóa",
+      "cancel": "Hủy",
+      "successToast": "Bài đăng đã được khóa thành công.",
+      "errorToast": "Lỗi khóa bài viết."
+    },
+    "tags": {
+      "headerWithTags": "thẻ:",
+      "headerNoTags": "Chưa có thẻ nào! Thêm một số:",
+      "updateError": "Lỗi cập nhật thẻ."
+    },
+    "fullBlock": {
+      "headingPrefix": "Rất tiếc, bài viết \"{blockTitle}\" hiện đã",
+      "headingStatus": "đủ người chỉnh sửa.",
+      "retryPrefix": "Vui lòng",
+      "retryLink": "thử một bài viết khác",
+      "retrySuffix": "hoặc quay lại vào lúc khác.",
+      "consolationPrefix": "Trong lúc chờ đợi hãy đọc nhé",
+      "consolationBestOf": "một số bài viết yêu thích của chúng tôi",
+      "consolationMiddle": "hoặc để duyệt",
+      "consolationArchive": "kho lưu trữ."
+    }
+  }
+}

--- a/i18n/vi/blockList.json
+++ b/i18n/vi/blockList.json
@@ -1,0 +1,11 @@
+{
+  "blockList": {
+    "period": {
+      "all": "từ trước đến nay",
+      "days": "trong những ngày {n} vừa qua",
+      "day": "trong 24 giờ qua"
+    },
+    "createdBy": "Được tạo bởi:",
+    "on": "vào"
+  }
+}

--- a/i18n/vi/blockTags.json
+++ b/i18n/vi/blockTags.json
@@ -1,0 +1,15 @@
+{
+  "blockTags": {
+    "header": {
+      "withTags": "thẻ:",
+      "noTags": "Chưa có thẻ nào! Thêm một số:"
+    },
+    "input": {
+      "placeholder": "Thẻ mới",
+      "addButton": "Thêm vào"
+    },
+    "buttons": {
+      "removeTag": "x"
+    }
+  }
+}

--- a/i18n/vi/blockView.json
+++ b/i18n/vi/blockView.json
@@ -1,0 +1,129 @@
+{
+  "blockView": {
+    "meta": {
+      "title": "Bài viết - {blockTitle}",
+      "titleFallback": "Bài viết"
+    },
+    "labels": {
+      "room": "Phòng",
+      "author": "Tác giả",
+      "created": "Đã tạo",
+      "unknownAuthor": "Vô danh",
+      "authorAvatarAlt": "Hình đại diện của {username}",
+      "viewAuthorProfile": "Xem hồ sơ của {username}",
+      "lang": "Bản dịch:",
+      "available": "có sẵn"
+    },
+    "buttons": {
+      "edit": "Chỉnh sửa",
+      "deleteBlock": "Xóa bài đăng",
+      "share": "Chia sẻ",
+      "flagContent": "Gắn cờ nội dung"
+    },
+    "description": {
+      "label": "Mô tả",
+      "none": "Chưa có mô tả...",
+      "expand": "Mở rộng",
+      "collapse": "Thu gọn"
+    },
+    "editorial": {
+      "heading": "Hướng dẫn đọc",
+      "roleLabel": "Kiểu đọc",
+      "clusterLabel": "Hướng dẫn",
+      "sequence": "Phần {sequence}",
+      "primaryPillarHeading": "Bắt đầu ở đây",
+      "relatedHeading": "Tiếp tục đọc",
+      "clusterHeading": "Thêm trong hướng dẫn này",
+      "expandSection": "Hiển thị thêm {count}",
+      "collapseSection": "Hiển thị ít hơn",
+      "roleNames": {
+        "pillar": "Hướng dẫn cốt lõi",
+        "companion": "Bài đọc chuyên sâu",
+        "texture": "Bối cảnh"
+      }
+    },
+    "comments": {
+      "heading": "Bình luận",
+      "count": "Bình luận {count}",
+      "empty": "Chưa có ai trả lời. Nhận xét sẽ hiển thị ở đây khi cuộc trò chuyện bắt đầu.",
+      "composer": {
+        "label": "Thêm một bình luận",
+        "placeholder": "Viết bình luận...",
+        "submit": "Đăng bình luận",
+        "submitting": "Đang đăng...",
+        "success": "Bình luận được đăng.",
+        "error": "Không thể gửi bình luận của bạn ngay bây giờ.",
+        "loginPrompt": "Đăng nhập để tham gia cuộc trò chuyện.",
+        "loginCta": "Đăng nhập để bình luận",
+        "verifyPrompt": "Xác minh email của bạn trước khi đăng bình luận.",
+        "verifyCta": "Xác minh email"
+      },
+      "sort": {
+        "label": "Sắp xếp",
+        "oldestFirst": "Cũ nhất đầu tiên",
+        "newestFirst": "Mới nhất đầu tiên"
+      },
+      "by": "Bởi",
+      "unknownAuthor": "Không xác định",
+      "reply": {
+        "action": "Hồi đáp",
+        "label": "Thêm câu trả lời",
+        "placeholder": "Viết thư trả lời...",
+        "submit": "Đăng trả lời",
+        "submitting": "Đang đăng...",
+        "success": "Trả lời được đăng.",
+        "error": "Không thể gửi câu trả lời của bạn ngay bây giờ.",
+        "cancel": "Hủy",
+        "loginPrompt": "Đăng nhập để trả lời."
+      },
+      "manage": {
+        "edited": "Đã chỉnh sửa",
+        "editAction": "Chỉnh sửa",
+        "deleteAction": "Xóa bỏ",
+        "deleteConfirm": "Xóa nhận xét này? Thao tác này cũng sẽ xóa mọi câu trả lời bên dưới nó.",
+        "deleteSuccess": "Bình luận đã bị xóa.",
+        "deleteError": "Không thể xóa bình luận này ngay bây giờ.",
+        "forbidden": "Bạn chỉ có thể quản lý nhận xét của riêng bạn.",
+        "edit": {
+          "label": "Chỉnh sửa nhận xét",
+          "save": "Lưu",
+          "saving": "Đang lưu...",
+          "cancel": "Hủy",
+          "success": "Đã cập nhật bình luận.",
+          "error": "Không thể cập nhật nhận xét này ngay bây giờ."
+        }
+      },
+      "report": {
+        "action": "Báo cáo",
+        "pending": "Báo cáo...",
+        "success": "Đã báo cáo bình luận.",
+        "error": "Không thể báo cáo bình luận này ngay bây giờ.",
+        "ownError": "Bạn không thể báo cáo bình luận của riêng bạn.",
+        "hidden": "Bình luận bị ẩn sau khi báo cáo.",
+        "reported": "Đã báo cáo"
+      },
+      "deepLink": {
+        "focused": "Nhận xét được liên kết",
+        "unavailable": "Nhận xét được liên kết không còn tồn tại."
+      },
+      "loadMore": "Tải thêm bình luận",
+      "loading": "Đang tải...",
+      "loadError": "Không thể tải thêm bình luận ngay bây giờ."
+    },
+    "share": {
+      "title": "Chia sẻ bài đăng này",
+      "shareOn": "Chia sẻ trên:",
+      "nativeText": "Hãy xem bài đăng này: {title}",
+      "alt": {
+        "facebook": "Biểu tượng Facebook",
+        "reddit": "Biểu tượng Reddit",
+        "whatsapp": "Biểu tượng WhatsApp",
+        "twitter": "Biểu tượng Twitter"
+      }
+    },
+    "errors": {
+      "notFound": "Không tìm thấy bài đăng hoặc không thuộc về phòng này.",
+      "loadFailed": "Lỗi tải chế độ xem bài đăng."
+    }
+  }
+}

--- a/i18n/vi/createBlock.json
+++ b/i18n/vi/createBlock.json
@@ -1,0 +1,92 @@
+{
+  "createBlock": {
+    "meta": {
+      "title": "Tạo một bài đăng mới - Daily Page",
+      "description": "Bắt đầu một bài đăng sáng tạo mới với các thẻ, ngôn ngữ và khả năng hiển thị tùy chọn."
+    },
+    "heading": "Tạo một bài viết mới",
+    "roomInfo": {
+      "roomLabel": "Phòng:",
+      "unavailable": "Thông tin phòng không có sẵn.",
+      "noDescription": "Chưa có mô tả."
+    },
+    "form": {
+      "title": {
+        "label": "Tiêu đề:",
+        "placeholder": {
+          "full": "ví dụ. 'Kiệt tác của tôi', 'Ý tưởng hay nhất từ ​​trước đến nay', 'Clickbait dành cho những người mọt sách'",
+          "short": "ví dụ. 'Kiệt tác của tôi'"
+        }
+      },
+      "description": {
+        "label": "Mô tả (tùy chọn):",
+        "placeholder": "Giải thích sự xuất sắc của bạn… hoặc chỉ chắp cánh cho nó."
+      },
+      "initialContent": {
+        "label": "Nội dung ban đầu (tùy chọn):",
+        "help": "Bắt đầu viết tại đây hoặc nhấn “Tạo” để tiếp tục trên trang biên tập đầy đủ, nơi bạn có thể nhúng hình ảnh và cộng tác trong thời gian thực.",
+        "placeholder": "Bắt đầu bài đăng của bạn tại đây hoặc tiếp tục chỉnh sửa sau khi tạo…"
+      },
+      "visibility": {
+        "label": "Chế độ hiển thị:"
+      },
+      "submit": "Tạo bài đăng"
+    },
+    "visibility": {
+      "public": {
+        "label": "Công khai",
+        "title": "Có thể chỉnh sửa bởi bất cứ ai trong thời gian thực. Không cần đăng nhập.",
+        "inline": "Có thể chỉnh sửa bởi bất cứ ai trong thời gian thực. Không cần đăng nhập."
+      },
+      "unlisted": {
+        "label": "Bản nháp không công khai",
+        "title": "Ẩn khỏi trình duyệt công khai trong khi có thể chỉnh sửa. Hiển thị sau khi khóa.",
+        "inline": "Ẩn khỏi trình duyệt công khai trong khi có thể chỉnh sửa. Hiển thị sau khi khóa.",
+        "tooltip": "Các bản nháp không công khai bị ẩn khỏi trình duyệt công khai trong khi có thể chỉnh sửa. Bất kỳ ai có liên kết đều có thể cộng tác và bài đăng sẽ được công khai khi bị khóa."
+      }
+    },
+    "advanced": {
+      "summary": "Tùy chọn nâng cao",
+      "lang": {
+        "label": "Ngôn ngữ:",
+        "options": {
+          "en": "English",
+          "es": "Español",
+          "fr": "Français",
+          "ru": "Русский",
+          "id": "Bahasa Indonesia",
+          "de": "Deutsch",
+          "it": "Italiano",
+          "pt": "Português",
+          "zh": "中文",
+          "ja": "日本語",
+          "ko": "한국어",
+          "ar": "العربية",
+          "hi": "हिन्दी",
+          "tr": "Türkçe",
+          "nl": "Nederlands",
+          "sv": "Svenska",
+          "no": "Norsk",
+          "da": "Dansk",
+          "fi": "Suomi",
+          "pl": "Polski",
+          "cs": "Čeština",
+          "el": "Ελληνικά",
+          "he": "עברית",
+          "th": "ไทย",
+          "vi": "Tiếng Việt"
+        }
+      },
+      "translate": {
+        "label": "Dịch bài đăng hiện có (URL hoặc ID):",
+        "placeholder": "Dán URL hoặc ID bài đăng (tùy chọn)",
+        "invalid": "Có vẻ như đó không phải là URL hoặc ID bài đăng hợp lệ.",
+        "fetchError": "Không thể tìm nạp thông tin bài đăng."
+      }
+    },
+    "messages": {
+      "langExists": "Bản dịch cho ngôn ngữ đó đã tồn tại. Vui lòng chọn ngôn ngữ khác.",
+      "genericError": "Đã xảy ra lỗi. Vui lòng thử lại."
+    }
+  }
+}

--- a/i18n/vi/dashboard.json
+++ b/i18n/vi/dashboard.json
@@ -1,0 +1,57 @@
+{
+  "dashboard": {
+    "meta": {
+      "title": "Trang tổng quan",
+      "description": "Tổng quan về tài khoản và bảng điều khiển Daily Page của bạn."
+    },
+    "profile": {
+      "profilePicAlt": "Ảnh hồ sơ",
+      "noBio": "Chưa có tiểu sử. Nhấp vào \"Chỉnh sửa\" để thêm một!",
+      "editBio": "Chỉnh sửa tiểu sử",
+      "bioPlaceholder": "Nhập tiểu sử của bạn ở đây",
+      "save": "Lưu",
+      "cancel": "Hủy"
+    },
+    "activity": {
+      "title": "Hoạt động gần đây",
+      "none": "Không có hoạt động gần đây.",
+      "updatedOn": "Cập nhật vào {date}",
+      "viewAllBlocks": "Xem tất cả bài viết"
+    },
+    "drafts": {
+      "title": "Tiếp tục viết",
+      "none": "Không có bản nháp mở.",
+      "updatedOn": "Cập nhật vào {date}",
+      "unlisted": "Không công khai",
+      "viewAll": "Xem tất cả bài viết"
+    },
+    "streak": {
+      "title": "Chuỗi ngày viết",
+      "line": "{days} ngày liên tiếp! Tiếp tục đi!"
+    },
+    "starredRooms": {
+      "title": "Phòng được gắn dấu sao",
+      "none": "Bạn chưa gắn dấu sao cho bất kỳ phòng nào. Bắt đầu khám phá để tìm mục yêu thích của bạn!",
+      "viewAll": "Xem tất cả các phòng được gắn sao",
+      "unnamedRoom": "Phòng không tên"
+    },
+    "security": {
+      "title": "Bảo mật tài khoản",
+      "summary": "Thay đổi mật khẩu của bạn và quản lý xác thực hai yếu tố.",
+      "manage": "Quản lý bảo mật"
+    },
+    "stats": {
+      "title": "Số liệu thống kê của bạn",
+      "totalBlocks": "Tổng số bài viết đã tạo",
+      "collaborations": "Cộng tác",
+      "votesGiven": "Phiếu bầu đã đưa ra",
+      "daysActive": "Số ngày hoạt động",
+      "viewDetailed": "Xem số liệu thống kê chi tiết 📊"
+    },
+    "alerts": {
+      "uploadFailed": "Không thể tải lên ảnh hồ sơ. Vui lòng thử lại.",
+      "uploadUnexpected": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại.",
+      "bioUpdateFailed": "Lỗi cập nhật tiểu sử. Vui lòng thử lại."
+    }
+  }
+}

--- a/i18n/vi/detailedStats.json
+++ b/i18n/vi/detailedStats.json
@@ -1,0 +1,29 @@
+{
+  "detailedStats": {
+    "meta": {
+      "title": "Thống kê chi tiết",
+      "description": "Phân tích chi tiết về hoạt động trên Daily Page của bạn."
+    },
+    "nav": {
+      "backToDashboard": "← Quay lại Bảng điều khiển"
+    },
+    "header": {
+      "title": "📊 Tổng quan về số liệu thống kê của bạn 📊"
+    },
+    "cards": {
+      "totalBlocks": "Tổng số bài viết đã tạo 📝",
+      "collaborations": "Hợp tác 🤝",
+      "votesGiven": "Số phiếu bầu đã đưa ra 👍",
+      "daysActive": "Ngày hoạt động 📆"
+    },
+    "chart": {
+      "datasetLabel": "Số liệu thống kê của bạn",
+      "labels": {
+        "blocksCreated": "Bài viết đã được tạo",
+        "collaborations": "Cộng tác",
+        "votesGiven": "Phiếu bầu đã đưa ra",
+        "daysActive": "Số ngày hoạt động"
+      }
+    }
+  }
+}

--- a/i18n/vi/errors.json
+++ b/i18n/vi/errors.json
@@ -1,0 +1,18 @@
+{
+  "errors": {
+    "generic": {
+      "title": "Ối! Đã xảy ra lỗi.",
+      "message": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại sau.",
+      "home": "Quay lại trang chủ"
+    },
+    "notFound": {
+      "title": "404 - Không tìm thấy trang",
+      "metaTitle": "Không tìm thấy trang",
+      "message": "Xin lỗi, chúng tôi không thể tìm thấy trang bạn đang tìm kiếm.",
+      "homePrefix": "Bạn có thể quay lại",
+      "homeLink": "trang chủ",
+      "roomsPrefix": "hoặc kiểm tra",
+      "roomsLink": "thư mục phòng."
+    }
+  }
+}

--- a/i18n/vi/flagModal.json
+++ b/i18n/vi/flagModal.json
@@ -1,0 +1,28 @@
+{
+  "flagModal": {
+    "title": "Báo cáo nội dung không phù hợp",
+    "fields": {
+      "reason": {
+        "label": "Lý do",
+        "options": {
+          "spam": "Thư rác",
+          "offensive": "Xúc phạm (ngôn ngữ căm thù hoặc nói xấu)",
+          "inappropriate": "Không phù hợp (ảnh khỏa thân, nội dung phản cảm, v.v.)",
+          "other": "Khác"
+        }
+      },
+      "details": {
+        "label": "Chi tiết (tùy chọn)",
+        "placeholder": "Hãy mô tả những gì bạn đã thấy…"
+      }
+    },
+    "buttons": {
+      "submit": "Gửi báo cáo",
+      "cancel": "Hủy"
+    },
+    "toasts": {
+      "success": "Đã gửi báo cáo—cảm ơn bạn!",
+      "failed": "Không thể gửi báo cáo."
+    }
+  }
+}

--- a/i18n/vi/forgotPassword.json
+++ b/i18n/vi/forgotPassword.json
@@ -1,0 +1,34 @@
+{
+  "forgotPassword": {
+    "meta": {
+      "title": "Đặt lại mật khẩu",
+      "description": "Yêu cầu liên kết đặt lại cho tài khoản Daily Page của bạn."
+    },
+    "header": {
+      "title": "Bạn quên mật khẩu?",
+      "subtitle": "Nhập email của bạn và chúng tôi sẽ gửi cho bạn một liên kết đặt lại."
+    },
+    "form": {
+      "email": {
+        "label": "Địa chỉ email",
+        "placeholder": "Nhập email của bạn"
+      },
+      "submit": "Yêu cầu đặt lại mật khẩu"
+    },
+    "feedback": {
+      "successGeneric": "Nếu email đó tồn tại thì liên kết đặt lại đã được gửi.",
+      "missingEmail": "Email là bắt buộc.",
+      "genericError": "Đã xảy ra lỗi. Vui lòng thử lại.",
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+    },
+    "email": {
+      "subject": "Đặt lại mật khẩu Daily Page của bạn",
+      "heading": "Yêu cầu đặt lại mật khẩu",
+      "headingWithName": "Yêu cầu đặt lại mật khẩu, {username}",
+      "body": "Nhấp vào liên kết bên dưới để đặt lại mật khẩu của bạn.",
+      "cta": "Đặt lại mật khẩu của tôi",
+      "expires": "Liên kết này sẽ hết hạn sau (các) giờ {hours}.",
+      "ignore": "Nếu bạn không yêu cầu đặt lại mật khẩu, bạn có thể yên tâm bỏ qua email này."
+    }
+  }
+}

--- a/i18n/vi/home.json
+++ b/i18n/vi/home.json
@@ -1,0 +1,90 @@
+{
+  "home": {
+    "meta": {
+      "title": "Daily Page - Bài viết phổ biến trong 24 giờ qua",
+      "description": "Daily Page là một trang web viết lách độc lập, tối giản, nơi mọi người có thể đăng những suy nghĩ, kỷ niệm hoặc thử nghiệm sáng tạo—mỗi lần một bài. Khám phá những ý tưởng mới, tham gia phòng và đóng góp tiếng nói của bạn."
+    },
+    "hero": {
+      "eyebrow": "Một nơi yên tĩnh để viết, đọc và trở về",
+      "title": "Chào mừng đến với Daily Page!",
+      "subtitle": "Khám phá các bài đăng phổ biến nhất trong 24 giờ qua.",
+      "ctaPrefix": "Cảm thấy được truyền cảm hứng?",
+      "cta": "Tham gia một phòng",
+      "ctaSuffix": "và tạo bài đăng của riêng bạn!"
+    },
+    "stats": {
+      "blocks": "bài viết",
+      "rooms": "Phòng",
+      "tags": "Thẻ",
+      "collabsToday": "Hợp tác hôm nay"
+    },
+    "activity": {
+      "title": "Trực tiếp trên Daily Page",
+      "subtitle": "Cuộc trò chuyện và phản ứng mới mẻ, tất cả chỉ trong nháy mắt.",
+      "fallbackActor": "Người nào đó",
+      "inRoom": "trong",
+      "comments": {
+        "title": "Bình luận gần đây",
+        "more": "Khám phá cuộc trò chuyện",
+        "commentVerb": "đã bình luận về",
+        "replyVerb": "đã trả lời trên",
+        "empty": "Chưa có bình luận nào gần đây Cuộc trò chuyện tiếp theo có thể bắt đầu với bài viết của bạn."
+      },
+      "reactions": {
+        "title": "Phản ứng gần đây",
+        "more": "Xem các bài viết phổ biến",
+        "empty": "Chưa có phản ứng nào gần đây. Một bài viết hay có thể đánh thức điều này một cách nhanh chóng.",
+        "types": {
+          "heart": "đã thả tim cho",
+          "leaf": "đã thả lá cho",
+          "wow": "đã bày tỏ sự ngạc nhiên với",
+          "laugh": "đã thả cười cho"
+        }
+      }
+    },
+    "featured": {
+      "roomRibbon": "★ Phòng nổi bật",
+      "roomInfoDays": "Hoạt động trong những ngày {days} vừa qua: bài đăng {blocks}, phiếu bầu {votes}.",
+      "roomInfo24h": "Hoạt động trong 24 giờ qua: bài đăng {blocks}, phiếu bầu {votes}.",
+      "checkItOut": "Khám phá ngay",
+      "blockRibbon": "★ Bài đăng nổi bật",
+      "votes": "phiếu {n}",
+      "noContent": "(Không có nội dung được cung cấp...)",
+      "viewBlock": "Xem bài viết"
+    },
+    "trendingTags": {
+      "title": "Thẻ xu hướng",
+      "suffixDays": "({days} ngày qua)",
+      "suffixAllTime": "(từ trước đến nay)",
+      "blocks": "bài viết {n}",
+      "votes": "phiếu {n}",
+      "empty": "Chưa có thẻ xu hướng nào. Hãy là người đầu tiên gắn thẻ thứ gì đó thú vị!"
+    },
+    "trendingBlocks": {
+      "title": "Bài viết thịnh hành",
+      "suffixDays": "({days} ngày qua)",
+      "createdBy": "Được tạo bởi:",
+      "in": "trong",
+      "on": "vào",
+      "unknownRoom": "Phòng không xác định",
+      "empty24h": "Chưa có bài viết nào trong 24 giờ qua. Hãy quay lại sớm nhé!"
+    },
+    "supportWidget": {
+      "eyebrow": "Hỗ trợ trang web",
+      "title": "Hỗ trợ hàng tháng giúp Daily Page luôn trực tuyến.",
+      "text": "Mỗi khoản đóng góp định kỳ đều giúp trang trải chi phí cơ bản của Daily Page.",
+      "cta": "Hỗ trợ trang web",
+      "ariaLabel": "Tiến độ hỗ trợ hàng tháng: đã cam kết {raised} trên mục tiêu {goal}, đạt {percent}%.",
+      "ariaValue": "Đã cam kết {raised} trên mục tiêu {goal}",
+      "amountSeparator": "của",
+      "amountSuffix": "hàng tháng",
+      "goalReached": {
+        "title": "Mục tiêu hỗ trợ của tháng này đã được đáp ứng.",
+        "text": "Cảm ơn! Hỗ trợ bổ sung giúp Daily Page xử lý các chi phí và cải tiến trong tương lai.",
+        "meterLabel": "Đã đạt được mục tiêu",
+        "ariaLabel": "Đã đạt được mục tiêu hỗ trợ hàng tháng: {raised} đã cam kết thực hiện mục tiêu {goal}.",
+        "ariaValue": "Đã đạt mục tiêu; cam kết {raised} trên mục tiêu {goal}"
+      }
+    }
+  }
+}

--- a/i18n/vi/layout.json
+++ b/i18n/vi/layout.json
@@ -1,0 +1,55 @@
+{
+  "layout": {
+    "siteName": "Daily Page",
+    "welcomeUser": "Chào mừng bạn!",
+    "logout": "Đăng xuất",
+    "login": "Đăng nhập / Đăng ký",
+    "language": "Ngôn ngữ",
+    "openMenu": "Mở menu chính",
+    "closeMenu": "Đóng menu chính",
+    "privacy": "Chính sách bảo mật",
+    "uiFallbackNotice": "{requested} chưa được dịch. Hiện đang hiển thị {current}.",
+    "copyButton": {
+      "copy": "Sao chép",
+      "copied": "Đã sao chép!"
+    },
+    "copyright": "© {year}",
+    "languages": {
+      "en": "English",
+      "es": "Español",
+      "fr": "Français",
+      "ru": "Русский",
+      "id": "Bahasa Indonesia",
+      "de": "Deutsch",
+      "it": "Italiano",
+      "pt": "Português",
+      "zh": "中文",
+      "ja": "日本語",
+      "ko": "한국어",
+      "ar": "العربية",
+      "hi": "हिन्दी",
+      "tr": "Türkçe",
+      "nl": "Nederlands",
+      "sv": "Svenska",
+      "no": "Norsk",
+      "da": "Dansk",
+      "fi": "Suomi",
+      "pl": "Polski",
+      "cs": "Čeština",
+      "el": "Ελληνικά",
+      "he": "עברית",
+      "th": "ไทย",
+      "vi": "Tiếng Việt"
+    },
+    "theme": {
+      "label": "chủ đề",
+      "toggleToDark": "Chuyển sang chế độ tối",
+      "toggleToLight": "Chuyển sang chế độ sáng"
+    },
+    "blockImages": {
+      "preview": "Xem trước hình ảnh",
+      "close": "Đóng bản xem trước hình ảnh",
+      "open": "Mở xem trước hình ảnh"
+    }
+  }
+}

--- a/i18n/vi/modals.json
+++ b/i18n/vi/modals.json
@@ -1,0 +1,20 @@
+{
+  "modals": {
+    "login": {
+      "title": "Vui lòng đăng nhập",
+      "message": "Bạn cần phải đăng nhập để tiếp tục.",
+      "messageWithAction": "Bạn cần phải đăng nhập vào {action}.",
+      "cta": "Đăng nhập"
+    },
+    "actions": {
+      "voteOnBlock": "bỏ phiếu cho một bài viết",
+      "starRoom": "đánh dấu sao căn phòng này",
+      "reactToBlock": "phản ứng với bài viết này",
+      "commentOnBlock": "bình luận về bài viết này",
+      "reportComment": "báo cáo bình luận này"
+    },
+    "errors": {
+      "starToggleFail": "Không cập nhật được trạng thái sao. Vui lòng thử lại."
+    }
+  }
+}

--- a/i18n/vi/nav.json
+++ b/i18n/vi/nav.json
@@ -1,0 +1,19 @@
+{
+  "nav": {
+    "home": "Trang chủ",
+    "rooms": "Phòng",
+    "tags": "Thẻ",
+    "archive": "Lưu trữ",
+    "search": "Tìm kiếm",
+    "bestOf": "Tốt nhất của",
+    "about": "Về",
+    "support": "Ủng hộ",
+    "otherProjects": "Dự án khác",
+    "auth": {
+      "welcomePrefix": "Chào mừng,",
+      "welcomeFallbackUser": "Bạn",
+      "welcomeSuffix": "!"
+    },
+    "dashboard": "Trang tổng quan"
+  }
+}

--- a/i18n/vi/notifications.json
+++ b/i18n/vi/notifications.json
@@ -1,0 +1,39 @@
+{
+  "notifications": {
+    "inSite": {
+      "title": "Thông báo",
+      "openMenu": "Mở thông báo",
+      "loading": "Đang tải thông báo...",
+      "error": "Không thể tải thông báo ngay bây giờ.",
+      "empty": "Chưa có thông báo nào.",
+      "markRead": "Đánh dấu đã đọc",
+      "fallbackActor": "Người nào đó",
+      "fallbackBlockTitle": "bài đăng của bạn",
+      "item": {
+        "blockComment": "{actorUsername} đã nhận xét về bài đăng của bạn \"{blockTitle}\".",
+        "commentReply": "{actorUsername} đã trả lời bình luận của bạn về \"{blockTitle}\".",
+        "unknown": "Thông báo"
+      }
+    },
+    "email": {
+      "blockComment": {
+        "subject": "Bình luận mới về \"{blockTitle}\"",
+        "heading": "Bình luận mới về bài viết của bạn",
+        "headingWithName": "Xin chào {username},",
+        "body": "<strong>{actorUsername}</strong> đã nhận xét về bài đăng của bạn <strong>{blockTitle}</strong>.",
+        "cta": "Xem cuộc trò chuyện trên Daily Page",
+        "fallbackActor": "Người nào đó",
+        "fallbackBlockTitle": "bài đăng của bạn"
+      },
+      "commentReply": {
+        "subject": "Trả lời mới về \"{blockTitle}\"",
+        "heading": "Trả lời mới cho bình luận của bạn",
+        "headingWithName": "Xin chào {username},",
+        "body": "<strong>{actorUsername}</strong> đã trả lời bình luận của bạn về <strong>{blockTitle}</strong>.",
+        "cta": "Xem cuộc trò chuyện trên Daily Page",
+        "fallbackActor": "Người nào đó",
+        "fallbackBlockTitle": "bài đăng của bạn"
+      }
+    }
+  }
+}

--- a/i18n/vi/privacy.json
+++ b/i18n/vi/privacy.json
@@ -1,0 +1,44 @@
+{
+  "privacy": {
+    "meta": {
+      "title": "Daily Page — Chính sách bảo mật",
+      "description": "Cách Daily Page thu thập, sử dụng và bảo vệ dữ liệu của bạn bằng ngôn ngữ đơn giản."
+    },
+    "title": "Chính sách bảo mật",
+    "lastUpdated": "Cập nhật lần cuối: {date}",
+    "intro": {
+      "h2": "Giới thiệu",
+      "p1": "Daily Page (\"chúng tôi\", \"chúng tôi\" hoặc \"của chúng tôi\") vận hành trang web dailypage.org (sau đây gọi là \"Dịch vụ\").",
+      "p2": "Trang này thông báo cho bạn về các chính sách của chúng tôi về việc thu thập, sử dụng và tiết lộ dữ liệu cá nhân khi bạn sử dụng Dịch vụ của chúng tôi."
+    },
+    "collection": {
+      "h2": "Thu thập và sử dụng thông tin",
+      "p": "Chúng tôi thu thập dữ liệu cá nhân tối thiểu để cải thiện và cung cấp Dịch vụ của mình. Điều này bao gồm các địa chỉ email để quản lý tài khoản và nội dung do người dùng tự nguyện gửi."
+    },
+    "usage": {
+      "h2": "Sử dụng dữ liệu",
+      "p": "Dữ liệu được thu thập chỉ được sử dụng để xác thực tài khoản, kiểm duyệt nội dung và nâng cao trải nghiệm người dùng."
+    },
+    "storage": {
+      "h2": "Lưu trữ & bảo mật dữ liệu",
+      "p": "Dữ liệu của bạn được lưu trữ an toàn và không bao giờ được chia sẻ hoặc bán cho bên thứ ba mà không có sự đồng ý rõ ràng, trừ khi pháp luật yêu cầu."
+    },
+    "cookies": {
+      "h2": "Cookie",
+      "p": "Chúng tôi chỉ sử dụng cookie để quản lý phiên và cải thiện trải nghiệm người dùng. Bạn có thể tắt cookie thông qua cài đặt trình duyệt của mình."
+    },
+    "rights": {
+      "h2": "Quyền của bạn",
+      "p": "Bạn có thể yêu cầu xóa hoặc sửa đổi dữ liệu cá nhân của mình bất cứ lúc nào bằng cách liên hệ với chúng tôi."
+    },
+    "changes": {
+      "h2": "Những thay đổi đối với Chính sách quyền riêng tư này",
+      "p": "Thỉnh thoảng chúng tôi có thể cập nhật Chính sách quyền riêng tư của mình. Những thay đổi sẽ được đăng trên trang này."
+    },
+    "contact": {
+      "h2": "Liên hệ với chúng tôi",
+      "p": "Nếu có thắc mắc về Chính sách quyền riêng tư này, hãy liên hệ với chúng tôi tại:",
+      "emailLabel": "hỏi@dailypage.org"
+    }
+  }
+}

--- a/i18n/vi/profile.json
+++ b/i18n/vi/profile.json
@@ -1,0 +1,29 @@
+{
+  "profile": {
+    "meta": {
+      "titleUser": "Hồ sơ của {username}",
+      "descriptionUser": "Xem hoạt động gần đây, các phòng được gắn dấu sao và số liệu thống kê của {username}."
+    },
+    "profile": {
+      "profilePicAlt": "Ảnh hồ sơ",
+      "noBio": "(Không có sẵn tiểu sử.)"
+    },
+    "activity": {
+      "title": "Hoạt động gần đây",
+      "updatedOn": "Cập nhật vào {date}",
+      "none": "Không có hoạt động gần đây.",
+      "viewAllBlocks": "Xem tất cả bài viết"
+    },
+    "starredRooms": {
+      "title": "Phòng được gắn dấu sao",
+      "none": "Chưa có phòng được gắn dấu sao.",
+      "unnamedRoom": "Phòng không tên"
+    },
+    "stats": {
+      "title": "Thống kê người dùng",
+      "totalBlocks": "Tổng số bài viết đã tạo",
+      "collaborations": "Cộng tác",
+      "daysActive": "Số ngày hoạt động"
+    }
+  }
+}

--- a/i18n/vi/random.json
+++ b/i18n/vi/random.json
@@ -1,0 +1,17 @@
+{
+  "random": {
+    "meta": {
+      "title": "Daily Page — Các dự án khác",
+      "description": "Khám phá nhật ký bóng chày, thí nghiệm viết ngẫu nhiên và các dự án phụ khác từ Daily Page."
+    },
+    "title": "Dự án khác",
+    "tagline": "Một góc ấm cúng cho các thí nghiệm và nhiệm vụ phụ.",
+    "links": {
+      "baseball": "📖 Tạp chí bóng chày",
+      "randomWriter": "🎲 Người viết ngẫu nhiên"
+    },
+    "cta": {
+      "backToRooms": "Quay lại Phòng chính"
+    }
+  }
+}

--- a/i18n/vi/randomWriter.json
+++ b/i18n/vi/randomWriter.json
@@ -1,0 +1,14 @@
+{
+  "randomWriter": {
+    "meta": {
+      "title": "Daily Page — Người viết ngẫu nhiên",
+      "description": "Tạo vô số văn bản giả ngẫu nhiên để giải trí, truyền cảm hứng hoặc gây hỗn loạn."
+    },
+    "title": "Người viết ngẫu nhiên",
+    "buttons": {
+      "clear": "Thông thoáng",
+      "stop": "Dừng viết",
+      "start": "Bắt đầu viết"
+    }
+  }
+}

--- a/i18n/vi/reactions.json
+++ b/i18n/vi/reactions.json
@@ -1,0 +1,7 @@
+{
+  "reactions": {
+    "aria": "Phản ứng {emoji}: {count}",
+    "loginToReact": "Đăng nhập để phản ứng",
+    "countsLabel": "phản ứng"
+  }
+}

--- a/i18n/vi/readMore.json
+++ b/i18n/vi/readMore.json
@@ -1,0 +1,6 @@
+{
+  "readMore": {
+    "more": "Hơn...",
+    "aria": "Đọc toàn bộ bài viết: {title}"
+  }
+}

--- a/i18n/vi/resetPassword.json
+++ b/i18n/vi/resetPassword.json
@@ -1,0 +1,27 @@
+{
+  "resetPassword": {
+    "meta": {
+      "title": "Đặt lại mật khẩu của bạn",
+      "description": "Đặt mật khẩu mới cho tài khoản của bạn."
+    },
+    "header": {
+      "title": "Đặt lại mật khẩu của bạn",
+      "subtitle": "Chọn mật khẩu mới để lấy lại quyền truy cập."
+    },
+    "form": {
+      "newPassword": {
+        "label": "Mật khẩu mới",
+        "placeholder": "Nhập mật khẩu mới"
+      },
+      "submit": "Đặt mật khẩu mới"
+    },
+    "feedback": {
+      "missingToken": "Mã thông báo bị thiếu hoặc không hợp lệ.",
+      "missingFields": "Cần có mã thông báo và mật khẩu mới.",
+      "invalidOrExpired": "Mã thông báo không hợp lệ hoặc đã hết hạn.",
+      "success": "Đã cập nhật mật khẩu thành công!",
+      "genericError": "Đã xảy ra lỗi. Vui lòng thử lại.",
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+    }
+  }
+}

--- a/i18n/vi/roomDashboard.json
+++ b/i18n/vi/roomDashboard.json
@@ -1,0 +1,43 @@
+{
+  "roomDashboard": {
+    "meta": {
+      "title": "Daily Page — {roomName}",
+      "description": "Khám phá các bài đăng gần đây và đang được thực hiện trong {roomName}."
+    },
+    "links": {
+      "exploreLabel": "Khám phá:",
+      "allBlocks": "🗂️ Tất cả bài viết",
+      "browseByDate": "🗓️ Theo ngày",
+      "bestOf": "🏅 Hay nhất",
+      "searchInRoom": "🔎 Tìm kiếm"
+    },
+    "actions": {
+      "createBlock": "Tạo một bài đăng",
+      "starTitle": "Gắn dấu sao cho phòng này",
+      "unstarTitle": "Bỏ gắn dấu sao phòng này"
+    },
+    "tabs": {
+      "locked": "Bài viết bị khóa",
+      "inProgress": "Bài viết đang tiến hành"
+    },
+    "sections": {
+      "lockedHeader": "Bài viết bị khóa",
+      "inProgressHeader": "Bài đăng đang được thực hiện"
+    },
+    "editorial": {
+      "heading": "Hướng dẫn nổi bật",
+      "description": "Bắt đầu ở đây với các hướng dẫn nổi bật được tuyển chọn cho căn phòng này.",
+      "roleNames": {
+        "pillar": "Hướng dẫn cốt lõi",
+        "companion": "Hướng dẫn đọc",
+        "texture": "Hướng dẫn nền"
+      }
+    },
+    "empty": {
+      "noDescription": "Chưa có mô tả.",
+      "noLocked": "Chưa có bài viết nào bị khóa! Bài viết tự động khóa sau 1 giờ không hoạt động.",
+      "noInProgress": "Chưa có bài viết nào đang được thực hiện! Đã đến lúc bắt đầu một cái.",
+      "noBlocks": "Chưa có bài viết nào! Tạo cái đầu tiên và để lại dấu ấn của bạn. 😎"
+    }
+  }
+}

--- a/i18n/vi/roomsDirectory.json
+++ b/i18n/vi/roomsDirectory.json
@@ -1,0 +1,31 @@
+{
+  "roomsDirectory": {
+    "meta": {
+      "title": "Danh mục phòng",
+      "description": "Mỗi căn phòng là một cánh cửa dẫn vào một thế giới khác nhau. Bước vào bên trong, chia sẻ câu chuyện của bạn và cùng những người khác xây dựng một điều gì đó đẹp đẽ."
+    },
+    "eyebrow": "Tìm góc của bạn",
+    "heading": "Danh mục phòng",
+    "intro": "Bắt đầu với những căn phòng mà bạn cảm thấy sống động ngay bây giờ hoặc đi lang thang theo chủ đề cho đến khi có điều gì đó thú vị. Mỗi phòng là một gợi ý viết lách, fandom hoặc nỗi ám ảnh chung khác nhau đang chờ tiếng nói của bạn.",
+    "empty": "Hiện tại không có phòng trống. Hãy kiểm tra lại sau!",
+    "jumpToActive": "Xem phòng đang hoạt động",
+    "jumpToTopics": "Duyệt theo chủ đề",
+    "statsLabel": "Điểm nổi bật của thư mục phòng",
+    "liveNow": "Đang sôi nổi",
+    "recentlyActive": "Hoạt động gần đây",
+    "recentlyActiveSubtitle": "Cách nhanh nhất để tìm phòng có người ở trong đó ngay bây giờ.",
+    "browseByTopic": "Duyệt theo chủ đề",
+    "topicSubtitle": "Mở một chủ đề để khám phá các phòng của nó.",
+    "roomCount": "Phòng {count}",
+    "stats": {
+      "rooms": "phòng để khám phá",
+      "topics": "nhóm chủ đề",
+      "active": "phòng đang hoạt động"
+    },
+    "activeUsers": "Người dùng đang hoạt động: {count}",
+    "visitRoom": "Vào phòng",
+    "close": "Đóng",
+    "noTitle": "Không có tiêu đề nào",
+    "noDescription": "Không có mô tả nào"
+  }
+}

--- a/i18n/vi/search.json
+++ b/i18n/vi/search.json
@@ -1,0 +1,23 @@
+{
+  "search": {
+    "meta": {
+      "title": "Tìm kiếm",
+      "description": "Tìm kiếm bài viết công khai."
+    },
+    "title": "Tìm kiếm",
+    "placeholder": "Tìm kiếm bài viết...",
+    "hint": "Nhập ít nhất 2 ký tự để tìm kiếm.",
+    "noResults": "Không tìm thấy kết quả nào.",
+    "untitled": "Không có tiêu đề",
+    "votesTitle": "Phiếu bầu",
+    "pageLabel": "Trang",
+    "filters": {
+      "inRoom": "Trong phòng"
+    },
+    "buttons": {
+      "search": "Tìm kiếm",
+      "prev": "Trước đó",
+      "next": "Tiếp theo"
+    }
+  }
+}

--- a/i18n/vi/signup.json
+++ b/i18n/vi/signup.json
@@ -1,0 +1,33 @@
+{
+  "signup": {
+    "meta": {
+      "title": "Tạo một tài khoản",
+      "description": "Đăng ký Daily Page để truy cập tất cả các tính năng."
+    },
+    "header": {
+      "title": "Tạo tài khoản của bạn",
+      "subtitle": "Tham gia Daily Page để bắt đầu tạo và chia sẻ bài viết hàng ngày của bạn!"
+    },
+    "form": {
+      "email": {
+        "label": "E-mail",
+        "placeholder": "Nhập email của bạn"
+      },
+      "username": {
+        "label": "Tên người dùng",
+        "placeholder": "Nhập tên người dùng của bạn"
+      },
+      "password": {
+        "label": "Mật khẩu",
+        "placeholder": "Nhập mật khẩu"
+      },
+      "submit": "Đăng ký",
+      "feedback": {
+        "success": "Gửi biểu mẫu thành công!",
+        "successCreatedVerify": "Tài khoản được tạo thành công! Vui lòng kiểm tra email để xác minh tài khoản của bạn.",
+        "genericError": "Không tạo được tài khoản. Vui lòng thử lại.",
+        "unexpectedError": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+      }
+    }
+  }
+}

--- a/i18n/vi/starredRooms.json
+++ b/i18n/vi/starredRooms.json
@@ -1,0 +1,21 @@
+{
+  "starredRooms": {
+    "meta": {
+      "title": "Tất cả các phòng được gắn dấu sao",
+      "description": "Danh sách tất cả các phòng bạn đã gắn dấu sao."
+    },
+    "nav": {
+      "backToDashboard": "← Quay lại Bảng điều khiển"
+    },
+    "header": {
+      "title": "🌟 Tất cả các phòng được gắn dấu sao của bạn 🌟"
+    },
+    "rooms": {
+      "unnamedRoom": "Phòng không tên",
+      "noDescription": "Không có mô tả."
+    },
+    "empty": {
+      "message": "Bạn chưa gắn dấu sao cho bất kỳ phòng nào!"
+    }
+  }
+}

--- a/i18n/vi/support.json
+++ b/i18n/vi/support.json
@@ -1,0 +1,81 @@
+{
+  "support": {
+    "meta": {
+      "title": "Daily Page - Hỗ trợ",
+      "description": "Hỗ trợ Daily Page về mặt tài chính, đóng góp cho dự án nguồn mở, báo cáo sự cố, liên hệ hoặc yêu cầu phòng mới."
+    },
+    "hero": {
+      "eyebrow": "Hỗ trợ Daily Page",
+      "title": "Giúp giữ không gian viết nhỏ này trực tuyến.",
+      "tagline": "Daily Page là một dự án độc lập, mã nguồn mở. Một vài đóng góp ổn định sẽ giúp ích rất nhiều cho việc lưu trữ, email, lưu trữ, bảo trì và công việc thầm lặng để giữ cho nó luôn hữu ích."
+    },
+    "funding": {
+      "h2": "Mục tiêu tài trợ hàng tháng",
+      "p1": "Mục tiêu hiện tại là quyên góp được 20 USD mỗi tháng để trang trải các chi phí cơ bản để vận hành trang web.",
+      "p2": "Đồng hồ đo tiến độ phản ánh hỗ trợ định kỳ hàng tháng đã được xác nhận. Hỗ trợ một lần cũng được hoan nghênh nhưng đồng hồ đo sẽ theo dõi mục tiêu bền vững hàng tháng.",
+      "ctaMonthly": "Đóng góp hàng tháng",
+      "ctaOneTime": "Ủng hộ một lần",
+      "ctaEmail": "Gửi email cho Daily Page",
+      "meter": {
+        "label": "Tiến độ tháng này",
+        "amountSeparator": "đã quyên góp trên",
+        "amountSuffix": "hàng tháng",
+        "note": "Cập nhật khi có sự thay đổi hỗ trợ hàng tháng đã được xác nhận.",
+        "ariaLabel": "Tiến độ gây quỹ hàng tháng: đã quyên góp {raised} trên mục tiêu {goal}, đạt {percent}%.",
+        "ariaValue": "Đã quyên góp {raised} trên mục tiêu {goal}"
+      },
+      "monthlyOptionsLabel": "Chọn số tiền hàng tháng",
+      "monthlyOptionAriaLabel": "Đóng góp {amount} hàng tháng",
+      "goalReached": {
+        "h2": "Mục tiêu hàng tháng đã được đáp ứng. Xin cảm ơn!",
+        "p1": "Khoản hỗ trợ định kỳ hiện đã trang trải mức chi phí cơ bản {goal} mỗi tháng của Daily Page.",
+        "p2": "Hỗ trợ bổ sung vẫn được hoan nghênh và giúp xây dựng một khoản dự phòng cho các chi phí, bảo trì và cải tiến không mong muốn trong tương lai.",
+        "monthlyOptionsLabel": "Tiếp tục ủng hộ Daily Page",
+        "ctaMonthly": "Tiếp tục ủng hộ hàng tháng",
+        "meterLabel": "Đã đạt được mục tiêu",
+        "meterNote": "Cảm ơn bạn đã giúp trang trải chi phí cơ bản hàng tháng.",
+        "meterAriaLabel": "Đã đạt mục tiêu gây quỹ hàng tháng: cam kết {raised} trên mục tiêu {goal}.",
+        "meterAriaValue": "Đã đạt mục tiêu; cam kết {raised} trên mục tiêu {goal}"
+      }
+    },
+    "openSource": {
+      "h2": "Nguồn mở",
+      "p1": "Daily Page được phát triển công khai. Bạn có thể xem mã nguồn, báo lỗi, đề xuất tính năng hoặc mở pull request.",
+      "items": {
+        "code": {
+          "label": "Duyệt mã",
+          "text": "để xem trang web hoạt động như thế nào và nó sẽ dẫn đến đâu."
+        },
+        "issues": {
+          "label": "Sử dụng mục Issues",
+          "text": "để tìm lỗi, các góc cạnh thô, vấn đề về khả năng truy cập, lỗ hổng dịch thuật và ý tưởng về tính năng."
+        },
+        "community": {
+          "label": "Đóng góp thiết thực",
+          "text": "với các bản sửa lỗi, tài liệu, bản dịch, cải tiến thiết kế hoặc những cải tiến nhỏ giúp việc viết ở đây trở nên dễ dàng hơn."
+        }
+      },
+      "repoCta": "Xem repository",
+      "issuesCta": "Xem các issue đang mở"
+    },
+    "contact": {
+      "h2": "Câu hỏi và phản hồi",
+      "p1": "Đối với các câu hỏi riêng tư, trợ giúp về tài khoản hoặc bất kỳ điều gì không thuộc vấn đề công khai, email vẫn là con đường tốt nhất.",
+      "emailCta": "Gửi email cho Daily Page",
+      "issueCta": "Báo cáo sự cố"
+    },
+    "rooms": {
+      "h2": "Yêu cầu phòng",
+      "p1": "Các phòng giúp sắp xếp Daily Page theo những chủ đề chung. Nếu bạn muốn có một không gian viết mới, hãy gửi yêu cầu tại đây.",
+      "form": {
+        "nameLabel": "Tên phòng",
+        "topicLabel": "Chủ đề (tùy chọn)",
+        "descriptionLabel": "Mô tả",
+        "submit": "Gửi yêu cầu",
+        "success": "Yêu cầu được gửi thành công!",
+        "errorGeneric": "Không thể gửi yêu cầu. Vui lòng thử lại.",
+        "errorUnexpected": "Đã xảy ra lỗi không mong muốn. Vui lòng thử lại."
+      }
+    }
+  }
+}

--- a/i18n/vi/tags.json
+++ b/i18n/vi/tags.json
@@ -1,0 +1,50 @@
+{
+  "tags": {
+    "meta": {
+      "title": "Daily Page — Tổng quan về thẻ",
+      "description": "Duyệt qua tất cả các thẻ được sử dụng trên Daily Page, với các bộ lọc nhanh theo thời gian."
+    },
+    "title": "Tổng quan về thẻ",
+    "intro": "Khám phá tất cả các thẻ được sử dụng trong Daily Page.",
+    "tagCloudTitle": "Đám mây thẻ",
+    "timeframe": {
+      "last24h": "24 giờ qua",
+      "last7d": "7 ngày qua",
+      "last30d": "30 ngày qua",
+      "all": "từ trước đến nay"
+    },
+    "error": {
+      "loading": "Không thể tải tổng quan về thẻ"
+    },
+    "detail": {
+      "meta": {
+        "titlePrefix": "#",
+        "titleSuffix": "| Daily Page",
+        "description": "Các bài viết được gắn thẻ"
+      },
+      "header": {
+        "label": "Thẻ:",
+        "icon": "🏷️"
+      },
+      "stats": {
+        "totalBlocks": "Tổng số bài đăng với",
+        "totalBlocksTagSeparator": ":"
+      },
+      "blockInfo": {
+        "createdBy": "Được tạo bởi:",
+        "inRoom": "trong",
+        "unknownRoom": "Phòng không xác định",
+        "onDate": "vào"
+      },
+      "chart": {
+        "label": "Bài viết được tạo theo thời gian"
+      },
+      "empty": {
+        "message": "Chưa tìm thấy bài viết nào có thẻ này. Có lẽ bạn nên tạo cái đầu tiên? 🔥"
+      },
+      "error": {
+        "loadingTagPage": "Không thể tải trang thẻ"
+      }
+    }
+  }
+}

--- a/i18n/vi/translation.json
+++ b/i18n/vi/translation.json
@@ -1,0 +1,7 @@
+{
+  "translation": {
+    "prefix": "Được dịch từ",
+    "see": "nhìn thấy",
+    "originalBlock": "bài gốc"
+  }
+}

--- a/i18n/vi/userBlocks.json
+++ b/i18n/vi/userBlocks.json
@@ -1,0 +1,19 @@
+{
+  "userBlocks": {
+    "meta": {
+      "title": "Bài đăng của bạn",
+      "description": "Duyệt và sắp xếp tất cả các bài đăng bạn đã tạo hoặc cộng tác."
+    },
+    "header": {
+      "dashboardLink": "Trang tổng quan của bạn",
+      "profileLink": "Hồ sơ của {username}",
+      "allBlocks": "Tất cả bài viết"
+    },
+    "empty": "Chưa có bài viết nào",
+    "pagination": {
+      "prev": "← Trước đó",
+      "next": "Tiếp theo →"
+    },
+    "titleUser": "Bài viết của {username}"
+  }
+}

--- a/i18n/vi/verifyEmail.json
+++ b/i18n/vi/verifyEmail.json
@@ -1,0 +1,26 @@
+{
+  "verifyEmail": {
+    "meta": {
+      "title": "Xác minh email",
+      "description": "Xác minh địa chỉ email của bạn cho Daily Page."
+    },
+    "header": {
+      "title": "Đang xác minh email của bạn..."
+    },
+    "status": {
+      "checking": "Đang kiểm tra mã thông báo, vui lòng đợi...",
+      "missingToken": "Mã thông báo xác minh bị thiếu hoặc không hợp lệ.",
+      "genericFailure": "Xác minh không thành công.",
+      "unexpectedError": "Đã xảy ra lỗi không mong muốn.",
+      "success": "Tài khoản của bạn đã được xác minh thành công!",
+      "invalidOrExpired": "Mã thông báo xác minh không hợp lệ hoặc đã hết hạn."
+    },
+    "verificationMsg": {
+      "subject": "Xác minh tài khoản Daily Page của bạn ✨",
+      "heading": "Chào mừng đến với Daily Page, {username}!",
+      "body": "Vui lòng xác minh email của bạn bằng cách nhấp vào bên dưới:",
+      "cta": "Xác minh địa chỉ email",
+      "expires": "Liên kết này hết hạn sau {hours} giờ."
+    }
+  }
+}

--- a/i18n/vi/voteControls.json
+++ b/i18n/vi/voteControls.json
@@ -1,0 +1,9 @@
+{
+  "voteControls": {
+    "upvote": "ủng hộ",
+    "downvote": "Phản đối",
+    "errors": {
+      "failed": "Không lưu được phiếu bầu của bạn."
+    }
+  }
+}

--- a/server/middleware/hreflang.js
+++ b/server/middleware/hreflang.js
@@ -1,7 +1,7 @@
 // server/middleware/hreflang.js
 import { isLocalizedPath } from '../services/localizedPaths.js';
 
-const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th'];
+const indexableLangs = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th', 'vi'];
 
 // Treat block-view as "content-hreflang owns this page"
 function isBlockViewPath(path) {

--- a/server/services/cron.js
+++ b/server/services/cron.js
@@ -18,7 +18,7 @@ import {
   getRecentReactionActivity
 } from '../db/homeActivityService.js';
 
-const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th'];
+const HOME_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th', 'vi'];
 
 async function warmHomeCache({ preferredLang }) {
   // Settled so one failure doesn’t prevent other keys from warming
@@ -85,4 +85,5 @@ export function startJobs() {
   setTimeout(() => warmHomeCache({ preferredLang: 'el' }).catch(console.error), 11_500);
   setTimeout(() => warmHomeCache({ preferredLang: 'he' }).catch(console.error), 12_000);
   setTimeout(() => warmHomeCache({ preferredLang: 'th' }).catch(console.error), 12_500);
+  setTimeout(() => warmHomeCache({ preferredLang: 'vi' }).catch(console.error), 13_000);
 }

--- a/server/services/emailTemplates/commentNotification.js
+++ b/server/services/emailTemplates/commentNotification.js
@@ -9,7 +9,7 @@ function truncate(str, max = 180) {
 }
 
 function normalizeEmailLang(lang) {
-  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th']);
+  const supported = new Set(['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th', 'vi']);
   return supported.has(lang) ? lang : 'en';
 }
 

--- a/server/services/localeContext.js
+++ b/server/services/localeContext.js
@@ -1,6 +1,6 @@
 // server/services/localeContext.js
 
-export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th'];
+export const SUPPORTED_UI_LANGS = ['en', 'es', 'fr', 'ru', 'id', 'de', 'it', 'pt', 'zh', 'ja', 'ko', 'ar', 'hi', 'tr', 'nl', 'sv', 'no', 'da', 'fi', 'pl', 'cs', 'el', 'he', 'th', 'vi'];
 export const DEFAULT_UI_LANG = 'en';
 
 export function isSupportedUiLang(l) {


### PR DESCRIPTION
## Summary

- add complete Vietnamese translations for every English UI locale file
- register `vi` as a fully supported UI language
- add Vietnamese hreflang, notification email, and home-cache support
- preserve all interpolation placeholders
- leave DB-backed room translations unchanged

## Validation

- confirmed Vietnamese matches English file-for-file and key-for-key
- parsed all 1,000 locale JSON files successfully
- verified translation placeholders match English
- passed ESLint
- passed all 279 tests

## Follow-up

A native-speaker review would be valuable for further wording refinement after the initial rollout.