### PR TITLE
Use local timezones for block timestamps and writing streaks

### DIFF
--- a/lib/streakHelper.js
+++ b/lib/streakHelper.js
@@ -1,30 +1,43 @@
-// top-level variable to hold the date we last pinged
+const STREAK_PING_DATE_KEY = 'streakPingLocalDate';
+
+// top-level variable to hold the local date we last pinged
 let streakPingDate = typeof localStorage === 'undefined'
   ? null
-  : localStorage.getItem('streakPingDate') || null;
+  : localStorage.getItem(STREAK_PING_DATE_KEY) || null;
+
+export function localCalendarDateKey(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function browserTimeZone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
 
 // Utility to check if “today” is the same day we last sent a ping
 export function alreadyPingedToday() {
   if (!streakPingDate) return false;
-  // Compare the stored date to today’s date (UTC)
-  const todayUTC = new Date().toISOString().slice(0, 10); // e.g. "2025-03-15"
-  return streakPingDate === todayUTC;
+  return streakPingDate === localCalendarDateKey();
 }
 
 // Utility to store “today” so we won't send again
 export function markPingSentForToday() {
-  const todayUTC = new Date().toISOString().slice(0, 10);
+  const today = localCalendarDateKey();
   if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('streakPingDate', todayUTC);
+    localStorage.setItem(STREAK_PING_DATE_KEY, today);
   }
-  streakPingDate = todayUTC;
+  streakPingDate = today;
 }
 
 export function streakPing() {
   if (typeof userId === 'undefined' || !userId) return;
 
   fetch(`/api/v1/users/${userId}/streakPing`, {
-    method: 'POST'
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timeZone: browserTimeZone() })
   })
     .then(res => {
       if (!res.ok) throw new Error('Streak update failed');

--- a/public/js/create-block.js
+++ b/public/js/create-block.js
@@ -55,6 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     data.tags = tagsArray;
     if (!data.content) data.content = '';
+    data.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 
     try {
       const response = await fetch(form.action, {
@@ -139,7 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
 
       bumpIfDup();
-    } catch (err) {
+    } catch {
       alert(t('createBlock.advanced.translate.fetchError'));
       groupIdField.value = '';
     }

--- a/public/js/local-date-times.js
+++ b/public/js/local-date-times.js
@@ -1,0 +1,30 @@
+(function () {
+  const DATE_PLACEHOLDER = '__DATE__';
+
+  function formatLocalDateTimes(root = document) {
+    const locale = document.documentElement.lang || undefined;
+
+    root.querySelectorAll('[data-local-date-time]').forEach((element) => {
+      const rawDate = element.getAttribute('datetime') || element.dataset.localDateTime;
+      const date = new Date(rawDate);
+      if (Number.isNaN(date.getTime())) return;
+
+      const options = { dateStyle: element.dataset.dateStyle || 'medium' };
+      if (element.dataset.timeStyle) options.timeStyle = element.dataset.timeStyle;
+
+      const formatted = new Intl.DateTimeFormat(locale, options).format(date);
+      const template = element.dataset.dateTemplate;
+      element.textContent = template && template.includes(DATE_PLACEHOLDER)
+        ? template.replace(DATE_PLACEHOLDER, formatted)
+        : formatted;
+    });
+  }
+
+  window.formatLocalDateTimes = formatLocalDateTimes;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => formatLocalDateTimes());
+  } else {
+    formatLocalDateTimes();
+  }
+})();

--- a/server/api/v1/blocks.js
+++ b/server/api/v1/blocks.js
@@ -97,7 +97,8 @@ const useBlockAPI = (app) => {
       lang,
       groupId,
       originalBlock,
-      editorial
+      editorial,
+      timeZone
     } = req.body;
 
     if (!title || title.length < 3) {
@@ -163,7 +164,7 @@ const useBlockAPI = (app) => {
       // 2️⃣ Si hubo contenido inicial, actualizamos el streak
       if (req.user && content && content.trim() !== '') {
         try {
-          const updatedUser = await updateUserStreak(req.user.id);
+          const updatedUser = await updateUserStreak(req.user.id, { timeZone });
           // Re-generar el JWT con el nuevo streakLength
           refreshAuthToken(res, updatedUser)
         } catch (streakErr) {

--- a/server/api/v1/users.js
+++ b/server/api/v1/users.js
@@ -195,7 +195,7 @@ const useUserAPI = (app) => {
   router.post('/:userId/streakPing', isAuthenticated, mustMatchLoggedInUser, async (req, res) => {
     const userId = req.user.id;
     try {
-      const updatedUser = await updateUserStreak(userId);
+      const updatedUser = await updateUserStreak(userId, { timeZone: req.body?.timeZone });
       refreshAuthToken(res, updatedUser);
 
       res.status(200).json({ streakLength: updatedUser.streakLength });

--- a/server/db/schemas/UserSchema.js
+++ b/server/db/schemas/UserSchema.js
@@ -18,6 +18,7 @@ const userSchema = new Schema({
   bio: { type: String, default: '' },
   streakLength: { type: Number, default: 0 },
   streakLastUpdatedAt: { type: Date, default: null },
+  streakTimeZone: { type: String, default: 'UTC' },
   starredRooms: { type: [String], default: [] },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now },

--- a/server/db/userService.js
+++ b/server/db/userService.js
@@ -59,36 +59,62 @@ export async function unstarRoom(userId, roomId) {
   return user.toObject();
 }
 
-export async function updateUserStreak(userId) {
+export function validTimeZone(timeZone) {
+  if (typeof timeZone !== 'string' || timeZone.length > 100) return null;
+  try {
+    new Intl.DateTimeFormat('en', { timeZone }).format();
+    return timeZone;
+  } catch {
+    return null;
+  }
+}
+
+export function calendarDateKey(date, timeZone) {
+  const parts = new Intl.DateTimeFormat('en', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).formatToParts(new Date(date));
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function streakDayDifference(lastUpdatedAt, now, timeZone) {
+  const toDayNumber = (date) => {
+    const [year, month, day] = calendarDateKey(date, timeZone).split('-').map(Number);
+    return Date.UTC(year, month - 1, day) / (1000 * 60 * 60 * 24);
+  };
+  return toDayNumber(now) - toDayNumber(lastUpdatedAt);
+}
+
+export async function updateUserStreak(userId, { timeZone, now = new Date() } = {}) {
   const user = await User.findById(userId);
   if (!user) throw new Error('User not found');
 
-  const nowUTC = new Date();
-  // Round down to “date only” if needed
-  const today = Date.UTC(nowUTC.getUTCFullYear(), nowUTC.getUTCMonth(), nowUTC.getUTCDate());
+  const streakTimeZone = validTimeZone(timeZone) || validTimeZone(user.streakTimeZone) || 'UTC';
 
   if (!user.streakLastUpdatedAt) {
     // No streak yet; start one
     user.streakLength = 1;
-    user.streakLastUpdatedAt = nowUTC;
+    user.streakLastUpdatedAt = now;
   } else {
-    const last = new Date(user.streakLastUpdatedAt);
-    const lastUTC = Date.UTC(last.getUTCFullYear(), last.getUTCMonth(), last.getUTCDate());
-    const diffDays = (today - lastUTC) / (1000 * 60 * 60 * 24);
+    const diffDays = streakDayDifference(user.streakLastUpdatedAt, now, streakTimeZone);
 
     if (diffDays === 0) {
       // Already updated today, do nothing
     } else if (diffDays === 1) {
       // Consecutive day, increment
       user.streakLength += 1;
-      user.streakLastUpdatedAt = nowUTC;
+      user.streakLastUpdatedAt = now;
     } else {
       // Missed at least one day, reset
       user.streakLength = 1;
-      user.streakLastUpdatedAt = nowUTC;
+      user.streakLastUpdatedAt = now;
     }
   }
 
+  user.streakTimeZone = streakTimeZone;
   await user.save();
   return user.toObject();
 }

--- a/spec/localDateTimesSpec.js
+++ b/spec/localDateTimesSpec.js
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+const script = fs.readFileSync(new URL('../public/js/local-date-times.js', import.meta.url), 'utf8');
+
+function pageWith(body) {
+  const dom = new JSDOM(`<!doctype html><html lang="en"><body>${body}</body></html>`, {
+    runScripts: 'outside-only'
+  });
+  dom.window.eval(script);
+  return dom;
+}
+
+describe('local date-time formatting', () => {
+  it('formats an instant in the browser locale and timezone', () => {
+    const iso = '2026-01-01T01:00:00.000Z';
+    const dom = pageWith(
+      `<time datetime="${iso}" data-local-date-time data-date-style="medium" data-time-style="short">fallback</time>`
+    );
+
+    dom.window.formatLocalDateTimes();
+
+    const expected = new Intl.DateTimeFormat('en', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(new Date(iso));
+    expect(dom.window.document.querySelector('time').textContent).toBe(expected);
+  });
+
+  it('keeps translated text around the localized date', () => {
+    const dom = pageWith(
+      '<time datetime="2026-01-01T01:00:00.000Z" data-local-date-time data-date-template="Created on __DATE__">fallback</time>'
+    );
+
+    dom.window.formatLocalDateTimes();
+
+    expect(dom.window.document.querySelector('time').textContent).toMatch(/^Created on .+/);
+  });
+
+  it('leaves an invalid timestamp fallback unchanged', () => {
+    const dom = pageWith('<time datetime="not-a-date" data-local-date-time>fallback</time>');
+
+    dom.window.formatLocalDateTimes();
+
+    expect(dom.window.document.querySelector('time').textContent).toBe('fallback');
+  });
+});

--- a/spec/streakSpec.js
+++ b/spec/streakSpec.js
@@ -1,0 +1,57 @@
+import User from '../server/db/models/User.js';
+import {
+  calendarDateKey,
+  streakDayDifference,
+  updateUserStreak,
+  validTimeZone
+} from '../server/db/userService.js';
+import { localCalendarDateKey } from '../lib/streakHelper.js';
+
+describe('timezone-aware writing streaks', () => {
+  it('uses the browser calendar date for the client ping guard', () => {
+    const localDate = new Date(2026, 5, 22, 23, 30);
+    expect(localCalendarDateKey(localDate)).toBe('2026-06-22');
+  });
+
+  it('recognizes consecutive local days that straddle UTC inconsistently', () => {
+    const first = new Date('2026-06-21T00:00:00.000Z'); // June 20, 8 PM in New York
+    const second = new Date('2026-06-21T23:00:00.000Z'); // June 21, 7 PM in New York
+    const third = new Date('2026-06-23T00:00:00.000Z'); // June 22, 8 PM in New York
+
+    expect(streakDayDifference(first, second, 'America/New_York')).toBe(1);
+    expect(streakDayDifference(second, third, 'America/New_York')).toBe(1);
+  });
+
+  it('treats local midnight as a new day across daylight-saving changes', () => {
+    const before = new Date('2026-03-08T05:30:00.000Z'); // 12:30 AM EST
+    const after = new Date('2026-03-09T04:30:00.000Z'); // 12:30 AM EDT, 23 hours later
+
+    expect(streakDayDifference(before, after, 'America/New_York')).toBe(1);
+  });
+
+  it('updates and retains the timezone used for the streak', async () => {
+    const user = {
+      streakLength: 4,
+      streakLastUpdatedAt: new Date('2026-06-21T23:00:00.000Z'),
+      streakTimeZone: 'UTC',
+      save: jasmine.createSpy('save').and.resolveTo(),
+      toObject() { return this; }
+    };
+    spyOn(User, 'findById').and.resolveTo(user);
+
+    await updateUserStreak('user-id', {
+      timeZone: 'America/New_York',
+      now: new Date('2026-06-23T00:00:00.000Z')
+    });
+
+    expect(user.streakLength).toBe(5);
+    expect(user.streakTimeZone).toBe('America/New_York');
+    expect(user.save).toHaveBeenCalled();
+  });
+
+  it('validates IANA timezone input', () => {
+    expect(validTimeZone('Asia/Tokyo')).toBe('Asia/Tokyo');
+    expect(validTimeZone('not/a-timezone')).toBeNull();
+    expect(calendarDateKey('2026-01-01T01:00:00.000Z', 'America/New_York')).toBe('2025-12-31');
+  });
+});

--- a/views/archive/best-of-room.pug
+++ b/views/archive/best-of-room.pug
@@ -77,8 +77,16 @@ mixin renderBlockList(blocks)
               else
                 span.room-link= t('bestOf.labels.unknownRoom')
               - const _ui = (typeof uiLang === 'string' ? uiLang : 'en');
-              - const _date = new Date(block.createdAt).toLocaleString(_ui, { dateStyle: 'medium', timeStyle: 'short' });
-              |  #{t('bestOf.labels.onDate', { date: _date })}
+              - const _createdAt = new Date(block.createdAt);
+              - const _date = _createdAt.toLocaleString(_ui, { dateStyle: 'medium', timeStyle: 'short' });
+              = ' '
+              time(
+                datetime=_createdAt.toISOString()
+                data-local-date-time
+                data-date-style='medium'
+                data-time-style='short'
+                data-date-template=t('bestOf.labels.onDate', { date: '__DATE__' })
+              )= t('bestOf.labels.onDate', { date: _date })
             +translationAttribution(block)
             if block.contentHTML
               div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en'))!= block.contentHTML

--- a/views/archive/best-of.pug
+++ b/views/archive/best-of.pug
@@ -72,8 +72,16 @@ mixin renderBlockList(blocks)
               else
                 span.room-link= t('bestOf.labels.unknownRoom')
               - const _ui = (typeof uiLang === 'string' ? uiLang : 'en');
-              - const _date = new Date(block.createdAt).toLocaleString(_ui, { dateStyle: 'medium', timeStyle: 'short' });
-              |  #{t('bestOf.labels.onDate', { date: _date })}
+              - const _createdAt = new Date(block.createdAt);
+              - const _date = _createdAt.toLocaleString(_ui, { dateStyle: 'medium', timeStyle: 'short' });
+              = ' '
+              time(
+                datetime=_createdAt.toISOString()
+                data-local-date-time
+                data-date-style='medium'
+                data-time-style='short'
+                data-date-template=t('bestOf.labels.onDate', { date: '__DATE__' })
+              )= t('bestOf.labels.onDate', { date: _date })
             +translationAttribution(block)
             if block.contentHTML
               div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))!= block.contentHTML

--- a/views/archive/date.pug
+++ b/views/archive/date.pug
@@ -65,7 +65,16 @@ block content
                 a.user-profile-link(href=uiPath(`/users/${u}`))= block.creator
                 |  #{t('archive.date.labels.in')} 
                 a.room-link(href=uiPath(`/rooms/${block.roomId}`))= block.roomDisplayName || block.roomId || t('archive.date.labels.unknownRoom')
-                |  #{t('archive.date.labels.on', { datetime: formatDateTime(block.createdAt) })}
+                - const blockCreatedAt = new Date(block.createdAt)
+                - const blockCreatedAtFallback = formatDateTime(blockCreatedAt)
+                = ' '
+                time(
+                  datetime=blockCreatedAt.toISOString()
+                  data-local-date-time
+                  data-date-style='medium'
+                  data-time-style='short'
+                  data-date-template=t('archive.date.labels.on', { datetime: '__DATE__' })
+                )= t('archive.date.labels.on', { datetime: blockCreatedAtFallback })
               +translationAttribution(block)
               if block.contentHTML
                 div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en'))!= block.contentHTML

--- a/views/archive/index.pug
+++ b/views/archive/index.pug
@@ -28,7 +28,14 @@ block content
         li(lang=(b.lang || 'en'))
           a(href=`/rooms/${roomId}/blocks/${b._id}` lang=(b.lang || 'en'))= b.title
           span.meta(lang=(uiLang || 'en'))
-            | (#{b.voteCount} ★ • #{b.createdAt.toLocaleDateString(uiLang || undefined)})
+            | (#{b.voteCount} ★ •
+            = ' '
+            time(
+              datetime=b.createdAt.toISOString()
+              data-local-date-time
+              data-date-style='medium'
+            )= b.createdAt.toLocaleDateString(uiLang || undefined)
+            | )
     include ../partials/_pagination
     - const basePath = uiPath(`/rooms/${roomId}/index`)
     +pagination(

--- a/views/dashboard.pug
+++ b/views/dashboard.pug
@@ -53,7 +53,13 @@ block content
                 a(href=`/rooms/${draft.roomId}/blocks/${draft._id}/edit`)= draft.title
                 .draft-meta
                   - const updated = new Date(draft.updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-                  span= t('dashboard.drafts.updatedOn', { date: updated })
+                  time(
+                    datetime=new Date(draft.updatedAt).toISOString()
+                    data-local-date-time
+                    data-date-style='medium'
+                    data-time-style='short'
+                    data-date-template=t('dashboard.drafts.updatedOn', { date: '__DATE__' })
+                  )= t('dashboard.drafts.updatedOn', { date: updated })
                   if draft.visibility === 'unlisted'
                     span.draft-pill= t('dashboard.drafts.unlisted')
         else
@@ -68,7 +74,14 @@ block content
               li.activity-item
                 a(href=`/rooms/${activity.roomId}/blocks/${activity._id}`)= activity.title
                 - const formatted = new Date(activity.updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-                p= t('dashboard.activity.updatedOn', { date: formatted })
+                p
+                  time(
+                    datetime=new Date(activity.updatedAt).toISOString()
+                    data-local-date-time
+                    data-date-style='medium'
+                    data-time-style='short'
+                    data-date-template=t('dashboard.activity.updatedOn', { date: '__DATE__' })
+                  )= t('dashboard.activity.updatedOn', { date: formatted })
         else
           p= t('dashboard.activity.none')
         a(href=uiPath("/dashboard/blocks")).btn.stats-btn= t('dashboard.activity.viewAllBlocks')

--- a/views/home.pug
+++ b/views/home.pug
@@ -245,7 +245,15 @@ block content
                 a.user-profile-link(href=uiPath(`/users/${u}`))= block.creator
                 |  #{t('home.trendingBlocks.in')} 
                 a.room-link(href=uiPath(`/rooms/${block.roomId}`))= block.roomDisplayName || block.roomId || t('home.trendingBlocks.unknownRoom')
-                |  #{t('home.trendingBlocks.on')} #{new Date(block.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })}
+                |  #{t('home.trendingBlocks.on')}
+                = ' '
+                - const blockCreatedAt = new Date(block.createdAt)
+                time(
+                  datetime=blockCreatedAt.toISOString()
+                  data-local-date-time
+                  data-date-style='medium'
+                  data-time-style='short'
+                )= blockCreatedAt.toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
               +translationAttribution(block)
               if block.contentHTML
                 div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))!= block.contentHTML

--- a/views/partials/_block_list.pug
+++ b/views/partials/_block_list.pug
@@ -25,7 +25,13 @@ mixin blockList(blocks, period, label, room_id)
             - const u = encodeURIComponent(block.creator || '')
             a.user-profile-link(href=uiPath(`/users/${u}`))= block.creator
             |  #{t('blockList.on')} 
-            = new Date(block.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
+            - const blockCreatedAt = new Date(block.createdAt)
+            time(
+              datetime=blockCreatedAt.toISOString()
+              data-local-date-time
+              data-date-style='medium'
+              data-time-style='short'
+            )= blockCreatedAt.toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
 
           +translationAttribution(block)
 

--- a/views/partials/_common_scripts.pug
+++ b/views/partials/_common_scripts.pug
@@ -1,5 +1,6 @@
 script(src="/js/i18n-client.js")
 script(src="/js/i18n-t.js")
+script(src="/js/local-date-times.js")
 script(src="/js/theme.js")
 script(src="/js/notifications.js")
 script(src="/js/ui-lang-menu.js")

--- a/views/profile.pug
+++ b/views/profile.pug
@@ -28,7 +28,14 @@ block content
               li.activity-item
                 a(href=`/rooms/${activity.roomId}/blocks/${activity._id}`)= activity.title
                 - const formatted = new Date(activity.updatedAt).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
-                p= t('profile.activity.updatedOn', { date: formatted })
+                p
+                  time(
+                    datetime=new Date(activity.updatedAt).toISOString()
+                    data-local-date-time
+                    data-date-style='medium'
+                    data-time-style='short'
+                    data-date-template=t('profile.activity.updatedOn', { date: '__DATE__' })
+                  )= t('profile.activity.updatedOn', { date: formatted })
         else
           p= t('profile.activity.none')
 

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -114,7 +114,12 @@ block content
               if createdAtLabel
                 .meta-item
                   span.meta-label= t('blockView.labels.created')
-                  time(datetime=createdAt.toISOString())= createdAtLabel
+                  time(
+                    datetime=createdAt.toISOString()
+                    data-local-date-time
+                    data-date-style='medium'
+                    data-time-style='short'
+                  )= createdAtLabel
               if editorialRole
                 .meta-item
                   span.meta-label= t('blockView.editorial.roleLabel')

--- a/views/tags/tag.pug
+++ b/views/tags/tag.pug
@@ -53,7 +53,13 @@ block content
               |  #{t('tags.detail.blockInfo.inRoom')} 
               a.room-link(href=uiPath(`/rooms/${block.roomId}`))= block.roomDisplayName || block.roomId || t('tags.detail.blockInfo.unknownRoom')
               |  #{t('tags.detail.blockInfo.onDate')} 
-              = new Date(block.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
+              - const blockCreatedAt = new Date(block.createdAt)
+              time(
+                datetime=blockCreatedAt.toISOString()
+                data-local-date-time
+                data-date-style='medium'
+                data-time-style='short'
+              )= blockCreatedAt.toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
             +translationAttribution(block)
             if block.contentHTML
               div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en'))!= block.contentHTML

--- a/views/users/blocks.pug
+++ b/views/users/blocks.pug
@@ -39,7 +39,14 @@ block content
           li(lang=(b.lang || 'en'))
             a(href=`/rooms/${b.roomId}/blocks/${b._id}` lang=(b.lang || 'en'))= b.title
             span.meta(lang=(uiLang || 'en'))
-              | (#{b.voteCount} ★ • #{b.createdAt.toLocaleDateString(uiLang || undefined)})
+              | (#{b.voteCount} ★ •
+              = ' '
+              time(
+                datetime=b.createdAt.toISOString()
+                data-local-date-time
+                data-date-style='medium'
+              )= b.createdAt.toLocaleDateString(uiLang || undefined)
+              | )
     else
       p= t('userBlocks.empty')
 


### PR DESCRIPTION
## Summary

Use each visitor’s local timezone when displaying block timestamps and calculating daily writing streaks.

## Changes

- Format block creation and update timestamps in the browser’s timezone while preserving the selected UI language.
- Apply localized timestamps across block, archive, tag, home, dashboard, profile, and user-block views.
- Send the browser’s IANA timezone with streak updates and initial-content block creation.
- Calculate consecutive streak days using local calendar dates instead of UTC boundaries.
- Persist the timezone used for each user’s streak, with UTC as a fallback.
- Use a local calendar date for client-side streak ping suppression.
- Handle daylight-saving transitions correctly.
- Preserve server-rendered timestamp fallbacks when JavaScript is unavailable.

## Testing

- Added coverage for localized timestamp formatting and translated date templates.
- Added coverage for consecutive local days crossing UTC boundaries.
- Added coverage for daylight-saving transitions and timezone validation.
- Confirmed all 287 specs pass.
- Confirmed lint passes.
- Confirmed all Pug views compile.
- Confirmed the browser bundle builds successfully.