### PR TITLE
Load post recommendations without blocking initial page render

### DIFF
--- a/public/css/block-view.css
+++ b/public/css/block-view.css
@@ -220,6 +220,40 @@ hr {
   margin-bottom: 1rem;
 }
 
+.block-recommendations--loading {
+  overflow: hidden;
+}
+
+.block-recommendations__skeleton {
+  height: 5.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 12px;
+  background: linear-gradient(90deg, #e8edf5 25%, #f5f7fb 50%, #e8edf5 75%);
+  background-size: 200% 100%;
+  animation: recommendation-shimmer 1.4s ease-in-out infinite;
+}
+
+.block-recommendations__skeleton--heading {
+  width: 62%;
+  height: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.block-recommendations__skeleton:last-child {
+  margin-bottom: 0;
+}
+
+@keyframes recommendation-shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .block-recommendations__skeleton {
+    animation: none;
+  }
+}
+
 .block-recommendations__eyebrow {
   margin: 0 0 0.25rem;
   color: #596a82;
@@ -992,6 +1026,16 @@ html[data-theme="dark"] .block-recommendation__room {
 html[data-theme="dark"] .block-recommendation__tag {
   color: var(--text-color);
   background: color-mix(in srgb, var(--highlight-color) 13%, var(--surface-raised-bg));
+}
+
+html[data-theme="dark"] .block-recommendations__skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface-raised-bg) 25%,
+    color-mix(in srgb, var(--highlight-color) 9%, var(--surface-raised-bg)) 50%,
+    var(--surface-raised-bg) 75%
+  );
+  background-size: 200% 100%;
 }
 
 html[data-theme="dark"] .block-description-card {

--- a/public/js/block-recommendations.js
+++ b/public/js/block-recommendations.js
@@ -1,0 +1,36 @@
+(function () {
+  async function hydrateRecommendations() {
+    const loading = document.querySelector('[data-recommendations-loading]');
+    if (!loading) return;
+
+    try {
+      const response = await fetch(loading.dataset.endpoint, {
+        credentials: 'same-origin',
+        headers: { Accept: 'text/html' }
+      });
+
+      if (response.status === 204) {
+        const layout = loading.closest('.block-view-layout');
+        loading.remove();
+        layout?.classList.remove('block-view-layout--with-recommendations');
+        return;
+      }
+
+      if (!response.ok) throw new Error(`Recommendation request failed with ${response.status}`);
+
+      const html = await response.text();
+      if (html.trim()) loading.outerHTML = html;
+    } catch (error) {
+      console.error('Unable to load recommendations:', error);
+      const layout = loading.closest('.block-view-layout');
+      loading.remove();
+      layout?.classList.remove('block-view-layout--with-recommendations');
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', hydrateRecommendations, { once: true });
+  } else {
+    hydrateRecommendations();
+  }
+})();

--- a/server/db/blockRecommendationService.js
+++ b/server/db/blockRecommendationService.js
@@ -21,6 +21,19 @@ const CANDIDATE_LIMIT = 80;
 const CACHE_TTL_MS = 10 * 60 * 1000;
 const CACHE_STALE_TTL_MS = 60 * 60 * 1000;
 
+function recommendationCacheKey(block, limit) {
+  return `block-recommendations-${block._id}-${new Date(block.updatedAt || 0).getTime()}-${limit}`;
+}
+
+async function calculateBlockRecommendations(block, limit) {
+  const candidates = await fetchCandidates(block);
+  return rankBlockRecommendations(block, candidates, { limit }).map(toViewModel);
+}
+
+function cacheOptions() {
+  return { ttlMs: CACHE_TTL_MS, jitterMs: 60 * 1000, staleTtlMs: CACHE_STALE_TTL_MS };
+}
+
 function recommendationMatch(block) {
   return publiclyVisibleBlockMatch({
     _id: { $ne: block._id },
@@ -91,15 +104,30 @@ function toViewModel(block) {
 export async function getBlockRecommendations(block, options = {}) {
   if (!block?._id) return [];
   const limit = options.limit || 5;
-  const cacheKey = `block-recommendations-${block._id}-${new Date(block.updatedAt || 0).getTime()}-${limit}`;
+  const cacheKey = recommendationCacheKey(block, limit);
 
   return cache.get(
     cacheKey,
-    async () => {
-      const candidates = await fetchCandidates(block);
-      return rankBlockRecommendations(block, candidates, { limit }).map(toViewModel);
-    },
-    [],
-    { ttlMs: CACHE_TTL_MS, jitterMs: 60 * 1000, staleTtlMs: CACHE_STALE_TTL_MS }
+    calculateBlockRecommendations,
+    [block, limit],
+    cacheOptions()
   );
+}
+
+// Optional recommendations must never hold up the main post response. A cache
+// miss starts the same deduplicated calculation used by the hydration endpoint
+// and reports null so the view can render a loading shell.
+export function getBlockRecommendationsNonBlocking(block, options = {}) {
+  if (!block?._id) return [];
+  const limit = options.limit || 5;
+  const cacheKey = recommendationCacheKey(block, limit);
+
+  const recommendations = cache.getNonBlocking(
+    cacheKey,
+    calculateBlockRecommendations,
+    [block, limit],
+    cacheOptions()
+  );
+
+  return recommendations === undefined ? null : recommendations;
 }

--- a/server/db/schemas/AuthSessionSchema.js
+++ b/server/db/schemas/AuthSessionSchema.js
@@ -8,7 +8,7 @@ const authSessionSchema = new Schema({
   createdAt: { type: Date, default: Date.now },
   lastSeenAt: { type: Date, default: Date.now },
   expiresAt: { type: Date, required: true, index: true },
-  absoluteExpiresAt: { type: Date, required: true, index: true },
+  absoluteExpiresAt: { type: Date, required: true },
   revokedAt: { type: Date, default: null, index: true },
 }, {
   toObject: {

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -5,7 +5,10 @@ import {
   getPublicTranslationByGroupAndLang
 } from '../db/blockService.js';
 import { getBlockEditorialContext } from '../db/blockEditorialContextService.js';
-import { getBlockRecommendations } from '../db/blockRecommendationService.js';
+import {
+  getBlockRecommendations,
+  getBlockRecommendationsNonBlocking
+} from '../db/blockRecommendationService.js';
 import {
   getCommentsForBlockView,
   getFocusedCommentThreadForBlockView
@@ -31,6 +34,63 @@ function normalizeCommentId(commentId) {
   const value = String(commentId || '').trim();
   return value || null;
 }
+
+async function addRecommendationRoomNames(recommendations, currentRoomId, roomMetadata, uiLang) {
+  const roomIds = Array.from(new Set(
+    recommendations.map((recommendation) => recommendation.roomId)
+  ));
+  const roomNames = new Map(await Promise.all(
+    roomIds.map(async (roomId) => {
+      try {
+        const metadata = roomId === currentRoomId
+          ? roomMetadata
+          : await getRoomMetadata(roomId, uiLang);
+        return [roomId, metadata?.displayName || metadata?.name || roomId];
+      } catch {
+        return [roomId, roomId];
+      }
+    })
+  ));
+
+  return recommendations.map((recommendation) => ({
+    ...recommendation,
+    roomName: roomNames.get(recommendation.roomId) || recommendation.roomId
+  }));
+}
+
+router.get(
+  '/rooms/:room_id/blocks/:block_id/recommendations',
+  optionalAuth,
+  addI18n(['blockView']),
+  async (req, res) => {
+    try {
+      const { room_id, block_id } = req.params;
+      const block = await getBlockById(block_id);
+      if (!block || block.roomId !== room_id) return res.sendStatus(404);
+
+      const uiLang = res.locals.uiLang || res.locals.lang || 'en';
+      const recommendations = await getBlockRecommendations(block, { limit: 5 });
+      if (!recommendations.length) return res.status(204).end();
+
+      const roomMetadata = await getRoomMetadata(room_id, uiLang);
+      const recommendationItems = await addRecommendationRoomNames(
+        recommendations,
+        room_id,
+        roomMetadata,
+        uiLang
+      );
+
+      res.set('Cache-Control', 'private, no-store');
+      return res.render('partials/_block_recommendations', {
+        recommendations: recommendationItems,
+        uiLang
+      });
+    } catch (error) {
+      console.error(`Error loading recommendations for block ${req.params.block_id}:`, error);
+      return res.sendStatus(500);
+    }
+  }
+);
 
 router.get(
   '/rooms/:room_id/blocks/:block_id',
@@ -75,11 +135,7 @@ router.get(
       const descriptionHTML = renderMarkdownContent(block.description, { emptyHtml: '' });
       const translations = await getPublicTranslations(block.groupId);
 
-      const recommendationsPromise = getBlockRecommendations(block, { limit: 5 })
-        .catch((error) => {
-          console.error(`Error loading recommendations for block ${block_id}:`, error);
-          return [];
-        });
+      const recommendations = getBlockRecommendationsNonBlocking(block, { limit: 5 });
 
       const [
         reactionCounts,
@@ -88,8 +144,7 @@ router.get(
         dbUser,
         authorUser,
         editorialContext,
-        roomMetadata,
-        recommendations
+        roomMetadata
       ] = await Promise.all([
         getReactionCounts(block_id),
         getCommentsForBlockView({
@@ -116,8 +171,7 @@ router.get(
           ? findUserByUsername(block.creator)
           : Promise.resolve(null),
         getBlockEditorialContext(block),
-        getRoomMetadata(room_id, uiLang || 'en'),
-        recommendationsPromise
+        getRoomMetadata(room_id, uiLang || 'en')
       ]);
 
       let userReactions = [];
@@ -131,28 +185,9 @@ router.get(
       }
 
       const roomName = roomMetadata?.displayName || roomMetadata?.name || room_id;
-      const recommendationRoomIds = Array.from(new Set(
-        recommendations.map((recommendation) => recommendation.roomId)
-      ));
-      const recommendationRoomNames = new Map(await Promise.all(
-        recommendationRoomIds.map(async (recommendationRoomId) => {
-          try {
-            const metadata = recommendationRoomId === room_id
-              ? roomMetadata
-              : await getRoomMetadata(recommendationRoomId, uiLang || 'en');
-            return [
-              recommendationRoomId,
-              metadata?.displayName || metadata?.name || recommendationRoomId
-            ];
-          } catch {
-            return [recommendationRoomId, recommendationRoomId];
-          }
-        })
-      ));
-      const recommendationItems = recommendations.map((recommendation) => ({
-        ...recommendation,
-        roomName: recommendationRoomNames.get(recommendation.roomId) || recommendation.roomId
-      }));
+      const recommendationItems = recommendations === null
+        ? null
+        : await addRecommendationRoomNames(recommendations, room_id, roomMetadata, uiLang || 'en');
       const authorProfile = block.creator
         ? {
           username: block.creator,

--- a/server/services/cache.js
+++ b/server/services/cache.js
@@ -69,6 +69,34 @@ export async function get(key, refresh, args = [], timeOrOpts = DEFAULT_TTL_MS) 
   return p;
 }
 
+/**
+ * Return a cached value immediately, including a stale value. On a cold miss,
+ * start one deduplicated refresh and return undefined instead of making the
+ * caller wait for it. This is useful for optional content on latency-sensitive
+ * page renders.
+ */
+export function getNonBlocking(key, refresh, args = [], timeOrOpts = DEFAULT_TTL_MS) {
+  const { ttlMs, jitterMs, staleTtlMs } = readOptions(timeOrOpts);
+  const finalTtlMs = calculateTtl(ttlMs, jitterMs);
+  const existing = cache.get(key);
+
+  if (existing !== null) {
+    if (!isManagedEntry(existing)) return existing;
+
+    if (Date.now() >= existing.expiresAt && !inFlight.has(key)) {
+      refreshInBackground(key, refresh, args, finalTtlMs, staleTtlMs);
+    }
+
+    return existing.value;
+  }
+
+  if (!inFlight.has(key)) {
+    refreshInBackground(key, refresh, args, finalTtlMs, staleTtlMs);
+  }
+
+  return undefined;
+}
+
 function putValue(key, value, ttlMs, staleTtlMs) {
   if (!staleTtlMs) {
     cache.put(key, value, ttlMs);

--- a/spec/cacheSpec.js
+++ b/spec/cacheSpec.js
@@ -46,4 +46,22 @@ describe('cache service', () => {
     expect(second).toBe('value');
     expect(calls).toBe(1);
   });
+
+  it('returns immediately and deduplicates refreshes on non-blocking cold misses', async () => {
+    let calls = 0;
+    const refresh = async () => {
+      calls += 1;
+      await delay(20);
+      return 'ready';
+    };
+
+    expect(cache.getNonBlocking('optional-key', refresh, [], { ttlMs: 50 })).toBeUndefined();
+    expect(cache.getNonBlocking('optional-key', refresh, [], { ttlMs: 50 })).toBeUndefined();
+    expect(calls).toBe(1);
+
+    await delay(30);
+
+    expect(cache.getNonBlocking('optional-key', refresh, [], { ttlMs: 50 })).toBe('ready');
+    expect(calls).toBe(1);
+  });
 });

--- a/views/partials/_block_recommendations.pug
+++ b/views/partials/_block_recommendations.pug
@@ -1,0 +1,23 @@
+aside.block-recommendations(aria-labelledby='recommendations-heading' lang=(uiLang || 'en'))
+  .block-recommendations__header
+    p.block-recommendations__eyebrow= t('blockView.recommendations.eyebrow')
+    h2#recommendations-heading.block-recommendations__heading= t('blockView.recommendations.heading')
+    p.block-recommendations__description= t('blockView.recommendations.description')
+  ol.block-recommendations__list
+    each recommendation in recommendations
+      - const recommendationDate = recommendation.createdAt ? new Date(recommendation.createdAt) : null;
+      li.block-recommendation
+        a.block-recommendation__link(href=uiPath(`/rooms/${recommendation.roomId}/blocks/${recommendation.id}`))
+          span.block-recommendation__room= t('blockView.recommendations.roomLabel', { room: recommendation.roomName })
+          span.block-recommendation__title(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.title
+          if recommendation.description
+            span.block-recommendation__summary(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.description
+          span.block-recommendation__meta
+            if recommendation.creator
+              span= t('blockView.recommendations.byAuthor', { author: recommendation.creator })
+            if recommendationDate
+              time(datetime=recommendationDate.toISOString())= recommendationDate.toLocaleDateString(uiLang || undefined, { dateStyle: 'medium' })
+          if recommendation.tags && recommendation.tags.length
+            span.block-recommendation__tags(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))
+              each tag in recommendation.tags
+                span.block-recommendation__tag= tag

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -38,6 +38,7 @@ block append scripts
   script(src='/js/reactions.js')
   script(src='/js/comments.js')
   script(src='/js/block-editorial-guide.js')
+  script(src='/js/block-recommendations.js')
 
 block content
   - const blockDir = textDirForLang ? textDirForLang(lang) : 'ltr';
@@ -152,7 +153,7 @@ block content
               i.fa.fa-flag(aria-hidden="true")
               | #{t('blockView.buttons.flagContent')}
 
-    .block-view-layout(class=recommendations && recommendations.length ? 'block-view-layout--with-recommendations' : '')
+    .block-view-layout(class=recommendations === null || recommendations.length ? 'block-view-layout--with-recommendations' : '')
       .block-view-primary
         // Description block, read-only style
         if descriptionHTML
@@ -195,30 +196,19 @@ block content
         hr
         +tagSection(block.tags, false)
 
-      if recommendations && recommendations.length
-        aside.block-recommendations(aria-labelledby='recommendations-heading' lang=(uiLang || 'en'))
-          .block-recommendations__header
-            p.block-recommendations__eyebrow= t('blockView.recommendations.eyebrow')
-            h2#recommendations-heading.block-recommendations__heading= t('blockView.recommendations.heading')
-            p.block-recommendations__description= t('blockView.recommendations.description')
-          ol.block-recommendations__list
-            each recommendation in recommendations
-              - const recommendationDate = recommendation.createdAt ? new Date(recommendation.createdAt) : null;
-              li.block-recommendation
-                a.block-recommendation__link(href=uiPath(`/rooms/${recommendation.roomId}/blocks/${recommendation.id}`))
-                  span.block-recommendation__room= t('blockView.recommendations.roomLabel', { room: recommendation.roomName })
-                  span.block-recommendation__title(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.title
-                  if recommendation.description
-                    span.block-recommendation__summary(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))= recommendation.description
-                  span.block-recommendation__meta
-                    if recommendation.creator
-                      span= t('blockView.recommendations.byAuthor', { author: recommendation.creator })
-                    if recommendationDate
-                      time(datetime=recommendationDate.toISOString())= recommendationDate.toLocaleDateString(uiLang || undefined, { dateStyle: 'medium' })
-                  if recommendation.tags && recommendation.tags.length
-                    span.block-recommendation__tags(lang=(recommendation.lang || 'en') dir=(textDirForLang ? textDirForLang(recommendation.lang || 'en') : 'ltr'))
-                      each tag in recommendation.tags
-                        span.block-recommendation__tag= tag
+      if recommendations === null
+        aside.block-recommendations.block-recommendations--loading(
+          aria-label=t('blockView.recommendations.heading')
+          aria-busy='true'
+          data-recommendations-loading
+          data-endpoint=uiPath(`/rooms/${room_id}/blocks/${block._id}/recommendations`)
+        )
+          .block-recommendations__skeleton.block-recommendations__skeleton--heading
+          .block-recommendations__skeleton
+          .block-recommendations__skeleton
+          .block-recommendations__skeleton
+      else if recommendations.length
+        include ../partials/_block_recommendations
 
       .block-view-conversation
         include ../partials/_comments_section


### PR DESCRIPTION
## Summary

Prevents cold recommendation-cache misses from delaying the initial post page render.

## What changed

- Starts recommendation calculations without blocking the main response
- Deduplicates concurrent cache refreshes
- Preserves immediate server rendering for cached recommendations
- Adds a dedicated endpoint for asynchronously loading cold recommendations
- Displays a shimmer placeholder while recommendations load
- Removes the sidebar cleanly when no recommendations are available
- Extracts the recommendation markup into a reusable partial

## Testing

- All 295 automated specs pass
- ESLint passes
- Pug partial rendering verified
- Manually tested cold-cache loading and sidebar hydration