### PR TITLE
Document Daily Page sustainability and open-source strategy

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -101,6 +101,30 @@ A useful design test is:
 
 If so, resources may deepen it. If not, it is likely a reward treadmill rather than part of the forest's emotional life.
 
+## Sustainability boundary
+
+The forest's future revenue model should preserve the same moral shape as its resource economy: payment may expand private space, continuity, and hosted convenience, but should not buy public status, creative dignity, or mechanical power.
+
+A promising boundary is:
+
+```text
+Free:
+public writing grows a meaningful public Activity Forest
+
+Paid:
+private writing grows private Activity Forest spaces
+```
+
+This makes the paid value a natural inward extension of the same product idea rather than a superior version of the public experience. Public writing remains complete, beautiful, and worth tending. Paid private forests support more personal writing, private organization, hosted infrastructure, backups, long-term continuity, and privacy expectations.
+
+The guiding principle is:
+
+> **Paid privacy, not paid dignity.**
+
+Everyone should receive the core magic of seeing writing become a place. Payment should buy private terrain on the hosted service, not better trees, stronger resources, higher visibility, moderation influence, or a privileged public identity.
+
+The broader product and open-source implications of this model are tracked in `docs/product/sustainability-and-open-source.md`.
+
 ## Product guardrails
 
 - No punishment, damage, or irreversible loss caused by absence.

--- a/docs/product/sustainability-and-open-source.md
+++ b/docs/product/sustainability-and-open-source.md
@@ -1,0 +1,98 @@
+# Daily Page Sustainability and Open Source
+
+## Purpose
+
+This document records a product strategy direction for making Daily Page financially sustainable without violating the spirit of the site.
+
+Daily Page should remain a generous public writing commons. Revenue should come from paid private space and hosted continuity, not from selling visibility, public status, moderation power, or access to the basic dignity of writing here.
+
+The short version is:
+
+> **The public forest should prove the spirit of Daily Page. The private forest should sustain it.**
+
+## Revenue model
+
+The cleanest long-term paid boundary is private hosted writing:
+
+```text
+Free:
+public writing in the Daily Page commons
+public posts represented in a meaningful Activity Forest
+core reading, writing, discovery, and community participation
+
+Paid:
+private writing spaces
+private Activity Forests grown from private writing
+hosted continuity, privacy expectations, backups, and personal organization
+```
+
+This boundary works because it is not a tax on public participation. It does not make free users' writing less expressive, less beautiful, or less legitimate. It gives paying users a deeper inward version of the same product idea: the ability to bring more personal writing into Daily Page and let it grow into a private place.
+
+Daily Page should avoid revenue models that undermine the commons:
+
+- Selling public visibility or ranking.
+- Giving paid users superior public status.
+- Charging for core public writing, commenting, or reading functions.
+- Making the free Activity Forest feel intentionally dull or incomplete.
+- Turning resources, streaks, or activity volume into public power.
+- Depending on ads that distort the writing environment.
+
+The paid promise should be private terrain, not paid dignity. Everyone gets the core magic. Paid users get hosted private space for writing that does not belong in the public square.
+
+## Product principles
+
+Payment should attach to real hosted value:
+
+- Privacy and access control.
+- Storage and infrastructure.
+- Backups and long-term continuity.
+- Personal organization and private rooms.
+- Reliable deployment, updates, and security maintenance.
+- A private Activity Forest that reflects private writing history.
+
+Payment should not attach to public leverage:
+
+- More powerful trees or resources.
+- Preferential moderation outcomes.
+- Higher visibility in public spaces.
+- Exclusive public expression mechanics.
+- Essential writing, reading, or community tools.
+
+A useful shorthand is:
+
+> **Paid privacy, not paid dignity.**
+
+## Open-source posture
+
+Daily Page being open source does not inherently weaken this model. The business is not selling access to hidden code. The business would be selling a trusted hosted writing place with identity, continuity, privacy, community, moderation, and stewardship.
+
+The official hosted service can remain valuable even when the code is public because most users do not want to operate the full stack themselves. A complete independent deployment can require database setup, object storage, email, environment variables, production hosting, domain and HTTPS configuration, WebRTC/TURN support, backups, updates, monitoring, moderation, and ongoing maintenance.
+
+Self-hosting can still be a strength. It can support developers, schools, clubs, experiments, accessibility work, audits, and community contributions. Public source code can increase trust because users can inspect how the site works, understand its values, and contribute improvements to the Activity Forest and the broader app.
+
+The moat should not be secrecy. The moat should be the living bundle:
+
+- The canonical Daily Page domain.
+- The public writing commons.
+- User identity and writing history.
+- Hosted private forests.
+- Reliable infrastructure and backups.
+- Moderation and trust.
+- Ongoing design taste.
+- The creator's stewardship.
+
+## License note
+
+The repository currently uses the MIT license. That is a permissive and friendly open-source posture, but it also allows commercial reuse and competing hosted services as long as the license terms are followed.
+
+This does not make the sustainability model invalid. It does mean the licensing choice should remain intentional, especially if the Activity Forest becomes a central business asset. Future review could consider whether MIT still fits the project, or whether another open-source strategy such as copyleft, network copyleft, or open core better matches Daily Page's goals.
+
+This is a planning note, not legal advice. Any license change should be handled carefully before meaningful revenue or outside contributions make the question more complicated.
+
+## Forest connection
+
+The Activity Forest is the strongest known expression of this model because it turns writing history into an inhabitable place. The public version can show why Daily Page matters:
+
+> "Here, your writing becomes a place."
+
+The private version can make the same promise for writing that users want to keep personal. That is why the forest should be designed first as a meaningful public experience, then extended into private space only in ways that preserve the public commons.


### PR DESCRIPTION
## Summary

- Add a product planning doc for Daily Page’s sustainability and open-source posture
- Document the proposed public/free vs private/paid boundary
- Add a small Activity Forest section tying paid private forests to the existing economy guardrails
- Note that MIT licensing is compatible with the current strategy but should remain an intentional future review point

## Notes

This is a planning-only change. It does not change licensing, implementation, pricing, or product behavior.

## Testing

Not run; docs-only change.