### PR TITLE
Fix dark mode styling for the editor inactivity warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Rare UI states can be previewed without manufacturing matching database or colla
 - `/en/__dev/views/tag-detail` to preview the tag-detail trend chart with representative fixture data.
 - `/en/__dev/views/full-post-capacity` to preview the message shown when a post editor has reached its collaborator limit.
 - `/en/__dev/views/toasts` to trigger neutral, success, error, long-message, and stacked toast states.
+- `/en/__dev/views/inactive-warning` to preview the editor inactivity warning in light and dark modes.
 
 Replace `/en/` with another supported UI-language prefix when checking localized layout behavior. These routes render the real application templates and shared frontend assets, but use development fixture data where needed.
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -956,6 +956,7 @@ Editor
   background-color: rgb(232, 243, 231);
   border: 5px solid rgb(191, 243, 230);
   border-radius: 4px;
+  color: var(--text-color);
   font-size: 20px;
   height: 170px;
   left: 32%;
@@ -982,6 +983,19 @@ button.inactive-dismiss {
   float: unset;
   margin: 0 auto;
   width: 60px;
+}
+
+html[data-theme="dark"] #inactive-warning {
+  background-color: var(--surface-raised-bg);
+  border-color: color-mix(in srgb, var(--success-color) 45%, var(--border-color));
+  color: var(--text-color);
+  box-shadow: var(--box-shadow);
+}
+
+html[data-theme="dark"] button.inactive-dismiss {
+  background-color: color-mix(in srgb, var(--success-color) 18%, var(--secondary-bg));
+  border-color: color-mix(in srgb, var(--success-color) 45%, var(--border-color));
+  color: var(--text-color);
 }
 
 #ownName {

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -61,4 +61,17 @@ router.get(
   }
 );
 
+router.get(
+  '/__dev/views/inactive-warning',
+  optionalAuth,
+  addI18n(['blockEditor']),
+  (req, res) => {
+    res.render('dev/inactive-warning', {
+      title: 'Inactivity warning preview',
+      user: req.user || null,
+      uiLang: res.locals.uiLang,
+    });
+  }
+);
+
 export default router;

--- a/views/dev/inactive-warning.pug
+++ b/views/dev/inactive-warning.pug
@@ -1,0 +1,12 @@
+extends ../layout
+
+block nav
+  include ../navLinks
+
+block content
+  main
+    h1 Inactivity warning preview
+    p Use the theme control in the navigation bar to compare the warning in light and dark modes.
+
+  include ../inactiveWarning
+  +inactiveWarning(true)

--- a/views/inactiveWarning.pug
+++ b/views/inactiveWarning.pug
@@ -1,5 +1,6 @@
-#inactive-warning(style="visibility: hidden;")
-  strong!= t('blockEditor.inactiveWarning.message')
-  .inactive-dismiss#box
-    button.inactive-dismiss
-      span.inactive-dismiss= t('blockEditor.inactiveWarning.confirm')
+mixin inactiveWarning(isVisible = false)
+  #inactive-warning(style=`visibility: ${isVisible ? 'visible' : 'hidden'};`)
+    strong!= t('blockEditor.inactiveWarning.message')
+    .inactive-dismiss#box
+      button.inactive-dismiss(type='button')
+        span.inactive-dismiss= t('blockEditor.inactiveWarning.confirm')

--- a/views/rooms/block-editor.pug
+++ b/views/rooms/block-editor.pug
@@ -122,6 +122,7 @@ block content
 
   include ../loading
   include ../inactiveWarning
+  +inactiveWarning()
   include ../partials/_block_delete_confirm
 
   #lock-modal.modal.hidden


### PR DESCRIPTION
## Summary

- improves the editor inactivity warning’s contrast in dark mode
- adds a development preview at `/en/__dev/views/inactive-warning`
- reuses the production warning component in the preview
- documents the new preview route

## Testing

- `npm run lint`
- `npm test` — 306 specs passing
- manually verified the warning preview in light and dark modes