### PR TITLE
Fix duplicate AuthSession expiration index warning

### DIFF
--- a/server/db/schemas/AuthSessionSchema.js
+++ b/server/db/schemas/AuthSessionSchema.js
@@ -8,7 +8,7 @@ const authSessionSchema = new Schema({
   createdAt: { type: Date, default: Date.now },
   lastSeenAt: { type: Date, default: Date.now },
   expiresAt: { type: Date, required: true, index: true },
-  absoluteExpiresAt: { type: Date, required: true, index: true },
+  absoluteExpiresAt: { type: Date, required: true },
   revokedAt: { type: Date, default: null, index: true },
 }, {
   toObject: {


### PR DESCRIPTION
## Summary

- Remove the redundant field-level index from `absoluteExpiresAt`
- Retain the schema-level TTL index with `expireAfterSeconds: 0`
- Eliminate the duplicate Mongoose schema index warning

## Testing

- ESLint passes
- Auth-session specs pass: 3 specs, 0 failures