### PR TITLE
Add Markdown table sorting controls to the editor

### DIFF
--- a/i18n/ar/blockEditor.json
+++ b/i18n/ar/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "يلغي",
       "insertStreetView": "إدراج Street View",
       "insertStreetViewHelp": "الصق رابط https://www.google.com/maps/embed من سمة src في iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "إدراج جدول",
+      "insertTableHelp": "اختر حجم الجدول وما إذا كان يمكن للقراء فرز أعمدته.",
+      "tableRows": "صفوف البيانات",
+      "tableColumns": "الأعمدة",
+      "tableSortable": "السماح للقراء بفرز الأعمدة"
     },
     "buttons": {
       "downloadFile": "تنزيل الملف"

--- a/i18n/cs/blockEditor.json
+++ b/i18n/cs/blockEditor.json
@@ -30,7 +30,12 @@
     "toolbar": { "insertImage": "Vložit obrázek", "insertImageUrlPlaceholder": "Zadejte adresu URL obrázku", "insertImageAltPlaceholder": "Alternativní text (volitelné)", "insertImageConfirm": "Potvrdit", "insertImageCancel": "Zrušit",
       "insertStreetView": "Vložit Street View",
       "insertStreetViewHelp": "Vložte adresu https://www.google.com/maps/embed z atributu src prvku iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Vložit tabulku",
+      "insertTableHelp": "Zvolte velikost tabulky a zda mohou čtenáři řadit její sloupce.",
+      "tableRows": "Datové řádky",
+      "tableColumns": "Sloupce",
+      "tableSortable": "Povolit čtenářům řazení sloupců"
     },
     "buttons": { "downloadFile": "Stáhnout soubor" },
     "lockModal": { "messageLine1": "Opravdu chcete tento příspěvek uzamknout?", "messageLine2": "Tím jej dokončíte a zabráníte dalším úpravám.", "confirm": "Uzamknout", "cancel": "Zrušit", "successToast": "Příspěvek byl úspěšně uzamčen.", "errorToast": "Chyba při uzamykání příspěvku." },

--- a/i18n/da/blockEditor.json
+++ b/i18n/da/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Ophæve",
       "insertStreetView": "Indsæt Street View",
       "insertStreetViewHelp": "Indsæt https://www.google.com/maps/embed-adressen fra iframe-elementets src-attribut.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Indsæt tabel",
+      "insertTableHelp": "Vælg tabellens størrelse, og om læserne kan sortere kolonnerne.",
+      "tableRows": "Datarækker",
+      "tableColumns": "Kolonner",
+      "tableSortable": "Tillad læserne at sortere kolonner"
     },
     "buttons": {
       "downloadFile": "Download fil"

--- a/i18n/de/blockEditor.json
+++ b/i18n/de/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Abbrechen",
       "insertStreetView": "Street View einfügen",
       "insertStreetViewHelp": "Füge die https://www.google.com/maps/embed-URL aus dem src-Attribut des iframe ein.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Tabelle einfügen",
+      "insertTableHelp": "Wähle die Tabellengröße und ob Leser die Spalten sortieren können.",
+      "tableRows": "Datenzeilen",
+      "tableColumns": "Spalten",
+      "tableSortable": "Lesern das Sortieren der Spalten erlauben"
     },
     "buttons": {
       "downloadFile": "Datei herunterladen"

--- a/i18n/el/blockEditor.json
+++ b/i18n/el/blockEditor.json
@@ -64,7 +64,12 @@
       "insertImageCancel": "Ακύρωση",
       "insertStreetView": "Εισαγωγή Street View",
       "insertStreetViewHelp": "Επικολλήστε το URL https://www.google.com/maps/embed από το γνώρισμα src του iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Εισαγωγή πίνακα",
+      "insertTableHelp": "Επιλέξτε το μέγεθος του πίνακα και αν οι αναγνώστες μπορούν να ταξινομούν τις στήλες του.",
+      "tableRows": "Γραμμές δεδομένων",
+      "tableColumns": "Στήλες",
+      "tableSortable": "Να επιτρέπεται η ταξινόμηση στηλών από τους αναγνώστες"
     },
     "buttons": { "downloadFile": "Λήψη αρχείου" },
     "lockModal": {

--- a/i18n/en/blockEditor.json
+++ b/i18n/en/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Cancel",
       "insertStreetView": "Insert Street View",
       "insertStreetViewHelp": "Paste the https://www.google.com/maps/embed URL from the iframe's src attribute.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Insert table",
+      "insertTableHelp": "Choose the table size and whether readers can sort its columns.",
+      "tableRows": "Body rows",
+      "tableColumns": "Columns",
+      "tableSortable": "Allow readers to sort columns"
     },
     "buttons": {
       "downloadFile": "Download file"

--- a/i18n/es/blockEditor.json
+++ b/i18n/es/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Cancelar",
       "insertStreetView": "Insertar Street View",
       "insertStreetViewHelp": "Pega la URL https://www.google.com/maps/embed del atributo src del iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Insertar tabla",
+      "insertTableHelp": "Elige el tamaño de la tabla y si los lectores pueden ordenar sus columnas.",
+      "tableRows": "Filas de datos",
+      "tableColumns": "Columnas",
+      "tableSortable": "Permitir que los lectores ordenen las columnas"
     },
     "buttons": {
       "downloadFile": "Descargar archivo"

--- a/i18n/fi/blockEditor.json
+++ b/i18n/fi/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Peruuta",
       "insertStreetView": "Lisää Street View",
       "insertStreetViewHelp": "Liitä iframe-elementin src-attribuutissa oleva https://www.google.com/maps/embed-osoite.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Lisää taulukko",
+      "insertTableHelp": "Valitse taulukon koko ja voivatko lukijat lajitella sen sarakkeita.",
+      "tableRows": "Tietorivit",
+      "tableColumns": "Sarakkeet",
+      "tableSortable": "Salli lukijoiden lajitella sarakkeita"
     },
     "buttons": {
       "downloadFile": "Lataa tiedosto"

--- a/i18n/fr/blockEditor.json
+++ b/i18n/fr/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Annuler",
       "insertStreetView": "Insérer Street View",
       "insertStreetViewHelp": "Collez l’URL https://www.google.com/maps/embed provenant de l’attribut src de l’iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Insérer un tableau",
+      "insertTableHelp": "Choisissez la taille du tableau et si les lecteurs peuvent trier ses colonnes.",
+      "tableRows": "Lignes de données",
+      "tableColumns": "Colonnes",
+      "tableSortable": "Permettre aux lecteurs de trier les colonnes"
     },
     "buttons": {
       "downloadFile": "Télécharger le fichier"

--- a/i18n/he/blockEditor.json
+++ b/i18n/he/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "בטל",
       "insertStreetView": "הוספת Street View",
       "insertStreetViewHelp": "הדביקו את כתובת https://www.google.com/maps/embed מתוך המאפיין src של ה-iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "הוספת טבלה",
+      "insertTableHelp": "בחרו את גודל הטבלה והאם הקוראים יוכלו למיין את העמודות שלה.",
+      "tableRows": "שורות נתונים",
+      "tableColumns": "עמודות",
+      "tableSortable": "לאפשר לקוראים למיין עמודות"
     },
     "buttons": {
       "downloadFile": "הורד קובץ"

--- a/i18n/hi/blockEditor.json
+++ b/i18n/hi/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "रद्द करना",
       "insertStreetView": "Street View डालें",
       "insertStreetViewHelp": "iframe के src एट्रिब्यूट से https://www.google.com/maps/embed URL पेस्ट करें।",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "तालिका डालें",
+      "insertTableHelp": "तालिका का आकार चुनें और तय करें कि पाठक उसके स्तंभों को क्रमबद्ध कर सकते हैं या नहीं।",
+      "tableRows": "डेटा पंक्तियाँ",
+      "tableColumns": "स्तंभ",
+      "tableSortable": "पाठकों को स्तंभ क्रमबद्ध करने दें"
     },
     "buttons": {
       "downloadFile": "डाउनलोड फ़ाइल"

--- a/i18n/id/blockEditor.json
+++ b/i18n/id/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Batal",
       "insertStreetView": "Sisipkan Street View",
       "insertStreetViewHelp": "Tempel URL https://www.google.com/maps/embed dari atribut src iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Sisipkan tabel",
+      "insertTableHelp": "Pilih ukuran tabel dan apakah pembaca dapat mengurutkan kolomnya.",
+      "tableRows": "Baris data",
+      "tableColumns": "Kolom",
+      "tableSortable": "Izinkan pembaca mengurutkan kolom"
     },
     "buttons": {
       "downloadFile": "Unduh file"

--- a/i18n/it/blockEditor.json
+++ b/i18n/it/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Annulla",
       "insertStreetView": "Inserisci Street View",
       "insertStreetViewHelp": "Incolla l’URL https://www.google.com/maps/embed dall’attributo src dell’iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Inserisci tabella",
+      "insertTableHelp": "Scegli le dimensioni della tabella e se i lettori possono ordinarne le colonne.",
+      "tableRows": "Righe di dati",
+      "tableColumns": "Colonne",
+      "tableSortable": "Consenti ai lettori di ordinare le colonne"
     },
     "buttons": {
       "downloadFile": "Scarica file"

--- a/i18n/ja/blockEditor.json
+++ b/i18n/ja/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "キャンセル",
       "insertStreetView": "Street View を挿入",
       "insertStreetViewHelp": "iframe の src 属性から https://www.google.com/maps/embed URL を貼り付けてください。",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "表を挿入",
+      "insertTableHelp": "表のサイズと、読者が列を並べ替えられるかどうかを選択します。",
+      "tableRows": "データ行",
+      "tableColumns": "列",
+      "tableSortable": "読者による列の並べ替えを許可"
     },
     "buttons": {
       "downloadFile": "ファイルをダウンロード"

--- a/i18n/ko/blockEditor.json
+++ b/i18n/ko/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "취소",
       "insertStreetView": "Street View 삽입",
       "insertStreetViewHelp": "iframe의 src 속성에서 https://www.google.com/maps/embed URL을 붙여 넣으세요.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "표 삽입",
+      "insertTableHelp": "표 크기와 독자가 열을 정렬할 수 있는지 선택하세요.",
+      "tableRows": "데이터 행",
+      "tableColumns": "열",
+      "tableSortable": "독자가 열을 정렬하도록 허용"
     },
     "buttons": {
       "downloadFile": "파일 다운로드"

--- a/i18n/nl/blockEditor.json
+++ b/i18n/nl/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Annuleren",
       "insertStreetView": "Street View invoegen",
       "insertStreetViewHelp": "Plak de URL https://www.google.com/maps/embed uit het src-attribuut van het iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Tabel invoegen",
+      "insertTableHelp": "Kies de tabelgrootte en of lezers de kolommen mogen sorteren.",
+      "tableRows": "Gegevensrijen",
+      "tableColumns": "Kolommen",
+      "tableSortable": "Lezers toestaan kolommen te sorteren"
     },
     "buttons": {
       "downloadFile": "Bestand downloaden"

--- a/i18n/no/blockEditor.json
+++ b/i18n/no/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Avbryt",
       "insertStreetView": "Sett inn Street View",
       "insertStreetViewHelp": "Lim inn https://www.google.com/maps/embed-adressen fra iframe-elementets src-attributt.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Sett inn tabell",
+      "insertTableHelp": "Velg tabellstørrelse og om leserne kan sortere kolonnene.",
+      "tableRows": "Datarader",
+      "tableColumns": "Kolonner",
+      "tableSortable": "Tillat leserne å sortere kolonner"
     },
     "buttons": {
       "downloadFile": "Last ned fil"

--- a/i18n/pl/blockEditor.json
+++ b/i18n/pl/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Anuluj",
       "insertStreetView": "Wstaw Street View",
       "insertStreetViewHelp": "Wklej adres https://www.google.com/maps/embed z atrybutu src elementu iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Wstaw tabelę",
+      "insertTableHelp": "Wybierz rozmiar tabeli i określ, czy czytelnicy mogą sortować jej kolumny.",
+      "tableRows": "Wiersze danych",
+      "tableColumns": "Kolumny",
+      "tableSortable": "Zezwalaj czytelnikom na sortowanie kolumn"
     },
     "buttons": {
       "downloadFile": "Pobierz plik"

--- a/i18n/pt/blockEditor.json
+++ b/i18n/pt/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Cancelar",
       "insertStreetView": "Inserir Street View",
       "insertStreetViewHelp": "Cole o URL https://www.google.com/maps/embed do atributo src do iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Inserir tabela",
+      "insertTableHelp": "Escolha o tamanho da tabela e se os leitores podem ordenar as colunas.",
+      "tableRows": "Linhas de dados",
+      "tableColumns": "Colunas",
+      "tableSortable": "Permitir que os leitores ordenem as colunas"
     },
     "buttons": {
       "downloadFile": "Baixar arquivo"

--- a/i18n/ru/blockEditor.json
+++ b/i18n/ru/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Отмена",
       "insertStreetView": "Вставить Street View",
       "insertStreetViewHelp": "Вставьте URL https://www.google.com/maps/embed из атрибута src элемента iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Вставить таблицу",
+      "insertTableHelp": "Выберите размер таблицы и возможность сортировки столбцов читателями.",
+      "tableRows": "Строки данных",
+      "tableColumns": "Столбцы",
+      "tableSortable": "Разрешить читателям сортировать столбцы"
     },
     "buttons": {
       "downloadFile": "Скачать файл"

--- a/i18n/sv/blockEditor.json
+++ b/i18n/sv/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Avbryt",
       "insertStreetView": "Infoga Street View",
       "insertStreetViewHelp": "Klistra in adressen https://www.google.com/maps/embed från iframe-elementets src-attribut.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Infoga tabell",
+      "insertTableHelp": "Välj tabellens storlek och om läsare får sortera kolumnerna.",
+      "tableRows": "Datarader",
+      "tableColumns": "Kolumner",
+      "tableSortable": "Tillåt läsare att sortera kolumner"
     },
     "buttons": {
       "downloadFile": "Ladda ner fil"

--- a/i18n/th/blockEditor.json
+++ b/i18n/th/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "ยกเลิก",
       "insertStreetView": "แทรก Street View",
       "insertStreetViewHelp": "วาง URL https://www.google.com/maps/embed จากแอตทริบิวต์ src ของ iframe",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "แทรกตาราง",
+      "insertTableHelp": "เลือกขนาดตารางและกำหนดว่าผู้อ่านสามารถเรียงลำดับคอลัมน์ได้หรือไม่",
+      "tableRows": "แถวข้อมูล",
+      "tableColumns": "คอลัมน์",
+      "tableSortable": "อนุญาตให้ผู้อ่านเรียงลำดับคอลัมน์"
     },
     "buttons": {
       "downloadFile": "ดาวน์โหลดแฟ้ม"

--- a/i18n/tr/blockEditor.json
+++ b/i18n/tr/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "İptal",
       "insertStreetView": "Street View ekle",
       "insertStreetViewHelp": "iframe öğesinin src özelliğindeki https://www.google.com/maps/embed URL’sini yapıştırın.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Tablo ekle",
+      "insertTableHelp": "Tablo boyutunu ve okuyucuların sütunları sıralayıp sıralayamayacağını seçin.",
+      "tableRows": "Veri satırları",
+      "tableColumns": "Sütunlar",
+      "tableSortable": "Okuyucuların sütunları sıralamasına izin ver"
     },
     "buttons": {
       "downloadFile": "Dosyayı indir"

--- a/i18n/vi/blockEditor.json
+++ b/i18n/vi/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "Hủy",
       "insertStreetView": "Chèn Street View",
       "insertStreetViewHelp": "Dán URL https://www.google.com/maps/embed từ thuộc tính src của iframe.",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "Chèn bảng",
+      "insertTableHelp": "Chọn kích thước bảng và liệu người đọc có thể sắp xếp các cột hay không.",
+      "tableRows": "Hàng dữ liệu",
+      "tableColumns": "Cột",
+      "tableSortable": "Cho phép người đọc sắp xếp các cột"
     },
     "buttons": {
       "downloadFile": "Tải tập tin xuống"

--- a/i18n/zh/blockEditor.json
+++ b/i18n/zh/blockEditor.json
@@ -84,7 +84,12 @@
       "insertImageCancel": "取消",
       "insertStreetView": "插入 Street View",
       "insertStreetViewHelp": "请粘贴 iframe 的 src 属性中的 https://www.google.com/maps/embed 网址。",
-      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=..."
+      "insertStreetViewUrlPlaceholder": "https://www.google.com/maps/embed?pb=...",
+      "insertTable": "插入表格",
+      "insertTableHelp": "选择表格大小，以及是否允许读者对列进行排序。",
+      "tableRows": "数据行",
+      "tableColumns": "列",
+      "tableSortable": "允许读者对列进行排序"
     },
     "buttons": {
       "downloadFile": "下载文件"

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -78,29 +78,17 @@ class Editor {
     if (isOpen) document.getElementById('street-view-url')?.focus();
   };
 
-  simulateTyping(snippet, pos, callback) {
+  insertAtCursor(snippet) {
     const cm = this.mde.codemirror;
-    let index = 0;
-    const typeNext = () => {
-      if (index < snippet.length) {
-        // Insert one character at a time using '+input'
-        cm.replaceRange(snippet.charAt(index), pos, pos, '+input');
-        pos = cm.getCursor(); // update the cursor position
-        index++;
-        setTimeout(typeNext, 50); // tiny pause between keystrokes
-      } else {
-        if (callback) callback();
-      }
-    };
-    typeNext();
+    const pos = cm.getCursor();
+    cm.replaceRange(snippet, pos, pos, '+input');
+    cm.focus();
   }
 
   insertImage = () => {
     const imgTooltip = document.getElementById('insert-img-tooltip');
     const imgUrlInput = document.getElementById('img-url');
     const imgAltInput = document.getElementById('img-alt');
-    const cm = this.mde.codemirror;
-
     const url = imgUrlInput.value.trim();
     const alt = imgAltInput.value.trim();
     if (!url) {
@@ -116,11 +104,8 @@ class Editor {
     }
 
     const snippet = `![${alt}](${url})`;
-    const pos = cm.getCursor();
-    // Simulate typing to insert the snippet so the CRDT sees each change
-    this.simulateTyping(snippet, pos, () => {
-      this.markImages();
-    });
+    this.insertAtCursor(snippet);
+    this.markImages();
 
     imgTooltip.classList.add('hidden');
     imgUrlInput.value = '';
@@ -152,8 +137,7 @@ class Editor {
       return;
     }
 
-    const pos = this.mde.codemirror.getCursor();
-    this.simulateTyping(`@[streetview](${url})`, pos);
+    this.insertAtCursor(`@[streetview](${url})`);
 
     tooltip.classList.add('hidden');
     document.getElementById('open-insert-street-view-btn')
@@ -213,12 +197,8 @@ class Editor {
     const columns = Number(document.getElementById('table-columns').value);
     const sortable = document.getElementById('table-sortable').checked;
     const snippet = createMarkdownTable(rows, columns, sortable);
-    const cm = this.mde.codemirror;
-    const pos = cm.getCursor();
-
-    cm.replaceRange(`\n\n${snippet}\n\n`, pos, pos, '+input');
+    this.insertAtCursor(`\n\n${snippet}\n\n`);
     this.closeTableInsertion({ restoreFocus: false });
-    cm.focus();
   };
 
   cancelTableInsertion = () => {

--- a/lib/editor.js
+++ b/lib/editor.js
@@ -5,6 +5,24 @@ import {
   streakPing
 } from './streakHelper.js';
 import { normalizeStreetViewEmbedUrl } from './streetViewEmbed.js';
+import { NO_SORT_MARKER } from './tableSortOptOut.js';
+
+export const TABLE_ROW_LIMIT = 20;
+export const TABLE_COLUMN_LIMIT = 10;
+
+export function createMarkdownTable(rows, columns, sortable = true) {
+  if (!Number.isInteger(rows) || rows < 1 || rows > TABLE_ROW_LIMIT) {
+    throw new RangeError(`Table rows must be between 1 and ${TABLE_ROW_LIMIT}.`);
+  }
+  if (!Number.isInteger(columns) || columns < 1 || columns > TABLE_COLUMN_LIMIT) {
+    throw new RangeError(`Table columns must be between 1 and ${TABLE_COLUMN_LIMIT}.`);
+  }
+
+  const blankRow = `| ${Array(columns).fill('').join(' | ')} |`;
+  const separator = `| ${Array(columns).fill('---').join(' | ')} |`;
+  const table = [blankRow, separator, ...Array(rows).fill(blankRow)].join('\n');
+  return sortable ? table : `${NO_SORT_MARKER}\n\n${table}`;
+}
 
 class Editor {
   constructor(mde) {
@@ -29,9 +47,13 @@ class Editor {
     const streetViewTooltip = document.getElementById('insert-street-view-tooltip');
     const imgButton = document.getElementById('open-insert-img-btn');
     const streetViewButton = document.getElementById('open-insert-street-view-btn');
+    const tableTooltip = document.getElementById('insert-table-tooltip');
+    const tableButton = document.getElementById('open-insert-table-btn');
 
     streetViewTooltip?.classList.add('hidden');
     streetViewButton?.setAttribute('aria-expanded', 'false');
+    tableTooltip?.classList.add('hidden');
+    tableButton?.setAttribute('aria-expanded', 'false');
     imgTooltip.classList.toggle('hidden');
     const isOpen = !imgTooltip.classList.contains('hidden');
     imgButton?.setAttribute('aria-expanded', String(isOpen));
@@ -43,9 +65,13 @@ class Editor {
     const streetViewTooltip = document.getElementById('insert-street-view-tooltip');
     const imgButton = document.getElementById('open-insert-img-btn');
     const streetViewButton = document.getElementById('open-insert-street-view-btn');
+    const tableTooltip = document.getElementById('insert-table-tooltip');
+    const tableButton = document.getElementById('open-insert-table-btn');
 
     imgTooltip?.classList.add('hidden');
     imgButton?.setAttribute('aria-expanded', 'false');
+    tableTooltip?.classList.add('hidden');
+    tableButton?.setAttribute('aria-expanded', 'false');
     streetViewTooltip.classList.toggle('hidden');
     const isOpen = !streetViewTooltip.classList.contains('hidden');
     streetViewButton?.setAttribute('aria-expanded', String(isOpen));
@@ -145,6 +171,66 @@ class Editor {
     urlInput.value = '';
   };
 
+  toggleTableTooltip = () => {
+    const tooltip = document.getElementById('insert-table-tooltip');
+    const button = document.getElementById('open-insert-table-btn');
+
+    document.getElementById('insert-img-tooltip')?.classList.add('hidden');
+    document.getElementById('open-insert-img-btn')?.setAttribute('aria-expanded', 'false');
+    document.getElementById('insert-street-view-tooltip')?.classList.add('hidden');
+    document.getElementById('open-insert-street-view-btn')
+      ?.setAttribute('aria-expanded', 'false');
+
+    tooltip.classList.toggle('hidden');
+    const isOpen = !tooltip.classList.contains('hidden');
+    button.setAttribute('aria-expanded', String(isOpen));
+    if (isOpen) document.getElementById('table-rows')?.focus();
+  };
+
+  resetTableInsertion = () => {
+    document.getElementById('table-rows').value = '3';
+    document.getElementById('table-columns').value = '3';
+    document.getElementById('table-sortable').checked = true;
+  };
+
+  closeTableInsertion = ({ restoreFocus = true } = {}) => {
+    document.getElementById('insert-table-tooltip').classList.add('hidden');
+    const button = document.getElementById('open-insert-table-btn');
+    button.setAttribute('aria-expanded', 'false');
+    this.resetTableInsertion();
+    if (restoreFocus) button.focus();
+  };
+
+  insertTable = (event) => {
+    event?.preventDefault();
+    const form = document.getElementById('insert-table-form');
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    const rows = Number(document.getElementById('table-rows').value);
+    const columns = Number(document.getElementById('table-columns').value);
+    const sortable = document.getElementById('table-sortable').checked;
+    const snippet = createMarkdownTable(rows, columns, sortable);
+    const cm = this.mde.codemirror;
+    const pos = cm.getCursor();
+
+    cm.replaceRange(`\n\n${snippet}\n\n`, pos, pos, '+input');
+    this.closeTableInsertion({ restoreFocus: false });
+    cm.focus();
+  };
+
+  cancelTableInsertion = () => {
+    this.closeTableInsertion();
+  };
+
+  handleTableInsertionKeydown = (event) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    this.closeTableInsertion();
+  };
+
   bindButtons() {
     const openInsertImgBtn = document.getElementById('open-insert-img-btn');
     const imgTooltip = document.getElementById('insert-img-tooltip');
@@ -185,6 +271,27 @@ class Editor {
 
       streetViewCancel.removeEventListener('click', this.cancelStreetViewInsertion);
       streetViewCancel.addEventListener('click', this.cancelStreetViewInsertion);
+    }
+
+    const openTableButton = document.getElementById('open-insert-table-btn');
+    const tableTooltip = document.getElementById('insert-table-tooltip');
+    const tableForm = document.getElementById('insert-table-form');
+    const tableCancel = document.getElementById('insert-table-cancel');
+
+    if (!openTableButton || !tableTooltip || !tableForm || !tableCancel) {
+      console.warn('Warning: Table insertion UI is missing. Skipping its bindings.');
+    } else {
+      openTableButton.removeEventListener('click', this.toggleTableTooltip);
+      openTableButton.addEventListener('click', this.toggleTableTooltip);
+
+      tableForm.removeEventListener('submit', this.insertTable);
+      tableForm.addEventListener('submit', this.insertTable);
+
+      tableCancel.removeEventListener('click', this.cancelTableInsertion);
+      tableCancel.addEventListener('click', this.cancelTableInsertion);
+
+      tableTooltip.removeEventListener('keydown', this.handleTableInsertionKeydown);
+      tableTooltip.addEventListener('keydown', this.handleTableInsertionKeydown);
     }
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ import Controller from './controller.js';
 import Broadcast from './broadcast.js';
 import Editor from './editor.js';
 import { streetViewEmbedPlugin } from './streetViewEmbed.js';
+import { tableSortOptOutPlugin } from './tableSortOptOut.js';
 
 let peerId = initialTargetPeerId;
 if (!peerId) {
@@ -26,6 +27,7 @@ const previewMarkdown = window.markdownit?.({
   breaks: false
 });
 previewMarkdown?.use(streetViewEmbedPlugin);
+previewMarkdown?.use(tableSortOptOutPlugin);
 
 function renderEscapedPreview(plainText) {
   const element = document.createElement('pre');

--- a/lib/tableSortOptOut.js
+++ b/lib/tableSortOptOut.js
@@ -1,0 +1,29 @@
+export const NO_SORT_MARKER = '{.no-sort}';
+
+/**
+ * Converts a standalone marker before a table into an HTML class.
+ * @param {import('markdown-it')} md
+ */
+export function tableSortOptOutPlugin(md) {
+  md.core.ruler.after('block', 'table_sort_opt_out', (state) => {
+    for (let i = 3; i < state.tokens.length; i++) {
+      const table = state.tokens[i];
+      const paragraphOpen = state.tokens[i - 3];
+      const marker = state.tokens[i - 2];
+      const paragraphClose = state.tokens[i - 1];
+
+      const isMarkerBeforeTable = table.type === 'table_open'
+        && paragraphOpen.type === 'paragraph_open'
+        && marker.type === 'inline'
+        && marker.content.trim() === NO_SORT_MARKER
+        && paragraphClose.type === 'paragraph_close'
+        && paragraphOpen.level === table.level;
+
+      if (!isMarkerBeforeTable) continue;
+
+      table.attrJoin('class', 'no-sort');
+      state.tokens.splice(i - 3, 3);
+      i -= 3;
+    }
+  });
+}

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -211,7 +211,8 @@ button.toolbar-insert-button i {
 
 /* Tooltip Input Fields */
 .insert-tooltip input[type="text"],
-.insert-tooltip input[type="url"] {
+.insert-tooltip input[type="url"],
+.insert-tooltip input[type="number"] {
   width: 100%;
   padding: 10px;
   border: 1px solid var(--border-color);
@@ -225,7 +226,8 @@ button.toolbar-insert-button i {
 
 /* Focus Effect for Input Fields */
 .insert-tooltip input[type="text"]:focus,
-.insert-tooltip input[type="url"]:focus {
+.insert-tooltip input[type="url"]:focus,
+.insert-tooltip input[type="number"]:focus {
   border-color: var(--highlight-color);
   outline: none;
 }
@@ -274,6 +276,84 @@ button.toolbar-insert-button i {
   color: var(--editor-text-muted);
   font-size: 0.88rem;
   line-height: 1.4;
+}
+
+.insert-tooltip__title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.insert-tooltip__fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 5rem;
+  align-items: center;
+  gap: 10px;
+}
+
+.insert-tooltip__fields input[type="number"] {
+  text-align: end;
+}
+
+.insert-table-dialog .insert-table-dialog__label {
+  float: none;
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-color);
+  cursor: default;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.insert-table-dialog .insert-table-dialog__input {
+  float: none;
+  box-sizing: border-box;
+  margin: 0;
+  background: var(--input-bg, #fff);
+  color: var(--text-color);
+  font-family: inherit;
+}
+
+.insert-tooltip__checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  line-height: 1.35;
+}
+
+.insert-tooltip__checkbox input {
+  margin-top: 0.15em;
+  flex: 0 0 auto;
+}
+
+.insert-table-dialog .insert-table-dialog__checkbox {
+  float: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-color);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.insert-table-dialog .insert-table-dialog__checkbox input {
+  accent-color: var(--highlight-color);
+}
+
+.insert-table-dialog button {
+  float: none;
+  margin: 0;
+  font-family: inherit;
+  line-height: 1.2;
 }
 
 #block-title-container {
@@ -638,7 +718,8 @@ html[data-theme="dark"] .modal-message {
 html[data-theme="dark"] #block-title-input,
 html[data-theme="dark"] #description-edit,
 html[data-theme="dark"] .insert-tooltip input[type="text"],
-html[data-theme="dark"] .insert-tooltip input[type="url"] {
+html[data-theme="dark"] .insert-tooltip input[type="url"],
+html[data-theme="dark"] .insert-tooltip input[type="number"] {
   color: var(--text-color);
   background: var(--input-bg);
   border-color: var(--border-color);

--- a/server/utils/markdownHelper.js
+++ b/server/utils/markdownHelper.js
@@ -1,37 +1,7 @@
 // server/utils/markdownHelper.js
 import MarkdownIt from 'markdown-it';
 import { streetViewEmbedPlugin } from '../../lib/streetViewEmbed.js';
-
-const NO_SORT_MARKER = '{.no-sort}';
-
-/**
- * Convierte un marcador independiente antes de una tabla en una clase HTML.
- * Mantiene la extensión deliberadamente limitada a `{.no-sort}`.
- * @param {MarkdownIt} mdInstance
- */
-function tableSortOptOutPlugin(mdInstance) {
-  mdInstance.core.ruler.after('block', 'table_sort_opt_out', (state) => {
-    for (let i = 3; i < state.tokens.length; i++) {
-      const table = state.tokens[i];
-      const paragraphOpen = state.tokens[i - 3];
-      const marker = state.tokens[i - 2];
-      const paragraphClose = state.tokens[i - 1];
-
-      const isMarkerBeforeTable = table.type === 'table_open'
-        && paragraphOpen.type === 'paragraph_open'
-        && marker.type === 'inline'
-        && marker.content.trim() === NO_SORT_MARKER
-        && paragraphClose.type === 'paragraph_close'
-        && paragraphOpen.level === table.level;
-
-      if (!isMarkerBeforeTable) continue;
-
-      table.attrJoin('class', 'no-sort');
-      state.tokens.splice(i - 3, 3);
-      i -= 3;
-    }
-  });
-}
+import { tableSortOptOutPlugin } from '../../lib/tableSortOptOut.js';
 
 /**
  * Instancia de Markdown-It.

--- a/server/utils/markdownHelper.js
+++ b/server/utils/markdownHelper.js
@@ -2,6 +2,37 @@
 import MarkdownIt from 'markdown-it';
 import { streetViewEmbedPlugin } from '../../lib/streetViewEmbed.js';
 
+const NO_SORT_MARKER = '{.no-sort}';
+
+/**
+ * Convierte un marcador independiente antes de una tabla en una clase HTML.
+ * Mantiene la extensión deliberadamente limitada a `{.no-sort}`.
+ * @param {MarkdownIt} mdInstance
+ */
+function tableSortOptOutPlugin(mdInstance) {
+  mdInstance.core.ruler.after('block', 'table_sort_opt_out', (state) => {
+    for (let i = 3; i < state.tokens.length; i++) {
+      const table = state.tokens[i];
+      const paragraphOpen = state.tokens[i - 3];
+      const marker = state.tokens[i - 2];
+      const paragraphClose = state.tokens[i - 1];
+
+      const isMarkerBeforeTable = table.type === 'table_open'
+        && paragraphOpen.type === 'paragraph_open'
+        && marker.type === 'inline'
+        && marker.content.trim() === NO_SORT_MARKER
+        && paragraphClose.type === 'paragraph_close'
+        && paragraphOpen.level === table.level;
+
+      if (!isMarkerBeforeTable) continue;
+
+      table.attrJoin('class', 'no-sort');
+      state.tokens.splice(i - 3, 3);
+      i -= 3;
+    }
+  });
+}
+
 /**
  * Instancia de Markdown-It.
  * - html: false (por seguridad, evita HTML crudo)
@@ -12,7 +43,9 @@ const md = new MarkdownIt({
   html: false,
   linkify: true,
   breaks: false
-}).use(streetViewEmbedPlugin);
+})
+  .use(streetViewEmbedPlugin)
+  .use(tableSortOptOutPlugin);
 
 /** ---------- Helpers de HTML post-render ---------- */
 
@@ -25,8 +58,8 @@ const md = new MarkdownIt({
 function wrapTables(html) {
   return html
     .replace(
-      /<table>/g,
-      '<div class="table-scroll-container"><div class="table-scroll-wrapper"><table>'
+      /<table([^>]*)>/g,
+      '<div class="table-scroll-container"><div class="table-scroll-wrapper"><table$1>'
     )
     .replace(/<\/table>/g, '</table></div></div>');
 }

--- a/spec/controllerSpec.js
+++ b/spec/controllerSpec.js
@@ -865,6 +865,22 @@ describe("Controller", () => {
       controller.localInsert("a", { line: 0, ch: 5 });
       expect(controller.crdt.handleLocalInsert).toHaveBeenCalledWith("a", { line: 0, ch: 6 });
     });
+
+    it("decomposes a multiline editor change into positioned character insertions", () => {
+      controller.isReadyForLocalEdits = true;
+      const insertions = [];
+      spyOn(controller.crdt, "handleLocalInsert").and.callFake((char, pos) => {
+        insertions.push({ char, pos: { ...pos } });
+      });
+
+      controller.localInsert("A\nB", { line: 2, ch: 4 });
+
+      expect(insertions).toEqual([
+        { char: 'A', pos: { line: 2, ch: 4 } },
+        { char: '\n', pos: { line: 2, ch: 5 } },
+        { char: 'B', pos: { line: 3, ch: 0 } }
+      ]);
+    });
   });
 
   describe("broadcastInsertion", () => {

--- a/spec/editorSpec.js
+++ b/spec/editorSpec.js
@@ -45,6 +45,7 @@ describe("Editor", () => {
     let dom;
     let toolbarEditor;
     let alertSpy;
+    let codemirror;
 
     beforeEach(() => {
       dom = new JSDOM(`
@@ -57,12 +58,13 @@ describe("Editor", () => {
       alertSpy = jasmine.createSpy('alert');
       globalThis.alert = alertSpy;
 
-      toolbarEditor = new Editor({
-        codemirror: {
-          setOption() {},
-          getCursor() { return { line: 2, ch: 3 }; }
-        }
-      });
+      codemirror = {
+        setOption() {},
+        getCursor() { return { line: 2, ch: 3 }; },
+        replaceRange: jasmine.createSpy('replaceRange'),
+        focus: jasmine.createSpy('focus')
+      };
+      toolbarEditor = new Editor({ codemirror });
     });
 
     afterEach(() => {
@@ -75,17 +77,19 @@ describe("Editor", () => {
       else globalThis.alert = originalAlert;
     });
 
-    it('inserts a validated Street View directive through simulated typing', () => {
+    it('inserts a validated Street View directive as one editor change', () => {
       const embedUrl = 'https://www.google.com/maps/embed?pb=!4v123!6m8';
       document.getElementById('street-view-url').value = ` ${embedUrl} `;
-      spyOn(toolbarEditor, 'simulateTyping');
 
       toolbarEditor.insertStreetView();
 
-      expect(toolbarEditor.simulateTyping).toHaveBeenCalledWith(
+      expect(codemirror.replaceRange).toHaveBeenCalledWith(
         `@[streetview](${embedUrl})`,
-        { line: 2, ch: 3 }
+        { line: 2, ch: 3 },
+        { line: 2, ch: 3 },
+        '+input'
       );
+      expect(codemirror.focus).toHaveBeenCalled();
       expect(document.getElementById('insert-street-view-tooltip').classList)
         .toContain('hidden');
       expect(document.getElementById('street-view-url').value).toBe('');
@@ -96,14 +100,60 @@ describe("Editor", () => {
     it('rejects a non-embed or untrusted URL', () => {
       document.getElementById('street-view-url').value =
         'https://www.google.com.evil.example/maps/embed?pb=value';
-      spyOn(toolbarEditor, 'simulateTyping');
 
       toolbarEditor.insertStreetView();
 
       expect(alertSpy).toHaveBeenCalledWith(
         'Enter a valid Google Maps Street View embed URL.'
       );
-      expect(toolbarEditor.simulateTyping).not.toHaveBeenCalled();
+      expect(codemirror.replaceRange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('image toolbar insertion', () => {
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+    let dom;
+    let imageEditor;
+    let codemirror;
+
+    beforeEach(() => {
+      dom = new JSDOM(`
+        <div id="insert-img-tooltip"></div>
+        <input id="img-url" value=" https://example.com/photo.jpg ">
+        <input id="img-alt" value=" A view ">
+      `);
+      globalThis.window = dom.window;
+      globalThis.document = dom.window.document;
+      codemirror = {
+        setOption() {},
+        getCursor() { return { line: 4, ch: 1 }; },
+        replaceRange: jasmine.createSpy('replaceRange'),
+        focus: jasmine.createSpy('focus')
+      };
+      imageEditor = new Editor({ codemirror });
+      spyOn(imageEditor, 'markImages');
+    });
+
+    afterEach(() => {
+      dom.window.close();
+      if (originalWindow === undefined) delete globalThis.window;
+      else globalThis.window = originalWindow;
+      if (originalDocument === undefined) delete globalThis.document;
+      else globalThis.document = originalDocument;
+    });
+
+    it('inserts image Markdown as one editor change', () => {
+      imageEditor.insertImage();
+
+      expect(codemirror.replaceRange).toHaveBeenCalledWith(
+        '![A view](https://example.com/photo.jpg)',
+        { line: 4, ch: 1 },
+        { line: 4, ch: 1 },
+        '+input'
+      );
+      expect(codemirror.focus).toHaveBeenCalled();
+      expect(imageEditor.markImages).toHaveBeenCalled();
     });
   });
 

--- a/spec/editorSpec.js
+++ b/spec/editorSpec.js
@@ -1,4 +1,4 @@
-import Editor from '../lib/editor.js';
+import Editor, { createMarkdownTable } from '../lib/editor.js';
 import { JSDOM } from 'jsdom';
 
 describe("Editor", () => {
@@ -104,6 +104,85 @@ describe("Editor", () => {
         'Enter a valid Google Maps Street View embed URL.'
       );
       expect(toolbarEditor.simulateTyping).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('table toolbar insertion', () => {
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+    let dom;
+    let tableEditor;
+    let codemirror;
+
+    beforeEach(() => {
+      dom = new JSDOM(`
+        <button id="open-insert-table-btn" aria-expanded="true"></button>
+        <div id="insert-table-tooltip">
+          <form id="insert-table-form">
+            <input id="table-rows" type="number" min="1" max="20" value="2" required>
+            <input id="table-columns" type="number" min="1" max="10" value="3" required>
+            <input id="table-sortable" type="checkbox">
+          </form>
+        </div>
+      `);
+      globalThis.window = dom.window;
+      globalThis.document = dom.window.document;
+      codemirror = {
+        setOption() {},
+        getCursor() { return { line: 1, ch: 4 }; },
+        replaceRange: jasmine.createSpy('replaceRange'),
+        focus: jasmine.createSpy('focus')
+      };
+      tableEditor = new Editor({ codemirror });
+    });
+
+    afterEach(() => {
+      dom.window.close();
+      if (originalWindow === undefined) delete globalThis.window;
+      else globalThis.window = originalWindow;
+      if (originalDocument === undefined) delete globalThis.document;
+      else globalThis.document = originalDocument;
+    });
+
+    it('builds a sortable Markdown table with the requested dimensions', () => {
+      expect(createMarkdownTable(2, 3)).toBe(
+        '|  |  |  |\n| --- | --- | --- |\n|  |  |  |\n|  |  |  |'
+      );
+    });
+
+    it('adds the no-sort marker when sorting is disabled', () => {
+      tableEditor.insertTable({ preventDefault() {} });
+
+      expect(codemirror.replaceRange).toHaveBeenCalledWith(
+        '\n\n{.no-sort}\n\n|  |  |  |\n| --- | --- | --- |\n|  |  |  |\n|  |  |  |\n\n',
+        { line: 1, ch: 4 },
+        { line: 1, ch: 4 },
+        '+input'
+      );
+      expect(document.getElementById('insert-table-tooltip').classList)
+        .toContain('hidden');
+      expect(document.getElementById('open-insert-table-btn')
+        .getAttribute('aria-expanded')).toBe('false');
+      expect(codemirror.focus).toHaveBeenCalled();
+    });
+
+    it('rejects dimensions outside the supported limits', () => {
+      expect(() => createMarkdownTable(0, 2)).toThrowError(RangeError);
+      expect(() => createMarkdownTable(2, 11)).toThrowError(RangeError);
+    });
+
+    it('closes on Escape and restores focus to the toolbar button', () => {
+      const button = document.getElementById('open-insert-table-btn');
+      spyOn(button, 'focus');
+
+      tableEditor.handleTableInsertionKeydown({
+        key: 'Escape',
+        preventDefault() {}
+      });
+
+      expect(document.getElementById('insert-table-tooltip').classList)
+        .toContain('hidden');
+      expect(button.focus).toHaveBeenCalled();
     });
   });
 

--- a/spec/markdownTableSortOptoutSpec.js
+++ b/spec/markdownTableSortOptoutSpec.js
@@ -1,0 +1,53 @@
+import {
+  renderMarkdownContent,
+  renderMarkdownPreview
+} from '../server/utils/markdownHelper.js';
+
+const table = `| Scale | Freezing |
+|---|---:|
+| Celsius | 0 |`;
+
+describe('Markdown table sorting opt-out', () => {
+  it('adds no-sort to a table after a standalone marker', () => {
+    const html = renderMarkdownContent(`{.no-sort}\n\n${table}`);
+
+    expect(html).toContain('<table class="no-sort">');
+    expect(html).not.toContain('{.no-sort}');
+    expect(html).toContain('<div class="table-scroll-wrapper"><table class="no-sort">');
+  });
+
+  it('supports the marker directly above the table without a blank line', () => {
+    const html = renderMarkdownContent(`{.no-sort}\n${table}`);
+
+    expect(html).toContain('<table class="no-sort">');
+    expect(html).not.toContain('{.no-sort}');
+  });
+
+  it('leaves ordinary tables sortable', () => {
+    const html = renderMarkdownContent(table);
+
+    expect(html).toContain('<table>');
+    expect(html).not.toContain('no-sort');
+  });
+
+  it('preserves the marker as text when it is not immediately followed by a table', () => {
+    const html = renderMarkdownContent(`{.no-sort}\n\nSome explanation.\n\n${table}`);
+
+    expect(html).toContain('<p>{.no-sort}</p>');
+    expect(html).toContain('<table>');
+  });
+
+  it('does not consume a marker combined with other text', () => {
+    const html = renderMarkdownContent(`Use {.no-sort}\n\n${table}`);
+
+    expect(html).toContain('<p>Use {.no-sort}</p>');
+    expect(html).toContain('<table>');
+  });
+
+  it('retains the opt-out in rendered previews', () => {
+    const { html } = renderMarkdownPreview(`{.no-sort}\n\n${table}`);
+
+    expect(html).toContain('<table class="no-sort">');
+    expect(html).not.toContain('{.no-sort}');
+  });
+});

--- a/spec/tableToolbarI18nSpec.js
+++ b/spec/tableToolbarI18nSpec.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { SUPPORTED_UI_LANGS } from '../server/services/localeContext.js';
+
+const toolbarPaths = [
+  'insertTable',
+  'insertTableHelp',
+  'tableRows',
+  'tableColumns',
+  'tableSortable'
+];
+
+function readToolbar(lang) {
+  const file = path.join(process.cwd(), 'i18n', lang, 'blockEditor.json');
+  return JSON.parse(fs.readFileSync(file, 'utf8')).blockEditor.toolbar;
+}
+
+describe('table toolbar localization', () => {
+  for (const lang of SUPPORTED_UI_LANGS) {
+    it(`defines every table toolbar string directly in ${lang}`, () => {
+      const toolbar = readToolbar(lang);
+
+      for (const key of toolbarPaths) {
+        expect(typeof toolbar[key]).withContext(`blockEditor.toolbar.${key}`).toBe('string');
+        expect(toolbar[key].trim().length)
+          .withContext(`blockEditor.toolbar.${key}`)
+          .toBeGreaterThan(0);
+      }
+    });
+  }
+});

--- a/views/rooms/block-editor.pug
+++ b/views/rooms/block-editor.pug
@@ -147,6 +147,32 @@ block content
                 .insert-tooltip__actions
                   button#insert-street-view-confirm.insert-tooltip__confirm(type='button')= t('blockEditor.toolbar.insertImageConfirm')
                   button#insert-street-view-cancel.insert-tooltip__cancel(type='button')= t('blockEditor.toolbar.insertImageCancel')
+            button#open-insert-table-btn.toolbar-insert-button(
+              type='button'
+              data-tooltip=t('blockEditor.toolbar.insertTable')
+              aria-label=t('blockEditor.toolbar.insertTable')
+              aria-expanded='false'
+              aria-controls='insert-table-tooltip'
+            )
+              i(data-feather='grid')
+            div#insert-table-tooltip.insert-tooltip.insert-table-dialog.hidden(
+              role='dialog'
+              aria-labelledby='insert-table-title'
+            )
+              form#insert-table-form
+                p#insert-table-title.insert-tooltip__title= t('blockEditor.toolbar.insertTable')
+                p.insert-tooltip__help= t('blockEditor.toolbar.insertTableHelp')
+                .insert-tooltip__fields
+                  label.insert-table-dialog__label(for='table-rows')= t('blockEditor.toolbar.tableRows')
+                  input#table-rows.insert-table-dialog__input(type='number' min='1' max='20' value='3' required)
+                  label.insert-table-dialog__label(for='table-columns')= t('blockEditor.toolbar.tableColumns')
+                  input#table-columns.insert-table-dialog__input(type='number' min='1' max='10' value='3' required)
+                label.insert-tooltip__checkbox.insert-table-dialog__checkbox(for='table-sortable')
+                  input#table-sortable(type='checkbox' checked)
+                  span= t('blockEditor.toolbar.tableSortable')
+                .insert-tooltip__actions
+                  button#insert-table-confirm.insert-tooltip__confirm(type='submit')= t('blockEditor.toolbar.insertImageConfirm')
+                  button#insert-table-cancel.insert-tooltip__cancel(type='button')= t('blockEditor.toolbar.insertImageCancel')
           textarea#editor-content(lang=contentLang dir=contentDir)= block.content
         p#peerId= t('blockEditor.peers.label')
     .video-modal.hide


### PR DESCRIPTION
## Summary

- add a `{.no-sort}` Markdown marker for disabling table sorting
- preserve the opt-out in full post and preview rendering
- add an accessible table-insertion dialog to the editor toolbar
- support configurable body rows, columns, and sorting behavior
- localize the table dialog across all supported UI languages
- isolate dialog styles from broad legacy form rules
- simplify Image, Street View, and table insertion through one immediate CodeMirror path
- retain per-character CRDT processing for collaborative edits

## Example

```markdown
{.no-sort}

| Scale | Freezing | Boiling |
|---|---:|---:|
| Celsius | 0 | 100 |
```

## Testing

- added coverage for marker parsing, previews, table generation, toolbar behavior, localization, and multiline CRDT insertion
- all 386 specs pass
- verified the editor template compiles and the client bundle builds
