### PR TITLE
Order background articles before deep dives in reading guides

### DIFF
--- a/server/db/blockEditorialContextService.js
+++ b/server/db/blockEditorialContextService.js
@@ -17,8 +17,8 @@ const REFERENCE_BLOCK_FIELDS = [
 
 const CLUSTER_ROLES = {
   pillar: 0,
-  companion: 1,
-  texture: 2
+  texture: 1,
+  companion: 2
 };
 
 function toId(value) {
@@ -56,13 +56,13 @@ function toEditorialLink(block) {
 }
 
 function compareClusterBlocks(a, b) {
-  const aSeq = Number.isInteger(a.editorial?.sequence) ? a.editorial.sequence : Number.POSITIVE_INFINITY;
-  const bSeq = Number.isInteger(b.editorial?.sequence) ? b.editorial.sequence : Number.POSITIVE_INFINITY;
-  if (aSeq !== bSeq) return aSeq - bSeq;
-
   const aRole = CLUSTER_ROLES[a.editorial?.role] ?? Number.POSITIVE_INFINITY;
   const bRole = CLUSTER_ROLES[b.editorial?.role] ?? Number.POSITIVE_INFINITY;
   if (aRole !== bRole) return aRole - bRole;
+
+  const aSeq = Number.isInteger(a.editorial?.sequence) ? a.editorial.sequence : Number.POSITIVE_INFINITY;
+  const bSeq = Number.isInteger(b.editorial?.sequence) ? b.editorial.sequence : Number.POSITIVE_INFINITY;
+  if (aSeq !== bSeq) return aSeq - bSeq;
 
   const aCreated = a.createdAt ? new Date(a.createdAt).getTime() : 0;
   const bCreated = b.createdAt ? new Date(b.createdAt).getTime() : 0;

--- a/server/db/roomEditorialClusterService.js
+++ b/server/db/roomEditorialClusterService.js
@@ -18,8 +18,8 @@ const ROOM_EDITORIAL_FIELDS = [
 
 const CLUSTER_ROLES = {
   pillar: 0,
-  companion: 1,
-  texture: 2
+  texture: 1,
+  companion: 2
 };
 
 function toId(value) {

--- a/spec/blockEditorialContextServiceSpec.js
+++ b/spec/blockEditorialContextServiceSpec.js
@@ -244,4 +244,64 @@ describe('getBlockEditorialContext', () => {
     expect(context?.cluster?.label).toBe('Forces and motion');
     expect(context?.cluster?.key).toBe('forces-path');
   });
+
+  it('places background articles before deep dives regardless of sequence or creation time', async () => {
+    spyOn(Block, 'find').and.callFake((filter) => {
+      const query = baseFilter(filter);
+
+      if (query._id?.$in) return makeQueryResult([]);
+
+      if (query['editorial.clusterKey'] === 'dimensions-guide') {
+        return makeQueryResult([
+          {
+            _id: '507f1f77bcf86cd799439311',
+            title: 'First deep dive',
+            roomId: 'physics',
+            lang: 'en',
+            visibility: 'public',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            editorial: { role: 'companion', sequence: 1 }
+          },
+          {
+            _id: '507f1f77bcf86cd799439312',
+            title: 'Human background',
+            roomId: 'physics',
+            lang: 'en',
+            visibility: 'public',
+            createdAt: '2026-01-03T00:00:00.000Z',
+            editorial: { role: 'texture', sequence: 3 }
+          },
+          {
+            _id: '507f1f77bcf86cd799439313',
+            title: 'Second deep dive',
+            roomId: 'physics',
+            lang: 'en',
+            visibility: 'public',
+            createdAt: '2026-01-02T00:00:00.000Z',
+            editorial: { role: 'companion', sequence: 2 }
+          }
+        ]);
+      }
+
+      throw new Error(`Unexpected Block.find call: ${JSON.stringify(filter)}`);
+    });
+
+    const context = await getBlockEditorialContext({
+      _id: '507f1f77bcf86cd799439399',
+      title: 'Core guide',
+      roomId: 'physics',
+      lang: 'en',
+      editorial: {
+        clusterKey: 'dimensions-guide',
+        role: 'pillar',
+        sequence: 0
+      }
+    });
+
+    expect(context.cluster.nearby.map((item) => item.title)).toEqual([
+      'Human background',
+      'First deep dive',
+      'Second deep dive'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- order reading guide entries by editorial role
- place core guides first, background articles second, and deep dives last
- preserve sequence and creation time ordering within each role
- add regression coverage for mixed-role clusters

## Testing

- `npx jasmine spec/blockEditorialContextServiceSpec.js spec/roomEditorialClusterServiceSpec.js`
- `npx eslint server/db/blockEditorialContextService.js server/db/roomEditorialClusterService.js spec/blockEditorialContextServiceSpec.js`