### PR TITLE
Add content-based post recommendations

### DIFF
--- a/i18n/ar/blockView.json
+++ b/i18n/ar/blockView.json
@@ -42,6 +42,13 @@
         "texture": "خلفية"
       }
     },
+    "recommendations": {
+      "eyebrow": "اكتشف شيئًا ذا صلة",
+      "heading": "تابع القراءة",
+      "description": "منشورات مترابطة حسب الموضوع واللغة وإشارات المجتمع.",
+      "roomLabel": "في {room}",
+      "byAuthor": "بقلم {author}"
+    },
     "comments": {
       "heading": "تعليقات",
       "count": "{count} التعليقات",

--- a/i18n/cs/blockView.json
+++ b/i18n/cs/blockView.json
@@ -14,6 +14,13 @@
       "expandSection": "Zobrazit dalších {count}", "collapseSection": "Zobrazit méně",
       "roleNames": { "pillar": "Hlavní průvodce", "companion": "Podrobný rozbor", "texture": "Souvislosti" }
     },
+    "recommendations": {
+      "eyebrow": "Objevte něco souvisejícího",
+      "heading": "Čtěte dál",
+      "description": "Příspěvky propojené tématem, jazykem a signály komunity.",
+      "roomLabel": "V místnosti {room}",
+      "byAuthor": "Autor: {author}"
+    },
     "comments": {
       "heading": "Komentáře", "count": "Počet komentářů: {count}",
       "empty": "Zatím nikdo neodpověděl. Komentáře se zde objeví, až začne konverzace.",

--- a/i18n/da/blockView.json
+++ b/i18n/da/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Baggrund"
       }
     },
+    "recommendations": {
+      "eyebrow": "Find noget relateret",
+      "heading": "Læs videre",
+      "description": "Indlæg forbundet via emne, sprog og signaler fra fællesskabet.",
+      "roomLabel": "I {room}",
+      "byAuthor": "Af {author}"
+    },
     "comments": {
       "heading": "Kommentarer",
       "count": "{count} kommentarer",

--- a/i18n/de/blockView.json
+++ b/i18n/de/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Hintergrund"
       }
     },
+    "recommendations": {
+      "eyebrow": "Entdecke etwas Ähnliches",
+      "heading": "Weiterlesen",
+      "description": "Beiträge, die durch Thema, Sprache und Signale der Community verbunden sind.",
+      "roomLabel": "In {room}",
+      "byAuthor": "Von {author}"
+    },
     "comments": {
       "heading": "Kommentare",
       "count": "{count} Kommentare",

--- a/i18n/el/blockView.json
+++ b/i18n/el/blockView.json
@@ -30,6 +30,13 @@
       "collapseSection": "Εμφάνιση λιγότερων",
       "roleNames": { "pillar": "Βασικός οδηγός", "companion": "Εμβάθυνση", "texture": "Υπόβαθρο" }
     },
+    "recommendations": {
+      "eyebrow": "Ανακαλύψτε κάτι σχετικό",
+      "heading": "Συνεχίστε την ανάγνωση",
+      "description": "Αναρτήσεις που συνδέονται βάσει θέματος, γλώσσας και σημάτων της κοινότητας.",
+      "roomLabel": "Στο {room}",
+      "byAuthor": "Από {author}"
+    },
     "comments": {
       "heading": "Σχόλια",
       "count": "{count} σχόλια",

--- a/i18n/en/blockView.json
+++ b/i18n/en/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Background"
       }
     },
+    "recommendations": {
+      "eyebrow": "Discover something related",
+      "heading": "Keep reading",
+      "description": "Posts connected by topic, language, and community signals.",
+      "roomLabel": "In {room}",
+      "byAuthor": "By {author}"
+    },
     "comments": {
       "heading": "Comments",
       "count": "{count} comments",

--- a/i18n/es/blockView.json
+++ b/i18n/es/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Contexto"
       }
     },
+    "recommendations": {
+      "eyebrow": "Descubre algo relacionado",
+      "heading": "Sigue leyendo",
+      "description": "Publicaciones conectadas por tema, idioma y señales de la comunidad.",
+      "roomLabel": "En {room}",
+      "byAuthor": "Por {author}"
+    },
     "comments": {
       "heading": "Comentarios",
       "count": "{count} comentarios",

--- a/i18n/fi/blockView.json
+++ b/i18n/fi/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Tausta"
       }
     },
+    "recommendations": {
+      "eyebrow": "Löydä aiheeseen liittyvää",
+      "heading": "Jatka lukemista",
+      "description": "Julkaisuja yhdistävät aihe, kieli ja yhteisön signaalit.",
+      "roomLabel": "Huoneessa {room}",
+      "byAuthor": "Kirjoittanut {author}"
+    },
     "comments": {
       "heading": "Kommentit",
       "count": "{count} kommenttia",

--- a/i18n/fr/blockView.json
+++ b/i18n/fr/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Contexte"
       }
     },
+    "recommendations": {
+      "eyebrow": "Découvrez un contenu similaire",
+      "heading": "Poursuivre la lecture",
+      "description": "Des publications reliées par leur sujet, leur langue et les signaux de la communauté.",
+      "roomLabel": "Dans {room}",
+      "byAuthor": "Par {author}"
+    },
     "comments": {
       "heading": "Commentaires",
       "count": "{count} commentaires",

--- a/i18n/he/blockView.json
+++ b/i18n/he/blockView.json
@@ -42,6 +42,13 @@
         "texture": "רקע"
       }
     },
+    "recommendations": {
+      "eyebrow": "גילוי תוכן קשור",
+      "heading": "המשך קריאה",
+      "description": "פוסטים המקושרים לפי נושא, שפה ואותות מהקהילה.",
+      "roomLabel": "ב־{room}",
+      "byAuthor": "מאת {author}"
+    },
     "comments": {
       "heading": "תגובות",
       "count": "{count} תגובות",

--- a/i18n/hi/blockView.json
+++ b/i18n/hi/blockView.json
@@ -42,6 +42,13 @@
         "texture": "पृष्ठभूमि"
       }
     },
+    "recommendations": {
+      "eyebrow": "कुछ संबंधित खोजें",
+      "heading": "पढ़ना जारी रखें",
+      "description": "विषय, भाषा और समुदाय के संकेतों से जुड़ी पोस्ट।",
+      "roomLabel": "{room} में",
+      "byAuthor": "{author} द्वारा"
+    },
     "comments": {
       "heading": "टिप्पणियाँ",
       "count": "{count} टिप्पणियाँ",

--- a/i18n/id/blockView.json
+++ b/i18n/id/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Latar belakang"
       }
     },
+    "recommendations": {
+      "eyebrow": "Temukan hal terkait",
+      "heading": "Lanjut membaca",
+      "description": "Postingan yang terhubung berdasarkan topik, bahasa, dan sinyal komunitas.",
+      "roomLabel": "Di {room}",
+      "byAuthor": "Oleh {author}"
+    },
     "comments": {
       "heading": "Komentar",
       "count": "{count} komentar",

--- a/i18n/it/blockView.json
+++ b/i18n/it/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Contesto"
       }
     },
+    "recommendations": {
+      "eyebrow": "Scopri qualcosa di correlato",
+      "heading": "Continua a leggere",
+      "description": "Post collegati per argomento, lingua e segnali della community.",
+      "roomLabel": "In {room}",
+      "byAuthor": "Di {author}"
+    },
     "comments": {
       "heading": "Commenti",
       "count": "{count} commenti",

--- a/i18n/ja/blockView.json
+++ b/i18n/ja/blockView.json
@@ -42,6 +42,13 @@
         "texture": "背景"
       }
     },
+    "recommendations": {
+      "eyebrow": "関連する投稿を見つける",
+      "heading": "続きを読む",
+      "description": "トピック、言語、コミュニティの反応に基づいて関連付けられた投稿です。",
+      "roomLabel": "{room} の投稿",
+      "byAuthor": "{author} による投稿"
+    },
     "comments": {
       "heading": "コメント",
       "count": "{count} 件のコメント",

--- a/i18n/ko/blockView.json
+++ b/i18n/ko/blockView.json
@@ -42,6 +42,13 @@
         "texture": "배경"
       }
     },
+    "recommendations": {
+      "eyebrow": "관련 글 둘러보기",
+      "heading": "계속 읽기",
+      "description": "주제, 언어 및 커뮤니티 신호를 바탕으로 연결된 게시물입니다.",
+      "roomLabel": "{room}에서",
+      "byAuthor": "{author} 작성"
+    },
     "comments": {
       "heading": "댓글",
       "count": "댓글 {count}개",

--- a/i18n/nl/blockView.json
+++ b/i18n/nl/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Achtergrond"
       }
     },
+    "recommendations": {
+      "eyebrow": "Ontdek iets verwants",
+      "heading": "Lees verder",
+      "description": "Berichten die verbonden zijn door onderwerp, taal en signalen uit de community.",
+      "roomLabel": "In {room}",
+      "byAuthor": "Door {author}"
+    },
     "comments": {
       "heading": "Opmerkingen",
       "count": "{count} opmerkingen",

--- a/i18n/no/blockView.json
+++ b/i18n/no/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Bakgrunn"
       }
     },
+    "recommendations": {
+      "eyebrow": "Finn noe relatert",
+      "heading": "Les videre",
+      "description": "Innlegg knyttet sammen av emne, språk og signaler fra fellesskapet.",
+      "roomLabel": "I {room}",
+      "byAuthor": "Av {author}"
+    },
     "comments": {
       "heading": "Kommentarer",
       "count": "{count} kommentarer",

--- a/i18n/pl/blockView.json
+++ b/i18n/pl/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Tło"
       }
     },
+    "recommendations": {
+      "eyebrow": "Odkryj coś powiązanego",
+      "heading": "Czytaj dalej",
+      "description": "Posty połączone na podstawie tematu, języka i sygnałów społeczności.",
+      "roomLabel": "W pokoju {room}",
+      "byAuthor": "Autor: {author}"
+    },
     "comments": {
       "heading": "Komentarze",
       "count": "Komentarze: {count}",

--- a/i18n/pt/blockView.json
+++ b/i18n/pt/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Contexto"
       }
     },
+    "recommendations": {
+      "eyebrow": "Descubra algo relacionado",
+      "heading": "Continue lendo",
+      "description": "Publicações conectadas por tema, idioma e sinais da comunidade.",
+      "roomLabel": "Em {room}",
+      "byAuthor": "Por {author}"
+    },
     "comments": {
       "heading": "Comentários",
       "count": "{count} comentários",

--- a/i18n/ru/blockView.json
+++ b/i18n/ru/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Фон"
       }
     },
+    "recommendations": {
+      "eyebrow": "Найдите что-нибудь по теме",
+      "heading": "Читайте дальше",
+      "description": "Публикации, связанные темой, языком и сигналами сообщества.",
+      "roomLabel": "В комнате {room}",
+      "byAuthor": "Автор: {author}"
+    },
     "comments": {
       "heading": "Комментарии",
       "count": "{count} комментариев",

--- a/i18n/sv/blockView.json
+++ b/i18n/sv/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Bakgrund"
       }
     },
+    "recommendations": {
+      "eyebrow": "Upptäck något relaterat",
+      "heading": "Läs vidare",
+      "description": "Inlägg som hör ihop genom ämne, språk och signaler från gemenskapen.",
+      "roomLabel": "I {room}",
+      "byAuthor": "Av {author}"
+    },
     "comments": {
       "heading": "Kommentarer",
       "count": "{count} kommentarer",

--- a/i18n/th/blockView.json
+++ b/i18n/th/blockView.json
@@ -42,6 +42,13 @@
         "texture": "พื้นหลัง"
       }
     },
+    "recommendations": {
+      "eyebrow": "ค้นพบเนื้อหาที่เกี่ยวข้อง",
+      "heading": "อ่านต่อ",
+      "description": "โพสต์ที่เชื่อมโยงกันตามหัวข้อ ภาษา และสัญญาณจากชุมชน",
+      "roomLabel": "ใน {room}",
+      "byAuthor": "โดย {author}"
+    },
     "comments": {
       "heading": "หมายเหตุ",
       "count": "{count} ความเห็น",

--- a/i18n/tr/blockView.json
+++ b/i18n/tr/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Arka plan"
       }
     },
+    "recommendations": {
+      "eyebrow": "İlgili bir şey keşfedin",
+      "heading": "Okumaya devam edin",
+      "description": "Konu, dil ve topluluk sinyalleriyle bağlantılı gönderiler.",
+      "roomLabel": "{room} içinde",
+      "byAuthor": "Yazan: {author}"
+    },
     "comments": {
       "heading": "Yorumlar",
       "count": "{count} yorum",

--- a/i18n/vi/blockView.json
+++ b/i18n/vi/blockView.json
@@ -42,6 +42,13 @@
         "texture": "Bối cảnh"
       }
     },
+    "recommendations": {
+      "eyebrow": "Khám phá nội dung liên quan",
+      "heading": "Đọc tiếp",
+      "description": "Các bài viết được kết nối theo chủ đề, ngôn ngữ và tín hiệu từ cộng đồng.",
+      "roomLabel": "Trong {room}",
+      "byAuthor": "Bởi {author}"
+    },
     "comments": {
       "heading": "Bình luận",
       "count": "Bình luận {count}",

--- a/i18n/zh/blockView.json
+++ b/i18n/zh/blockView.json
@@ -42,6 +42,13 @@
         "texture": "背景"
       }
     },
+    "recommendations": {
+      "eyebrow": "发现相关内容",
+      "heading": "继续阅读",
+      "description": "根据主题、语言和社区反馈关联的帖子。",
+      "roomLabel": "位于 {room}",
+      "byAuthor": "作者：{author}"
+    },
     "comments": {
       "heading": "评论",
       "count": "{count} 条评论",

--- a/public/css/block-view.css
+++ b/public/css/block-view.css
@@ -186,6 +186,210 @@ hr {
   white-space: unset;
 }
 
+.block-view-layout {
+  display: grid;
+  grid-template-areas:
+    "primary"
+    "recommendations"
+    "conversation";
+  min-width: 0;
+}
+
+.block-view-primary {
+  grid-area: primary;
+  min-width: 0;
+}
+
+.block-view-conversation {
+  grid-area: conversation;
+  min-width: 0;
+}
+
+.block-recommendations {
+  grid-area: recommendations;
+  min-width: 0;
+  margin: 2rem 0 0;
+  padding: 1.1rem;
+  border: 1px solid #d9e1ef;
+  border-radius: 18px;
+  background: linear-gradient(160deg, #f8fbff 0%, #fff 55%, #f8f6ff 100%);
+  box-shadow: 0 12px 34px rgba(23, 43, 77, 0.08);
+}
+
+.block-recommendations__header {
+  margin-bottom: 1rem;
+}
+
+.block-recommendations__eyebrow {
+  margin: 0 0 0.25rem;
+  color: #596a82;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.block-recommendations__heading {
+  margin: 0;
+  color: #202b3c;
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  line-height: 1.2;
+}
+
+.block-recommendations__description {
+  margin: 0.45rem 0 0;
+  color: #64748b;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.block-recommendations__list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: recommendations;
+}
+
+.block-recommendation {
+  min-width: 0;
+  counter-increment: recommendations;
+}
+
+.block-recommendation__link {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 0.95rem;
+  padding-inline-start: 2.7rem;
+  overflow: hidden;
+  border: 1px solid #e1e8f3;
+  border-radius: 14px;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.82);
+  text-decoration: none;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.block-recommendation__link::before {
+  content: counter(recommendations, decimal-leading-zero);
+  position: absolute;
+  top: 0.95rem;
+  inset-inline-start: 0.9rem;
+  color: #8492a6;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.block-recommendation__link:hover {
+  border-color: #a9c8f2;
+  box-shadow: 0 8px 20px rgba(23, 43, 77, 0.09);
+  transform: translateY(-1px);
+}
+
+.block-recommendation__link:focus-visible {
+  outline: 3px solid rgba(0, 123, 255, 0.28);
+  outline-offset: 3px;
+}
+
+.block-recommendation__room {
+  color: #52709a;
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.block-recommendation__title {
+  color: #202b3c;
+  font-size: 1rem;
+  font-weight: 750;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.block-recommendation__summary {
+  display: -webkit-box;
+  overflow: hidden;
+  color: #526176;
+  font-size: 0.88rem;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.block-recommendation__meta,
+.block-recommendation__tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem 0.65rem;
+}
+
+.block-recommendation__meta {
+  color: #738096;
+  font-size: 0.78rem;
+}
+
+.block-recommendation__tag {
+  max-width: 100%;
+  padding: 0.12rem 0.42rem;
+  overflow: hidden;
+  border-radius: 999px;
+  color: #49617f;
+  background: #edf3fb;
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (min-width: 720px) and (max-width: 1179px) {
+  .block-recommendations__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1180px) {
+  .block-view-layout--with-recommendations {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+    grid-template-areas:
+      "primary recommendations"
+      "conversation recommendations";
+    align-items: start;
+    gap: 0 2.25rem;
+  }
+
+  .block-recommendations {
+    position: sticky;
+    top: 5.75rem;
+    max-height: calc(100vh - 7rem);
+    margin-top: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+}
+
+@media (max-width: 380px) {
+  .block-recommendations {
+    padding: 0.85rem;
+    border-radius: 15px;
+  }
+
+  .block-recommendation__link {
+    padding: 0.8rem;
+    padding-inline-start: 2.35rem;
+  }
+
+  .block-recommendation__link::before {
+    top: 0.85rem;
+    inset-inline-start: 0.72rem;
+  }
+}
+
 .block-editorial-sequence {
   display: block;
   margin-top: 0.15rem;
@@ -620,7 +824,9 @@ html[data-theme="dark"] .block-title,
 html[data-theme="dark"] .block-author-name,
 html[data-theme="dark"] .block-editorial-card__title,
 html[data-theme="dark"] .block-editorial-section__title,
-html[data-theme="dark"] .block-editorial-card__cluster-name {
+html[data-theme="dark"] .block-editorial-card__cluster-name,
+html[data-theme="dark"] .block-recommendations__heading,
+html[data-theme="dark"] .block-recommendation__title {
   color: var(--text-color);
 }
 
@@ -640,7 +846,8 @@ html[data-theme="dark"] .expand-toggle:hover {
 }
 
 html[data-theme="dark"] .block-meta-card,
-html[data-theme="dark"] .block-editorial-card {
+html[data-theme="dark"] .block-editorial-card,
+html[data-theme="dark"] .block-recommendations {
   color: var(--text-color);
   background: var(--surface-bg);
   border-color: var(--border-color);
@@ -665,7 +872,11 @@ html[data-theme="dark"] .block-author-avatar--placeholder {
 html[data-theme="dark"] .meta-label,
 html[data-theme="dark"] .block-editorial-sequence,
 html[data-theme="dark"] .block-editorial-link__meta,
-html[data-theme="dark"] .description-label {
+html[data-theme="dark"] .description-label,
+html[data-theme="dark"] .block-recommendations__eyebrow,
+html[data-theme="dark"] .block-recommendations__description,
+html[data-theme="dark"] .block-recommendation__summary,
+html[data-theme="dark"] .block-recommendation__meta {
   color: var(--muted-text-color);
 }
 
@@ -683,6 +894,26 @@ html[data-theme="dark"] .block-editorial-link {
 html[data-theme="dark"] .block-editorial-link:hover {
   background: color-mix(in srgb, var(--highlight-color) 9%, var(--surface-raised-bg));
   border-color: color-mix(in srgb, var(--highlight-color) 50%, var(--border-color));
+}
+
+html[data-theme="dark"] .block-recommendation__link {
+  color: var(--text-color);
+  background: var(--surface-raised-bg);
+  border-color: var(--border-color);
+}
+
+html[data-theme="dark"] .block-recommendation__link:hover {
+  background: color-mix(in srgb, var(--highlight-color) 9%, var(--surface-raised-bg));
+  border-color: color-mix(in srgb, var(--highlight-color) 50%, var(--border-color));
+}
+
+html[data-theme="dark"] .block-recommendation__room {
+  color: var(--link-color);
+}
+
+html[data-theme="dark"] .block-recommendation__tag {
+  color: var(--text-color);
+  background: color-mix(in srgb, var(--highlight-color) 13%, var(--surface-raised-bg));
 }
 
 html[data-theme="dark"] .block-description-card {

--- a/server/db/blockRecommendationService.js
+++ b/server/db/blockRecommendationService.js
@@ -1,0 +1,105 @@
+import Block from './models/Block.js';
+import { publiclyVisibleBlockMatch } from './blockService.js';
+import * as cache from '../services/cache.js';
+import { extractSearchTerms, rankBlockRecommendations } from '../recommendations/contentRanker.js';
+
+const CANDIDATE_FIELDS = [
+  '_id',
+  'groupId',
+  'roomId',
+  'lang',
+  'title',
+  'description',
+  'content',
+  'tags',
+  'creator',
+  'voteCount',
+  'createdAt'
+].join(' ');
+
+const CANDIDATE_LIMIT = 80;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const CACHE_STALE_TTL_MS = 60 * 60 * 1000;
+
+function recommendationMatch(block) {
+  return publiclyVisibleBlockMatch({
+    _id: { $ne: block._id },
+    groupId: { $ne: block.groupId },
+    lang: block.lang || 'en'
+  });
+}
+
+function mergeCandidates(...groups) {
+  const byId = new Map();
+  for (const candidate of groups.flat()) {
+    if (candidate?._id) byId.set(String(candidate._id), candidate);
+  }
+  return Array.from(byId.values());
+}
+
+async function fetchCandidates(block) {
+  const baseMatch = recommendationMatch(block);
+  const searchTerms = extractSearchTerms(block);
+  const affinity = [];
+
+  if (block.roomId) affinity.push({ roomId: block.roomId });
+  if (Array.isArray(block.tags) && block.tags.length) affinity.push({ tags: { $in: block.tags } });
+
+  const textPromise = searchTerms.length
+    ? Block.find({
+        $and: [
+          baseMatch,
+          { $text: { $search: searchTerms.join(' ') } }
+        ]
+      })
+      .select({ ...Object.fromEntries(CANDIDATE_FIELDS.split(' ').map((field) => [field, 1])), textScore: { $meta: 'textScore' } })
+      .sort({ textScore: { $meta: 'textScore' }, voteCount: -1 })
+      .limit(CANDIDATE_LIMIT)
+      .lean()
+    : Promise.resolve([]);
+
+  const affinityPromise = Block.find({
+    $and: [
+      baseMatch,
+      affinity.length ? { $or: affinity } : {}
+    ]
+  })
+    .select(CANDIDATE_FIELDS)
+    .sort({ voteCount: -1, updatedAt: -1 })
+    .limit(CANDIDATE_LIMIT)
+    .lean();
+
+  const [textCandidates, affinityCandidates] = await Promise.all([textPromise, affinityPromise]);
+  return mergeCandidates(textCandidates, affinityCandidates);
+}
+
+function toViewModel(block) {
+  const description = String(block.description || '').replace(/\s+/g, ' ').trim();
+  return {
+    id: String(block._id),
+    roomId: block.roomId,
+    lang: block.lang || 'en',
+    title: block.title,
+    description: description.slice(0, 180),
+    tags: (block.tags || []).slice(0, 3),
+    creator: block.creator,
+    createdAt: block.createdAt,
+    score: block.recommendationScore
+  };
+}
+
+export async function getBlockRecommendations(block, options = {}) {
+  if (!block?._id) return [];
+  const limit = options.limit || 5;
+  const cacheKey = `block-recommendations-${block._id}-${new Date(block.updatedAt || 0).getTime()}-${limit}`;
+
+  return cache.get(
+    cacheKey,
+    async () => {
+      const candidates = await fetchCandidates(block);
+      return rankBlockRecommendations(block, candidates, { limit }).map(toViewModel);
+    },
+    [],
+    { ttlMs: CACHE_TTL_MS, jitterMs: 60 * 1000, staleTtlMs: CACHE_STALE_TTL_MS }
+  );
+}

--- a/server/recommendations/contentRanker.js
+++ b/server/recommendations/contentRanker.js
@@ -1,0 +1,164 @@
+const TOKEN_PATTERN = /[\p{L}\p{N}][\p{L}\p{N}'’_-]*/gu;
+const MAX_FIELD_TOKENS = 1200;
+
+// These are deliberately conservative. Keeping meaningful words is more useful
+// than aggressive, English-only stemming on a multilingual site.
+const STOP_WORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'been', 'but', 'by', 'for', 'from',
+  'had', 'has', 'have', 'he', 'her', 'his', 'i', 'if', 'in', 'into', 'is', 'it',
+  'its', 'me', 'my', 'not', 'of', 'on', 'or', 'our', 'she', 'so', 'than', 'that',
+  'the', 'their', 'them', 'there', 'they', 'this', 'to', 'up', 'us', 'was', 'we',
+  'were', 'what', 'when', 'where', 'which', 'who', 'will', 'with', 'you', 'your'
+]);
+
+const FIELD_WEIGHTS = Object.freeze({
+  title: 4,
+  tags: 5,
+  description: 2,
+  content: 1
+});
+
+function tokenize(value, limit = MAX_FIELD_TOKENS) {
+  const matches = String(value || '').toLocaleLowerCase().match(TOKEN_PATTERN) || [];
+  return matches
+    .filter((token) => token.length > 1 && !STOP_WORDS.has(token))
+    .slice(0, limit);
+}
+
+function weightedTermFrequency(block) {
+  const frequencies = new Map();
+  const fields = {
+    title: block?.title,
+    tags: Array.isArray(block?.tags) ? block.tags.join(' ') : '',
+    description: block?.description,
+    content: block?.content
+  };
+
+  for (const [field, value] of Object.entries(fields)) {
+    for (const token of tokenize(value)) {
+      frequencies.set(token, (frequencies.get(token) || 0) + FIELD_WEIGHTS[field]);
+    }
+  }
+
+  return frequencies;
+}
+
+function documentFrequencies(termMaps) {
+  const frequencies = new Map();
+  for (const terms of termMaps) {
+    for (const token of terms.keys()) {
+      frequencies.set(token, (frequencies.get(token) || 0) + 1);
+    }
+  }
+  return frequencies;
+}
+
+function vectorize(terms, frequencies, documentCount) {
+  const vector = new Map();
+  for (const [token, frequency] of terms) {
+    const inverseDocumentFrequency = Math.log((documentCount + 1) / ((frequencies.get(token) || 0) + 1)) + 1;
+    vector.set(token, (1 + Math.log(frequency)) * inverseDocumentFrequency);
+  }
+  return vector;
+}
+
+function cosineSimilarity(a, b) {
+  let dotProduct = 0;
+  let magnitudeA = 0;
+  let magnitudeB = 0;
+
+  for (const value of a.values()) magnitudeA += value * value;
+  for (const value of b.values()) magnitudeB += value * value;
+  if (!magnitudeA || !magnitudeB) return 0;
+
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+  for (const [token, value] of smaller) {
+    dotProduct += value * (larger.get(token) || 0);
+  }
+
+  return dotProduct / (Math.sqrt(magnitudeA) * Math.sqrt(magnitudeB));
+}
+
+function normalizedTags(block) {
+  return new Set((block?.tags || []).map((tag) => String(tag).trim().toLocaleLowerCase()).filter(Boolean));
+}
+
+function tagSimilarity(a, b) {
+  const aTags = normalizedTags(a);
+  const bTags = normalizedTags(b);
+  if (!aTags.size || !bTags.size) return 0;
+  const overlap = Array.from(aTags).filter((tag) => bTags.has(tag)).length;
+  return overlap / new Set([...aTags, ...bTags]).size;
+}
+
+function freshnessScore(createdAt, now) {
+  const timestamp = new Date(createdAt || 0).getTime();
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 0;
+  const ageInDays = Math.max(0, (now.getTime() - timestamp) / 86400000);
+  return Math.exp(-ageInDays / 730);
+}
+
+function qualityScore(voteCount) {
+  const votes = Number(voteCount) || 0;
+  return 1 / (1 + Math.exp(-votes / 5));
+}
+
+function idOf(block) {
+  return block?._id ? String(block._id) : null;
+}
+
+function groupOf(block) {
+  return block?.groupId ? String(block.groupId) : idOf(block);
+}
+
+export function extractSearchTerms(block, limit = 14) {
+  return Array.from(weightedTermFrequency(block).entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([token]) => token);
+}
+
+export function rankBlockRecommendations(source, candidates, options = {}) {
+  const limit = options.limit || 5;
+  const now = options.now || new Date();
+  const sourceId = idOf(source);
+  const sourceGroup = groupOf(source);
+  const seenGroups = new Set();
+  const eligible = [];
+
+  for (const candidate of candidates || []) {
+    const candidateId = idOf(candidate);
+    const candidateGroup = groupOf(candidate);
+    if (!candidateId || candidateId === sourceId || candidateGroup === sourceGroup || seenGroups.has(candidateGroup)) {
+      continue;
+    }
+    seenGroups.add(candidateGroup);
+    eligible.push(candidate);
+  }
+
+  if (!eligible.length) return [];
+
+  const termMaps = [source, ...eligible].map(weightedTermFrequency);
+  const frequencies = documentFrequencies(termMaps);
+  const vectors = termMaps.map((terms) => vectorize(terms, frequencies, termMaps.length));
+  const sourceVector = vectors[0];
+
+  return eligible
+    .map((candidate, index) => {
+      const semantic = cosineSimilarity(sourceVector, vectors[index + 1]);
+      const tags = tagSimilarity(source, candidate);
+      const sameRoom = source?.roomId && source.roomId === candidate.roomId ? 1 : 0;
+      const freshness = freshnessScore(candidate.createdAt, now);
+      const quality = qualityScore(candidate.voteCount);
+      const score = semantic * 0.76 + tags * 0.12 + sameRoom * 0.06 + freshness * 0.03 + quality * 0.03;
+
+      return { candidate, score, semantic, tags };
+    })
+    .filter((result) => result.semantic > 0 || result.tags > 0 || result.candidate.roomId === source?.roomId)
+    .sort((a, b) => b.score - a.score || new Date(b.candidate.createdAt || 0) - new Date(a.candidate.createdAt || 0))
+    .slice(0, limit)
+    .map(({ candidate, score }) => ({
+      ...candidate,
+      recommendationScore: score
+    }));
+}

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -5,6 +5,7 @@ import {
   getPublicTranslationByGroupAndLang
 } from '../db/blockService.js';
 import { getBlockEditorialContext } from '../db/blockEditorialContextService.js';
+import { getBlockRecommendations } from '../db/blockRecommendationService.js';
 import {
   getCommentsForBlockView,
   getFocusedCommentThreadForBlockView
@@ -74,7 +75,22 @@ router.get(
       const descriptionHTML = renderMarkdownContent(block.description, { emptyHtml: '' });
       const translations = await getPublicTranslations(block.groupId);
 
-      const [reactionCounts, commentsData, focusedCommentData, dbUser, authorUser, editorialContext] = await Promise.all([
+      const recommendationsPromise = getBlockRecommendations(block, { limit: 5 })
+        .catch((error) => {
+          console.error(`Error loading recommendations for block ${block_id}:`, error);
+          return [];
+        });
+
+      const [
+        reactionCounts,
+        commentsData,
+        focusedCommentData,
+        dbUser,
+        authorUser,
+        editorialContext,
+        roomMetadata,
+        recommendations
+      ] = await Promise.all([
         getReactionCounts(block_id),
         getCommentsForBlockView({
           blockId: block_id,
@@ -99,7 +115,9 @@ router.get(
         block.creator && block.creator !== 'anonymous'
           ? findUserByUsername(block.creator)
           : Promise.resolve(null),
-        getBlockEditorialContext(block)
+        getBlockEditorialContext(block),
+        getRoomMetadata(room_id, uiLang || 'en'),
+        recommendationsPromise
       ]);
 
       let userReactions = [];
@@ -112,9 +130,29 @@ router.get(
         block.userVote = userVote;
       }
 
-      // Room metadata localized (match your editor approach)
-      const roomMetadata = await getRoomMetadata(room_id, uiLang || 'en');
       const roomName = roomMetadata?.displayName || roomMetadata?.name || room_id;
+      const recommendationRoomIds = Array.from(new Set(
+        recommendations.map((recommendation) => recommendation.roomId)
+      ));
+      const recommendationRoomNames = new Map(await Promise.all(
+        recommendationRoomIds.map(async (recommendationRoomId) => {
+          try {
+            const metadata = recommendationRoomId === room_id
+              ? roomMetadata
+              : await getRoomMetadata(recommendationRoomId, uiLang || 'en');
+            return [
+              recommendationRoomId,
+              metadata?.displayName || metadata?.name || recommendationRoomId
+            ];
+          } catch {
+            return [recommendationRoomId, recommendationRoomId];
+          }
+        })
+      ));
+      const recommendationItems = recommendations.map((recommendation) => ({
+        ...recommendation,
+        roomName: recommendationRoomNames.get(recommendation.roomId) || recommendation.roomId
+      }));
       const authorProfile = block.creator
         ? {
           username: block.creator,
@@ -143,6 +181,7 @@ router.get(
         roomName,
         authorProfile,
         block,
+        recommendations: recommendationItems,
         editorialContext,
         descriptionHTML,
         title,

--- a/spec/contentRankerSpec.js
+++ b/spec/contentRankerSpec.js
@@ -1,0 +1,85 @@
+import {
+  extractSearchTerms,
+  rankBlockRecommendations
+} from '../server/recommendations/contentRanker.js';
+
+describe('content recommendation ranker', () => {
+  const source = {
+    _id: 'source',
+    groupId: 'source-group',
+    roomId: 'gardening',
+    title: 'Growing tomatoes in small city gardens',
+    description: 'Container gardening techniques for healthy tomato plants.',
+    content: 'Choose rich soil and give tomato roots enough water and sunlight.',
+    tags: ['tomatoes', 'urban gardening'],
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  };
+
+  it('extracts weighted title and tag terms for candidate generation', () => {
+    const terms = extractSearchTerms(source, 6);
+
+    expect(terms).toContain('tomatoes');
+    expect(terms).toContain('gardening');
+    expect(terms).not.toContain('in');
+  });
+
+  it('prefers a semantic cross-room connection over an unrelated same-room post', () => {
+    const candidates = [
+      {
+        _id: 'unrelated',
+        groupId: 'unrelated-group',
+        roomId: 'gardening',
+        title: 'Building a wooden garden gate',
+        description: 'A carpentry project with hinges and cedar boards.',
+        content: 'Measure lumber, cut the frame, and attach the hardware.',
+        tags: ['woodworking'],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        voteCount: 10
+      },
+      {
+        _id: 'semantic',
+        groupId: 'semantic-group',
+        roomId: 'food',
+        title: 'Why container tomatoes need deep soil',
+        description: 'Healthy roots, watering, and sunlight for urban tomato plants.',
+        content: 'Container gardening succeeds when tomato roots have space and rich soil.',
+        tags: ['tomatoes', 'containers'],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        voteCount: 0
+      }
+    ];
+
+    const ranked = rankBlockRecommendations(source, candidates, {
+      limit: 2,
+      now: new Date('2026-01-02T00:00:00.000Z')
+    });
+
+    expect(String(ranked[0]._id)).toBe('semantic');
+  });
+
+  it('excludes the source translation group and deduplicates candidate groups', () => {
+    const candidates = [
+      { ...source, _id: 'source-translation', lang: 'es' },
+      { ...source, _id: 'first', groupId: 'shared-group', title: 'Tomato soil basics' },
+      { ...source, _id: 'second', groupId: 'shared-group', title: 'More tomato soil basics' }
+    ];
+
+    const ranked = rankBlockRecommendations(source, candidates, { limit: 5 });
+
+    expect(ranked.map((block) => String(block._id))).toEqual(['first']);
+  });
+
+  it('does not recommend unrelated cross-room filler', () => {
+    const ranked = rankBlockRecommendations(source, [{
+      _id: 'filler',
+      groupId: 'filler-group',
+      roomId: 'music',
+      title: 'Modal harmony for jazz piano',
+      description: 'Voicings and improvisation.',
+      content: 'Practice scales over chord changes.',
+      tags: ['music']
+    }]);
+
+    expect(ranked).toEqual([]);
+  });
+});

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -143,46 +143,75 @@ block content
               i.fa.fa-flag(aria-hidden="true")
               | #{t('blockView.buttons.flagContent')}
 
-    // Description block, read-only style
-    if descriptionHTML
-      .block-description-card(lang=lang dir=blockDir)
-        span.description-label= t('blockView.description.label')
-        .description-body.collapsed
-          div#description-view!= descriptionHTML
-        .expand-toggle
-          span(
-            data-expand-label=t('blockView.description.expand')
-            data-collapse-label=t('blockView.description.collapse')
-          )= t('blockView.description.expand')
+    .block-view-layout(class=recommendations && recommendations.length ? 'block-view-layout--with-recommendations' : '')
+      .block-view-primary
+        // Description block, read-only style
+        if descriptionHTML
+          .block-description-card(lang=lang dir=blockDir)
+            span.description-label= t('blockView.description.label')
+            .description-body.collapsed
+              div#description-view!= descriptionHTML
+            .expand-toggle
+              span(
+                data-expand-label=t('blockView.description.expand')
+                data-collapse-label=t('blockView.description.collapse')
+              )= t('blockView.description.expand')
 
-    if editorialContext
-      aside.block-editorial-card(lang=(uiLang || 'en'))
-        .block-editorial-card__header
-          h2.block-editorial-card__title= t('blockView.editorial.heading')
-          if editorialCluster && editorialCluster.label
-            p.block-editorial-card__cluster
-              span.meta-label= t('blockView.editorial.clusterLabel')
-              span.block-editorial-card__cluster-name= editorialCluster.label
+        if editorialContext
+          aside.block-editorial-card(lang=(uiLang || 'en'))
+            .block-editorial-card__header
+              h2.block-editorial-card__title= t('blockView.editorial.heading')
+              if editorialCluster && editorialCluster.label
+                p.block-editorial-card__cluster
+                  span.meta-label= t('blockView.editorial.clusterLabel')
+                  span.block-editorial-card__cluster-name= editorialCluster.label
 
-        if editorialPrimaryPillar
-          section.block-editorial-section
-            h3.block-editorial-section__title= t('blockView.editorial.primaryPillarHeading')
-            +editorialLink(editorialPrimaryPillar)
+            if editorialPrimaryPillar
+              section.block-editorial-section
+                h3.block-editorial-section__title= t('blockView.editorial.primaryPillarHeading')
+                +editorialLink(editorialPrimaryPillar)
 
-        if editorialRelated.length
-          +editorialListSection('blockView.editorial.relatedHeading', editorialRelated, editorialPreviewCount)
+            if editorialRelated.length
+              +editorialListSection('blockView.editorial.relatedHeading', editorialRelated, editorialPreviewCount)
 
-        if editorialCluster && editorialCluster.nearby && editorialCluster.nearby.length
-          +editorialListSection('blockView.editorial.clusterHeading', editorialCluster.nearby, editorialPreviewCount)
+            if editorialCluster && editorialCluster.nearby && editorialCluster.nearby.length
+              +editorialListSection('blockView.editorial.clusterHeading', editorialCluster.nearby, editorialPreviewCount)
 
-    // The main content, already rendered to HTML on the server
-    if block.contentHTML
-      .block-content(lang=lang dir=blockDir)
-        != block.contentHTML
-    include ../partials/_reaction_bar
-    hr
-    +tagSection(block.tags, false)
-    include ../partials/_comments_section
+        // The main content, already rendered to HTML on the server
+        if block.contentHTML
+          .block-content(lang=lang dir=blockDir)
+            != block.contentHTML
+        include ../partials/_reaction_bar
+        hr
+        +tagSection(block.tags, false)
+
+      if recommendations && recommendations.length
+        aside.block-recommendations(aria-labelledby='recommendations-heading' lang=(uiLang || 'en'))
+          .block-recommendations__header
+            p.block-recommendations__eyebrow= t('blockView.recommendations.eyebrow')
+            h2#recommendations-heading.block-recommendations__heading= t('blockView.recommendations.heading')
+            p.block-recommendations__description= t('blockView.recommendations.description')
+          ol.block-recommendations__list
+            each recommendation in recommendations
+              - const recommendationDate = recommendation.createdAt ? new Date(recommendation.createdAt) : null;
+              li.block-recommendation
+                a.block-recommendation__link(href=uiPath(`/rooms/${recommendation.roomId}/blocks/${recommendation.id}`))
+                  span.block-recommendation__room= t('blockView.recommendations.roomLabel', { room: recommendation.roomName })
+                  span.block-recommendation__title(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.title
+                  if recommendation.description
+                    span.block-recommendation__summary(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.description
+                  span.block-recommendation__meta
+                    if recommendation.creator
+                      span= t('blockView.recommendations.byAuthor', { author: recommendation.creator })
+                    if recommendationDate
+                      time(datetime=recommendationDate.toISOString())= recommendationDate.toLocaleDateString(uiLang || undefined, { dateStyle: 'medium' })
+                  if recommendation.tags && recommendation.tags.length
+                    span.block-recommendation__tags(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))
+                      each tag in recommendation.tags
+                        span.block-recommendation__tag= tag
+
+      .block-view-conversation
+        include ../partials/_comments_section
 
   // Reuse your login modal partial if needed
   include ../partials/_login_modal


### PR DESCRIPTION
## Summary

- Add a content-based recommendation engine for post-view pages.
- Generate candidates using text search, shared tags, and room affinity.
- Rank candidates using weighted TF-IDF similarity, tags, room, freshness, and votes.
- Cache recommendation results with stale background refresh.
- Add a responsive recommendation rail with mobile, dark-mode, RTL, and accessibility support.
- Translate the recommendation UI across all supported locales.

## Validation

- 294 specs passing
- ESLint passing
- Pug template compilation verified
- Translation structure and interpolation placeholders validated
- Tested against live post data