### PR TITLE
Constrain wide Markdown table columns

### DIFF
--- a/public/css/table-scroll-fade.css
+++ b/public/css/table-scroll-fade.css
@@ -22,6 +22,14 @@
   table-layout: auto;
 }
 
+/* Keep one content-heavy column from becoming wider than the viewport. */
+.table-scroll-wrapper th,
+.table-scroll-wrapper td {
+  max-width: min(36rem, 75vw);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 /* Fade izquierdo */
 .table-scroll-container::before {
   content: "";


### PR DESCRIPTION
## Summary

- limit Markdown table columns to `min(36rem, 75vw)`
- wrap prose within oversized cells
- break long URLs and identifiers when necessary
- preserve horizontal scrolling for tables with multiple columns

## Testing

- all 386 specs pass