### PR TITLE
Vary v3 procedural tree branch starting height

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -149,6 +149,7 @@ Renderer v2 established the original deterministic visual grammar and is preserv
 
 - Deterministic three-dimensional, space-colonization-inspired branch growth projected into two dimensions.
 - Persistent trunk and branch hierarchy with bounded growth and explicit termination.
+- Seed-derived specimen architecture, beginning with bounded branch-start height variation.
 - Back-propagated branch thickness, trunk taper, root flare, and leafless wood rasterization.
 - Depth-aware individual foliage attached to eligible branch growth.
 - Coverage repair that preserves negative space without producing detached canopy masses.
@@ -166,6 +167,7 @@ The recommended near-term technical sequence is:
 ### Files
 
 - `server/services/forestTreeGeneratorV3.js`: experimental v3 orchestration.
+- `server/services/forest/v3/architecture.js`: deterministic per-tree architectural traits.
 - `server/services/forest/v3/phenotype.js`: pilot phenotype and growth tendencies.
 - `server/services/forest/v3/growth.js`: deterministic three-dimensional branch growth.
 - `server/services/forest/v3/rasterizeWood.js`: tapered wood, root flare, and bark rendering.

--- a/server/services/forest/v3/architecture.js
+++ b/server/services/forest/v3/architecture.js
@@ -1,0 +1,14 @@
+import { createRandom } from './random.js';
+
+function sampleRange(random, range) {
+  return range[0] + ((range[1] - range[0]) * random());
+}
+
+export function deriveTreeArchitecture(seed, phenotype) {
+  const random = createRandom(seed ^ 0xA2C417EC);
+  const branchStartHeight = Math.round(
+    sampleRange(random, phenotype.architecture.branchStartHeight) * 2
+  ) / 2;
+
+  return Object.freeze({ branchStartHeight });
+}

--- a/server/services/forest/v3/growth.js
+++ b/server/services/forest/v3/growth.js
@@ -1,4 +1,5 @@
 import { createRandom } from './random.js';
+import { deriveTreeArchitecture } from './architecture.js';
 
 const clamp = (value, minimum, maximum) => Math.max(minimum, Math.min(maximum, value));
 
@@ -152,7 +153,7 @@ function appendSegment(segments, parent, child) {
   });
 }
 
-function buildScaffold(nodes, segments, phenotype, random) {
+function buildScaffold(nodes, segments, phenotype, architecture, random) {
   let leader = nodes[0];
   const trunkNodes = [];
   while (leader.worldY - phenotype.internodeLength > phenotype.trunkTopY) {
@@ -168,7 +169,8 @@ function buildScaffold(nodes, segments, phenotype, random) {
     });
     appendSegment(segments, leader, child);
     leader = child;
-    if (leader.worldY <= phenotype.branchStartY) trunkNodes.push(leader);
+    const heightAboveGround = phenotype.groundY - leader.worldY;
+    if (heightAboveGround >= architecture.branchStartHeight) trunkNodes.push(leader);
   }
 
   const primaryTips = [];
@@ -270,6 +272,13 @@ function directionIsClear(parent, direction, nodes, phenotype) {
     worldZ: parent.worldZ + (direction.z * phenotype.internodeLength)
   };
   if (candidate.worldY <= 0 || candidate.worldY >= phenotype.groundY) return false;
+  const projected = projectPosition({
+    x: candidate.worldX,
+    y: candidate.worldY,
+    z: candidate.worldZ
+  }, phenotype);
+  if (projected.x < 0 || projected.x > phenotype.width
+    || projected.y < 0 || projected.y > phenotype.groundY) return false;
   if (parent.generation > 0 && !insideCrown({
     x: candidate.worldX,
     y: candidate.worldY,
@@ -307,6 +316,7 @@ function calculateRadii(nodes, segments, phenotype) {
 
 export function growBranchGraph(seed, phenotype) {
   const random = createRandom(seed ^ 0xB4A9C135);
+  const architecture = deriveTreeArchitecture(seed, phenotype);
   const attractionPoints = generateAttractionPoints(seed, phenotype);
   let remainingPoints = attractionPoints.slice();
   const rootProjection = projectPosition({ x: 0, y: phenotype.groundY, z: 0 }, phenotype);
@@ -326,7 +336,7 @@ export function growBranchGraph(seed, phenotype) {
     axisDirection: { x: 0, y: -1, z: 0 }
   }];
   const segments = [];
-  let terminals = buildScaffold(nodes, segments, phenotype, random);
+  let terminals = buildScaffold(nodes, segments, phenotype, architecture, random);
   let iterations = 0;
 
   while (iterations < phenotype.maxIterations && remainingPoints.length && terminals.length
@@ -393,6 +403,7 @@ export function growBranchGraph(seed, phenotype) {
     : iterations >= phenotype.maxIterations ? 'iteration-limit'
       : remainingPoints.length === 0 ? 'points-consumed' : 'growth-exhausted';
   return {
+    architecture,
     nodes: nodes.map(node => ({
       id: node.id,
       x: node.x,

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -15,7 +15,9 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
   growthEnvelopeOverscan: 1.04,
   attractionPointCount: 180,
   attractionGap: 0.1,
-  branchStartY: 91,
+  architecture: Object.freeze({
+    branchStartHeight: Object.freeze([22, 38])
+  }),
   trunkTopY: 43,
   primaryBranchCount: 5,
   primaryBranchAngle: 0.88,

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -23,6 +23,26 @@ describe('v3 forest branch graph generator', () => {
     expect(second.nodes).not.toEqual(first.nodes);
   });
 
+  it('derives a deterministic, bounded branch starting height for each specimen', () => {
+    const observedHeights = new Set();
+    for (let seed = 0; seed < 100; seed += 1) {
+      const graph = generateForestTreeGraph(post, { seed });
+      const [minimum, maximum] = graph.phenotype.architecture.branchStartHeight;
+      const { branchStartHeight } = graph.architecture;
+      const primaryOrigins = graph.segments
+        .filter(segment => graph.nodes[segment.fromId].generation === 0
+          && graph.nodes[segment.toId].generation === 1)
+        .map(segment => graph.phenotype.groundY - graph.nodes[segment.fromId].worldY);
+
+      expect(branchStartHeight).toBeGreaterThanOrEqual(minimum);
+      expect(branchStartHeight).toBeLessThanOrEqual(maximum);
+      expect(primaryOrigins.length).toBeGreaterThanOrEqual(graph.phenotype.primaryBranchCount);
+      expect(primaryOrigins.every(height => height >= branchStartHeight)).toBeTrue();
+      observedHeights.add(branchStartHeight);
+    }
+    expect(observedHeights.size).toBeGreaterThan(10);
+  });
+
   it('creates a valid rooted graph with one parent per non-root node', () => {
     const graph = generateForestTreeGraph(post);
     const incoming = Array(graph.nodes.length).fill(0);

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -101,6 +101,7 @@ block content
           p.forest-comparison__meta
             - const maximumOrder = Math.max(...item.tree.nodes.map(node => node.generation))
             | Seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
+            |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
             |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·
             |  #{item.tree.foliage.leaves.length} leaves ·
             |  #{item.tree.diagnostics.crossingCount} projected overlaps ·


### PR DESCRIPTION
## Summary

This PR adds the first specimen-level architectural variance to the v3 Activity Forest tree generator: deterministic branch-start height variation.

Instead of every tree beginning its primary branching at the same fixed trunk height, each tree now derives a bounded `branchStartHeight` from its seed. This keeps the current deciduous phenotype intact while letting individual trees differ more naturally in where their crown begins.

## Changes

- Adds `server/services/forest/v3/architecture.js` for deterministic per-tree architectural traits.
- Replaces the fixed `branchStartY` phenotype value with a bounded architecture range.
- Derives `branchStartHeight` from the tree seed and includes it in the generated graph output.
- Uses the derived branch-start height when building the trunk scaffold and primary branches.
- Adds a projected bounds check during growth candidate validation.
- Shows branch-start height in the Forest Lab debug metadata.
- Documents the new architecture layer in the forest design notes.
- Adds spec coverage for deterministic, bounded branch-start variance.

## Why

This is the first step toward making trees feel like individual grown organisms within the same phenotype, rather than identical structures with different random details.

Longer term, this architecture layer should also support:

- trunk lean
- base thickness and taper variation
- major forks and split trunks
- leader weight balance
- phenotype-specific architectural tendencies

## Testing

- Forest v3 spec passes.
- Full test suite passes.
- `git diff --check` passes.