### PR TITLE
Fix archive month and weekday labels outside UTC

### DIFF
--- a/lib/dateHelper.js
+++ b/lib/dateHelper.js
@@ -54,7 +54,10 @@ class DateHelper {
     // Usamos una fecha fija: día 1 del mes pedido.
     const d = new Date(Date.UTC(2020, index - 1, 1));
     // 'long' -> 'January', 'enero', etc.
-    return new Intl.DateTimeFormat(lang, { month: 'long' }).format(d);
+    return new Intl.DateTimeFormat(lang, {
+      month: 'long',
+      timeZone: 'UTC'
+    }).format(d);
   }
 
   /**
@@ -64,7 +67,10 @@ class DateHelper {
   static weekdayShortNames(lang = 'en') {
     // Domingo conocido: 2020-02-02 fue domingo (UTC)
     const start = new Date(Date.UTC(2020, 1, 2));
-    const fmt = new Intl.DateTimeFormat(lang, { weekday: 'short' });
+    const fmt = new Intl.DateTimeFormat(lang, {
+      weekday: 'short',
+      timeZone: 'UTC'
+    });
     const arr = [];
     for (let i = 0; i < 7; i++) {
       const d = new Date(start);

--- a/spec/dateHelperSpec.js
+++ b/spec/dateHelperSpec.js
@@ -1,0 +1,27 @@
+import DateHelper from '../lib/dateHelper.js';
+
+describe('DateHelper archive labels', () => {
+  const originalTimeZone = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = 'America/New_York';
+  });
+
+  afterEach(() => {
+    if (originalTimeZone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTimeZone;
+    }
+  });
+
+  it('formats a one-based month without shifting it in a western timezone', () => {
+    expect(DateHelper.monthName(6, 'en')).toBe('June');
+  });
+
+  it('keeps archive weekday headings aligned from Sunday through Saturday', () => {
+    expect(DateHelper.weekdayShortNames('en')).toEqual([
+      'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fix archive month names and weekday headings shifting backward when the server runs west of UTC.

## Cause

Archive label helpers created dates at UTC midnight but formatted them using the server’s local timezone. For example, June 1 at UTC midnight is still May 31 in New York.

Production’s UTC timezone masked the issue.

## Changes

- Format archive month names in UTC
- Format archive weekday headings in UTC
- Add regression tests using `America/New_York`

## Testing

- Confirmed archive month and weekday labels render correctly locally
- All 306 specs pass