### PR TITLE
Polish post reading guides and recommendation sidebar

### DIFF
--- a/public/css/block-view.css
+++ b/public/css/block-view.css
@@ -366,10 +366,13 @@ hr {
   .block-recommendations {
     position: sticky;
     top: 5.75rem;
-    max-height: calc(100vh - 7rem);
+    box-sizing: border-box;
+    max-height: calc(100vh - 6.5rem);
+    max-height: calc(100dvh - 6.5rem);
     margin-top: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scrollbar-gutter: stable;
   }
 }
 
@@ -402,20 +405,80 @@ hr {
   border: 1px solid #d9e1ef;
   border-radius: 16px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(246, 249, 253, 0.95));
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.block-editorial-card:has(> .block-editorial-details > .block-editorial-card__summary:hover),
+.block-editorial-card:has(> .block-editorial-details > .block-editorial-card__summary:focus-visible) {
+  border-color: color-mix(in srgb, var(--highlight-color) 32%, #d9e1ef);
+  box-shadow: 0 10px 28px rgba(23, 43, 77, 0.09);
 }
 
 .block-editorial-card__header {
   display: flex;
+  min-width: 0;
+  flex: 1;
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
   gap: 0.75rem 1rem;
-  margin-bottom: 0.9rem;
+}
+
+.block-editorial-card__summary {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: -1rem -1.1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 15px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.block-editorial-card__summary::-webkit-details-marker {
+  display: none;
+}
+
+.block-editorial-card__summary::after {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  flex: 0 0 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: #6b7a90;
+  transform: rotate(45deg) translate(-0.1rem, -0.1rem);
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.block-editorial-details[open] > .block-editorial-card__summary::after {
+  transform: rotate(225deg) translate(-0.1rem, -0.1rem);
+}
+
+.block-editorial-card__summary:hover .block-editorial-card__title,
+.block-editorial-card__summary:hover::after {
+  color: color-mix(in srgb, var(--highlight-color) 78%, #334155);
+}
+
+.block-editorial-card__summary:focus-visible {
+  outline: 3px solid rgba(0, 123, 255, 0.28);
+  outline-offset: 3px;
+}
+
+.block-editorial-card__body {
+  margin-top: 1rem;
 }
 
 .block-editorial-card__title,
 .block-editorial-section__title {
   margin: 0;
+}
+
+.block-editorial-card__title {
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+  transition: color 160ms ease;
 }
 
 .block-editorial-card__cluster {
@@ -894,6 +957,21 @@ html[data-theme="dark"] .block-editorial-link {
 html[data-theme="dark"] .block-editorial-link:hover {
   background: color-mix(in srgb, var(--highlight-color) 9%, var(--surface-raised-bg));
   border-color: color-mix(in srgb, var(--highlight-color) 50%, var(--border-color));
+}
+
+html[data-theme="dark"] .block-editorial-card:has(> .block-editorial-details > .block-editorial-card__summary:hover),
+html[data-theme="dark"] .block-editorial-card:has(> .block-editorial-details > .block-editorial-card__summary:focus-visible) {
+  border-color: color-mix(in srgb, var(--highlight-color) 42%, var(--border-color));
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.42);
+}
+
+html[data-theme="dark"] .block-editorial-card__summary::after {
+  color: var(--muted-text-color);
+}
+
+html[data-theme="dark"] .block-editorial-card__summary:hover .block-editorial-card__title,
+html[data-theme="dark"] .block-editorial-card__summary:hover::after {
+  color: var(--link-color);
 }
 
 html[data-theme="dark"] .block-recommendation__link {

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -48,6 +48,8 @@ block content
   - const editorialCluster = editorialContext && editorialContext.cluster ? editorialContext.cluster : null;
   - const editorialPrimaryPillar = editorialContext && editorialContext.primaryPillar ? editorialContext.primaryPillar : null;
   - const editorialRelated = editorialContext && editorialContext.related ? editorialContext.related : [];
+  - const editorialClusterNearby = editorialCluster && editorialCluster.nearby ? editorialCluster.nearby : [];
+  - const hasEditorialGuideContent = Boolean(editorialPrimaryPillar || editorialRelated.length || editorialClusterNearby.length);
   - const editorialPreviewCount = 4;
   - const getEditorialPreviewItems = (items, previewCount = editorialPreviewCount) => Array.isArray(items) ? items.slice(0, previewCount) : [];
   - const getEditorialOverflowItems = (items, previewCount = editorialPreviewCount) => Array.isArray(items) ? items.slice(previewCount) : [];
@@ -78,6 +80,13 @@ block content
           summary.block-editorial-more__summary
             span.block-editorial-more__label= t('blockView.editorial.expandSection', { count: overflowItems.length })
           +editorialList(overflowItems)
+  mixin editorialHeader()
+    span.block-editorial-card__header
+      span.block-editorial-card__title(role='heading' aria-level='2')= t('blockView.editorial.heading')
+      if editorialCluster && editorialCluster.label
+        span.block-editorial-card__cluster
+          span.meta-label= t('blockView.editorial.clusterLabel')
+          span.block-editorial-card__cluster-name= editorialCluster.label
   include ../partials/_tag_section
   #block-page
     .block-header
@@ -159,23 +168,24 @@ block content
 
         if editorialContext
           aside.block-editorial-card(lang=(uiLang || 'en'))
-            .block-editorial-card__header
-              h2.block-editorial-card__title= t('blockView.editorial.heading')
-              if editorialCluster && editorialCluster.label
-                p.block-editorial-card__cluster
-                  span.meta-label= t('blockView.editorial.clusterLabel')
-                  span.block-editorial-card__cluster-name= editorialCluster.label
+            if hasEditorialGuideContent
+              details.block-editorial-details
+                summary.block-editorial-card__summary
+                  +editorialHeader()
 
-            if editorialPrimaryPillar
-              section.block-editorial-section
-                h3.block-editorial-section__title= t('blockView.editorial.primaryPillarHeading')
-                +editorialLink(editorialPrimaryPillar)
+                .block-editorial-card__body
+                  if editorialPrimaryPillar
+                    section.block-editorial-section
+                      h3.block-editorial-section__title= t('blockView.editorial.primaryPillarHeading')
+                      +editorialLink(editorialPrimaryPillar)
 
-            if editorialRelated.length
-              +editorialListSection('blockView.editorial.relatedHeading', editorialRelated, editorialPreviewCount)
+                  if editorialRelated.length
+                    +editorialListSection('blockView.editorial.relatedHeading', editorialRelated, editorialPreviewCount)
 
-            if editorialCluster && editorialCluster.nearby && editorialCluster.nearby.length
-              +editorialListSection('blockView.editorial.clusterHeading', editorialCluster.nearby, editorialPreviewCount)
+                  if editorialClusterNearby.length
+                    +editorialListSection('blockView.editorial.clusterHeading', editorialClusterNearby, editorialPreviewCount)
+            else
+              +editorialHeader()
 
         // The main content, already rendered to HTML on the server
         if block.contentHTML


### PR DESCRIPTION
## Summary

- Collapse post reading guides by default to reduce visual clutter.
- Use native, accessible disclosure controls for expanding guide links.
- Keep guides without link content static.
- Fix the recommendation sidebar’s viewport height calculation so its bottom padding and border remain reachable.
- Replace the inset reading-guide hover shading with subtle full-card border, shadow, title, and chevron feedback.
- Support the updated interactions in both light and dark themes.

## Validation

- 294 specs passing
- ESLint passing
- Pug template compilation verified
- `git diff --check` passing