### PR TITLE
feat(home): redesign homepage around trending content

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,7 +44,9 @@ import { initI18n, addI18n } from './server/services/i18n.js'
 import { startJobs } from './server/services/cron.js';
 import * as google from './server/services/google.js';
 import { timeIt } from './server/services/perf.js';
+import { getHomeActivitySince, getHomeActivityVisibility } from './server/services/homepage.js';
 import { getRecurringSupportMonthlyTotalUsd } from './server/db/supportFundingService.js';
+import { listPublicQuestsOverview } from './server/db/questService.js';
 
 import { renderMarkdownContent } from './server/utils/markdownHelper.js';
 import { titleOnlyMeta } from './server/utils/unfinished.js';
@@ -632,7 +634,7 @@ async function getSupportFundingViewModel() {
       '/',
       optionalAuth,
       addI18n([
-        'home', 'blockCommon', 'translation', 'reactions', 'readMore', 'voteControls'
+        'home', 'quests', 'blockCommon', 'translation', 'reactions', 'readMore', 'voteControls'
       ]),
       stripLegacyLang({ canonicalPath: '/' }),
       async (req, res) => {
@@ -644,34 +646,37 @@ async function getSupportFundingViewModel() {
 
           const PERF = process.env.PERF_HOME === '1';
 
-          let fbRes, frRes, topRes, tagsRes, statsRes, roomsRes, totalTagsRes, recentComments, recentReactions, supportFunding;
+          let fbRes, frRes, topRes, tagsRes, statsRes, roomsRes, totalTagsRes, recentComments, recentReactions, supportFunding, questsRes;
+          const activitySince = getHomeActivitySince();
 
           // Dispara todo en paralelo (con perf opcional por cada llamada)
           if (!PERF) {
-            [fbRes, frRes, topRes, tagsRes, statsRes, roomsRes, totalTagsRes, recentComments, recentReactions, supportFunding] = await Promise.all([
-              getFeaturedBlockWithFallback({ preferredLang: preferredContentLang }),
-              getFeaturedRoomWithFallback(),
+            [fbRes, frRes, topRes, tagsRes, statsRes, roomsRes, totalTagsRes, recentComments, recentReactions, supportFunding, questsRes] = await Promise.all([
+              config.homeShowFeaturedPost ? getFeaturedBlockWithFallback({ preferredLang: preferredContentLang }) : null,
+              config.homeShowFeaturedRoom ? getFeaturedRoomWithFallback() : null,
               getTopBlocksWithFallback({ lockedOnly: false, limit: 20, preferredLang: preferredContentLang, includePinnedHome: true }),
               getTrendingTagsWithFallback({ limit: 10, sortBy: 'totalBlocks' }),
               getGlobalBlockStats(),
               getTotalRooms(),
               getTotalTags(),
-              getRecentCommentActivity({ limit: 5, lang: uiLang }),
-              getRecentReactionActivity({ limit: 5, lang: uiLang }),
-              getSupportFundingViewModel(),
+              getRecentCommentActivity({ limit: 5, lang: uiLang, since: activitySince }),
+              getRecentReactionActivity({ limit: 5, lang: uiLang, since: activitySince }),
+              config.homeShowSupport ? getSupportFundingViewModel() : null,
+              listPublicQuestsOverview({ uiLang, page: 1, limit: 3 }),
             ]);
           } else {
             const perfResults = await Promise.all([
-              timeIt('featuredBlock', () => getFeaturedBlockWithFallback({ preferredLang: preferredContentLang })),
-              timeIt('featuredRoomRaw', () => getFeaturedRoomWithFallback()),
+              timeIt('featuredBlock', () => config.homeShowFeaturedPost ? getFeaturedBlockWithFallback({ preferredLang: preferredContentLang }) : null),
+              timeIt('featuredRoomRaw', () => config.homeShowFeaturedRoom ? getFeaturedRoomWithFallback() : null),
               timeIt('topBlocks', () => getTopBlocksWithFallback({ lockedOnly: false, limit: 20, preferredLang: preferredContentLang, includePinnedHome: true })),
               timeIt('trendingTags', () => getTrendingTagsWithFallback({ limit: 10, sortBy: 'totalBlocks' })),
               timeIt('globalBlockStats', () => getGlobalBlockStats()),
               timeIt('totalRooms', () => getTotalRooms()),
               timeIt('totalTags', () => getTotalTags()),
-              timeIt('recentComments', () => getRecentCommentActivity({ limit: 5, lang: uiLang })),
-              timeIt('recentReactions', () => getRecentReactionActivity({ limit: 5, lang: uiLang })),
-              timeIt('supportFunding', () => getSupportFundingViewModel()),
+              timeIt('recentComments', () => getRecentCommentActivity({ limit: 5, lang: uiLang, since: activitySince })),
+              timeIt('recentReactions', () => getRecentReactionActivity({ limit: 5, lang: uiLang, since: activitySince })),
+              timeIt('supportFunding', () => config.homeShowSupport ? getSupportFundingViewModel() : null),
+              timeIt('quests', () => listPublicQuestsOverview({ uiLang, page: 1, limit: 3 })),
             ]);
 
             perfResults
@@ -693,8 +698,8 @@ async function getSupportFundingViewModel() {
             recentComments = perfResults.find(r => r.label === 'recentComments')?.value || [];
             recentReactions = perfResults.find(r => r.label === 'recentReactions')?.value || [];
             supportFunding = perfResults.find(r => r.label === 'supportFunding')?.value;
+            questsRes = perfResults.find(r => r.label === 'quests')?.value;
           }
-
 
           // Post-procesamiento mínimo (sin I/O extra)
           const fb = fbRes?.featuredBlock || null;
@@ -731,6 +736,11 @@ async function getSupportFundingViewModel() {
             totalTags: totalTagsRes ?? 0,
             collaborationsToday: statsRes?.collaborationsToday ?? 0,
           };
+          const { showRecentComments, showRecentReactions } = getHomeActivityVisibility({
+            comments: recentComments,
+            reactions: recentReactions
+          });
+          const homeQuests = (questsRes?.quests || []).filter(quest => quest.status === 'active');
 
           res.render('home', {
             title: t('home.meta.title'),
@@ -748,6 +758,9 @@ async function getSupportFundingViewModel() {
             tagsPeriod,
             recentComments: recentComments || [],
             recentReactions: recentReactions || [],
+            showRecentComments,
+            showRecentReactions,
+            homeQuests,
             supportFunding,
 
             user: req.user || null,

--- a/config/config.js
+++ b/config/config.js
@@ -12,6 +12,11 @@ function parseCsv(value) {
     .filter(Boolean);
 }
 
+function envFlag(value, fallback = false) {
+  if (value == null || value === '') return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(String(value).trim().toLowerCase());
+}
+
 function parseMonthlyDonateOptions(value) {
   const optionsByAmount = new Map();
 
@@ -83,6 +88,11 @@ export const config = {
   port: process.env.PORT || 3000,
   backendUrl: process.env.BACKEND_URL,
   rateLimitSalt: process.env.RATE_LIMIT_SALT,
+
+  // Homepage sections. Expensive data is not loaded when its section is disabled.
+  homeShowSupport: envFlag(process.env.HOME_SHOW_SUPPORT),
+  homeShowFeaturedPost: envFlag(process.env.HOME_SHOW_FEATURED_POST),
+  homeShowFeaturedRoom: envFlag(process.env.HOME_SHOW_FEATURED_ROOM),
 
   // Support page funding display
   supportMonthlyGoalUsd: process.env.SUPPORT_MONTHLY_GOAL_USD,

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -884,3 +884,313 @@ html[data-theme="dark"] .home-support-widget__fill {
     padding-right: 0.9rem;
   }
 }
+
+/* Discovery-first homepage layout */
+.homepage-header {
+  display: grid;
+  grid-template-columns: minmax(15rem, 1.15fr) minmax(25rem, 1fr);
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1.15rem 1.3rem;
+}
+
+.homepage-header h1 {
+  font-size: clamp(1.75rem, 3.3vw, 2.55rem);
+}
+
+.homepage-header .subtitle {
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.homepage-header .global-stats {
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.homepage-header .stat-item {
+  padding: 0.7rem 0.45rem;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.homepage-header .stat-item i {
+  font-size: 1.15rem;
+}
+
+.homepage-header .stat-number {
+  margin-top: 0.25rem;
+  font-size: clamp(1rem, 1.8vw, 1.35rem);
+}
+
+.homepage-header .stat-label {
+  font-size: 0.75rem;
+}
+
+.home-discovery__tabs {
+  display: none;
+}
+
+.home-discovery__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(17rem, 1fr);
+  align-items: start;
+  gap: 1.35rem;
+}
+
+.home-discovery__sidebar {
+  display: grid;
+  gap: 1rem;
+  position: sticky;
+  top: 1rem;
+}
+
+.home-discovery__panel {
+  min-width: 0;
+}
+
+.home-discovery__panel > h2,
+.home-quests-heading h2 {
+  margin: 0 0 0.85rem;
+  color: #24384d;
+  font-size: 1.25rem;
+}
+
+.home-discovery__panel--tags,
+.home-discovery__panel--quests {
+  padding: 1rem;
+  border: 1px solid #dce5eb;
+  border-radius: 16px;
+  background: var(--surface-bg);
+  box-shadow: 0 8px 22px rgba(20, 40, 60, 0.05);
+}
+
+.home-discovery .trending-tags-widget {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.home-discovery .trending-tags {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.home-discovery .tag-chip {
+  display: flex;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.home-discovery .tag-badge {
+  margin-left: auto;
+  text-align: right;
+}
+
+.home-quests-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.home-quests-heading h2 {
+  margin-bottom: 0;
+}
+
+.home-quest-list {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.home-quest__link {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  color: inherit;
+  background: var(--surface-raised-bg);
+  text-decoration: none;
+}
+
+.home-quest__link:hover,
+.home-quest__link:focus-visible {
+  border-color: var(--highlight-color);
+  text-decoration: none;
+}
+
+.home-quest__badge {
+  flex: 0 0 auto;
+  object-fit: contain;
+}
+
+.home-quest__body {
+  min-width: 0;
+  flex: 1;
+}
+
+.home-quest__body strong {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.home-quest__progress {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  color: var(--muted-text-color);
+  font-size: 0.75rem;
+}
+
+.home-quest__progress progress {
+  width: 100%;
+  height: 0.45rem;
+  accent-color: var(--highlight-color);
+}
+
+.home-quests-empty {
+  margin: 0;
+  color: var(--muted-text-color);
+}
+
+.live-activity {
+  margin-top: 1.5rem;
+}
+
+.activity-grid--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+html[data-theme='dark'] .homepage-header .stat-item,
+html[data-theme='dark'] .home-discovery__panel--tags,
+html[data-theme='dark'] .home-discovery__panel--quests {
+  color: var(--text-color);
+  border-color: var(--border-color);
+  background: var(--surface-bg);
+}
+
+html[data-theme='dark'] .home-discovery__panel > h2,
+html[data-theme='dark'] .home-quests-heading h2 {
+  color: var(--text-color);
+}
+
+@media (max-width: 980px) {
+  .homepage-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 799px) {
+  .home-discovery__tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.2rem;
+    margin: 0 0 0.85rem;
+    padding: 0.2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background: var(--surface-raised-bg);
+  }
+
+  .home-discovery__tab {
+    float: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.38rem;
+    min-width: 0;
+    min-height: 44px;
+    margin: 0;
+    padding: 0.4rem 0.45rem;
+    border: 0;
+    border-radius: 9px;
+    color: var(--muted-text-color);
+    background: transparent;
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 700;
+    line-height: 1.15;
+    text-align: center;
+    cursor: pointer;
+  }
+
+  .home-discovery__tab i {
+    flex: 0 0 auto;
+    width: 1em;
+    font-size: 0.82rem;
+  }
+
+  .home-discovery__tab span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .home-discovery__tab.is-active {
+    color: var(--highlight-contrast);
+    background: var(--highlight-color);
+    box-shadow: 0 3px 10px color-mix(in srgb, var(--highlight-color) 25%, transparent);
+  }
+
+  .home-discovery__tab:focus-visible {
+    outline: 2px solid var(--highlight-color);
+    outline-offset: 2px;
+  }
+
+  html[data-theme='dark'] .home-discovery__tab {
+    border: 0;
+    color: var(--muted-text-color);
+    background: transparent;
+  }
+
+  html[data-theme='dark'] .home-discovery__tab.is-active {
+    color: var(--highlight-contrast);
+    background: var(--highlight-color);
+  }
+
+  .home-discovery__grid,
+  .home-discovery__sidebar {
+    display: block;
+  }
+
+  .home-discovery__sidebar {
+    position: static;
+  }
+
+  .home-discovery__panel:not(.is-active) {
+    display: none;
+  }
+
+  .home-discovery__panel--tags,
+  .home-discovery__panel--quests {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .homepage-header .global-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .homepage-header {
+    padding: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-discovery__tab,
+  .home-quest__link {
+    transition: none;
+  }
+}

--- a/public/js/home-discovery.js
+++ b/public/js/home-discovery.js
@@ -1,0 +1,48 @@
+(() => {
+  const discovery = document.querySelector('[data-home-discovery]');
+  if (!discovery) return;
+
+  const tabs = [...discovery.querySelectorAll('[data-home-tab]')];
+  const panels = [...discovery.querySelectorAll('[data-home-panel]')];
+  let activeIndex = 0;
+
+  function selectTab(index, { focus = false } = {}) {
+    activeIndex = (index + tabs.length) % tabs.length;
+    tabs.forEach((tab, tabIndex) => {
+      const selected = tabIndex === activeIndex;
+      tab.classList.toggle('is-active', selected);
+      tab.setAttribute('aria-selected', String(selected));
+      tab.tabIndex = selected ? 0 : -1;
+      if (selected && focus) tab.focus();
+    });
+    panels.forEach((panel, panelIndex) => {
+      panel.classList.toggle('is-active', panelIndex === activeIndex);
+    });
+  }
+
+  tabs.forEach((tab, index) => {
+    tab.addEventListener('click', () => selectTab(index));
+    tab.addEventListener('keydown', (event) => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      if (event.key === 'Home') return selectTab(0, { focus: true });
+      if (event.key === 'End') return selectTab(tabs.length - 1, { focus: true });
+      selectTab(activeIndex + (event.key === 'ArrowRight' ? 1 : -1), { focus: true });
+    });
+  });
+
+  let touchStart = null;
+  discovery.addEventListener('touchstart', (event) => {
+    const touch = event.changedTouches[0];
+    touchStart = { x: touch.clientX, y: touch.clientY };
+  }, { passive: true });
+  discovery.addEventListener('touchend', (event) => {
+    if (!touchStart || !window.matchMedia('(max-width: 799px)').matches) return;
+    const touch = event.changedTouches[0];
+    const deltaX = touch.clientX - touchStart.x;
+    const deltaY = touch.clientY - touchStart.y;
+    touchStart = null;
+    if (Math.abs(deltaX) < 55 || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+    selectTab(activeIndex + (deltaX < 0 ? 1 : -1));
+  }, { passive: true });
+})();

--- a/server/db/homeActivityService.js
+++ b/server/db/homeActivityService.js
@@ -23,6 +23,16 @@ function clampLimit(limit, fallback = 5, max = 8) {
   return Math.max(1, Math.min(Number(limit) || fallback, max));
 }
 
+function normalizeSince(since) {
+  if (since == null || since === '') return null;
+  const date = since instanceof Date ? since : new Date(since);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function sinceCacheKey(since) {
+  return since ? since.toISOString().slice(0, 10) : 'all-time';
+}
+
 function uniqueStrings(values = []) {
   return [...new Set(values.map((value) => String(value || '')).filter(Boolean))];
 }
@@ -116,21 +126,24 @@ function serializeRoom(roomMap, roomId) {
   };
 }
 
-export async function getRecentCommentActivity({ limit = 5, lang = 'en' } = {}) {
+export async function getRecentCommentActivity({ limit = 5, lang = 'en', since = null } = {}) {
   const safeLimit = clampLimit(limit);
+  const normalizedSince = normalizeSince(since);
   return await cache.get(
-    `recent-comment-activity-${safeLimit}-${lang}`,
-    () => getRecentCommentActivityFresh({ safeLimit, lang }),
+    `recent-comment-activity-${safeLimit}-${lang}-${sinceCacheKey(normalizedSince)}`,
+    () => getRecentCommentActivityFresh({ safeLimit, lang, since: normalizedSince }),
     [],
     { ttlMs: ACTIVITY_TTL, staleTtlMs: ACTIVITY_STALE_TTL }
   );
 }
 
-async function getRecentCommentActivityFresh({ safeLimit, lang }) {
-  const rawComments = await BlockComment.find({
+async function getRecentCommentActivityFresh({ safeLimit, lang, since }) {
+  const commentMatch = {
     status: 'visible',
     deletedAt: null
-  })
+  };
+  if (since) commentMatch.createdAt = { $gte: since };
+  const rawComments = await BlockComment.find(commentMatch)
     .sort({ createdAt: -1, _id: -1 })
     .limit(safeLimit * 6)
     .lean();
@@ -182,18 +195,20 @@ async function getRecentCommentActivityFresh({ safeLimit, lang }) {
   });
 }
 
-export async function getRecentReactionActivity({ limit = 5, lang = 'en' } = {}) {
+export async function getRecentReactionActivity({ limit = 5, lang = 'en', since = null } = {}) {
   const safeLimit = clampLimit(limit);
+  const normalizedSince = normalizeSince(since);
   return await cache.get(
-    `recent-reaction-activity-${safeLimit}-${lang}`,
-    () => getRecentReactionActivityFresh({ safeLimit, lang }),
+    `recent-reaction-activity-${safeLimit}-${lang}-${sinceCacheKey(normalizedSince)}`,
+    () => getRecentReactionActivityFresh({ safeLimit, lang, since: normalizedSince }),
     [],
     { ttlMs: ACTIVITY_TTL, staleTtlMs: ACTIVITY_STALE_TTL }
   );
 }
 
-async function getRecentReactionActivityFresh({ safeLimit, lang }) {
-  const rawReactions = await BlockReaction.find({})
+async function getRecentReactionActivityFresh({ safeLimit, lang, since }) {
+  const reactionMatch = since ? { createdAt: { $gte: since } } : {};
+  const rawReactions = await BlockReaction.find(reactionMatch)
     .sort({ createdAt: -1, _id: -1 })
     .limit(safeLimit * 8)
     .lean();

--- a/server/services/homepage.js
+++ b/server/services/homepage.js
@@ -1,0 +1,13 @@
+export const HOME_ACTIVITY_WINDOW_DAYS = 7;
+export const HOME_ACTIVITY_MINIMUM = 4;
+
+export function getHomeActivitySince(now = new Date()) {
+  return new Date(now.getTime() - (HOME_ACTIVITY_WINDOW_DAYS * 24 * 60 * 60 * 1000));
+}
+
+export function getHomeActivityVisibility({ comments = [], reactions = [] } = {}) {
+  return {
+    showRecentComments: comments.length >= HOME_ACTIVITY_MINIMUM,
+    showRecentReactions: reactions.length >= HOME_ACTIVITY_MINIMUM
+  };
+}

--- a/spec/homepageSpec.js
+++ b/spec/homepageSpec.js
@@ -1,0 +1,30 @@
+import {
+  getHomeActivitySince,
+  getHomeActivityVisibility,
+  HOME_ACTIVITY_MINIMUM,
+  HOME_ACTIVITY_WINDOW_DAYS
+} from '../server/services/homepage.js';
+
+describe('homepage activity visibility', () => {
+  it('uses a seven-day activity window', () => {
+    const now = new Date('2026-07-10T12:00:00.000Z');
+    expect(HOME_ACTIVITY_WINDOW_DAYS).toBe(7);
+    expect(getHomeActivitySince(now).toISOString()).toBe('2026-07-03T12:00:00.000Z');
+  });
+
+  it('qualifies comments and reactions independently at four records', () => {
+    const comments = Array.from({ length: HOME_ACTIVITY_MINIMUM }, () => ({}));
+    const reactions = Array.from({ length: HOME_ACTIVITY_MINIMUM - 1 }, () => ({}));
+    expect(getHomeActivityVisibility({ comments, reactions })).toEqual({
+      showRecentComments: true,
+      showRecentReactions: false
+    });
+  });
+
+  it('hides both feeds below the threshold', () => {
+    expect(getHomeActivityVisibility()).toEqual({
+      showRecentComments: false,
+      showRecentReactions: false
+    });
+  });
+});

--- a/views/home.pug
+++ b/views/home.pug
@@ -9,15 +9,16 @@ block nav
 
 block append scripts
   script(src='/js/toast-utils.js')
-  script(src="/js/vote-controls.js")
+  script(src='/js/vote-controls.js')
   script(src='/js/reaction-counts-hydrate.js')
-  script(src="/js/modal.js")
+  script(src='/js/modal.js')
   script(src='/js/table-scroll-fade.js')
   script(src='/js/sortable-tables.js')
   script(src='/js/banner-images.js')
+  script(src='/js/home-discovery.js' defer)
 
 block append head
-  link(rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css")
+  link(rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css')
   link(rel='stylesheet' href='/css/block-common.css')
   link(rel='stylesheet' href='/css/blocks-dashboard.css')
   link(rel='stylesheet' href='/css/vote-controls.css')
@@ -31,170 +32,47 @@ block append head
   link(rel='stylesheet' href='/css/banner-images.css')
 
 block content
-
-  .home-top
-    .homepage-header
+  header.homepage-header
+    .homepage-header__copy
       p.homepage-header__eyebrow= t('home.hero.eyebrow')
       h1= t('home.hero.title')
       p.subtitle
         = t('home.hero.subtitle') + ' '
-        |
         = t('home.hero.ctaPrefix') + ' '
-        a(href=uiPath("/rooms")).join-room= t('home.hero.cta')
-        |  #{' '}
-        = t('home.hero.ctaSuffix')
-
-    if supportFunding
-      -
-        const supportWidgetKey = supportFunding.goalReached ? 'home.supportWidget.goalReached' : 'home.supportWidget';
-        const supportWidgetText = t(`${supportWidgetKey}.text`);
-        const supportWidgetAriaLabel = t(`${supportWidgetKey}.ariaLabel`, {
-          raised: supportFunding.monthlyRaisedDisplay,
-          goal: supportFunding.monthlyGoalDisplay,
-          percent: supportFunding.percent
-        });
-        const supportWidgetAriaValue = t(`${supportWidgetKey}.ariaValue`, {
-          raised: supportFunding.monthlyRaisedDisplay,
-          goal: supportFunding.monthlyGoalDisplay
-        });
-        const supportWidgetFillWidth = supportFunding.percent > 0 ? `${supportFunding.percent}%` : '8px';
-      aside.home-support-widget(aria-labelledby='home-support-title')
-        .home-support-widget__copy
-          p.home-support-widget__eyebrow= t('home.supportWidget.eyebrow')
-          h2#home-support-title= t(`${supportWidgetKey}.title`)
-          p= supportWidgetText
-        .home-support-widget__status
-          .home-support-widget__meter(aria-label=supportWidgetAriaLabel)
-            .home-support-widget__headline
-              if supportFunding.goalReached
-                strong.home-support-widget__percent= t('home.supportWidget.goalReached.meterLabel')
-              else
-                strong.home-support-widget__percent #{supportFunding.percent}%
-            .home-support-widget__track(
-              role='progressbar'
-              aria-valuemin='0'
-              aria-valuemax=supportFunding.monthlyGoal
-              aria-valuenow=supportFunding.meterValue
-              aria-valuetext=supportWidgetAriaValue
-            )
-              .home-support-widget__fill(style=`width: ${supportWidgetFillWidth}`)
-            p.home-support-widget__amount
-              strong= supportFunding.monthlyRaisedDisplay
-              span= t('home.supportWidget.amountSeparator')
-              strong= supportFunding.monthlyGoalDisplay
-              span= t('home.supportWidget.amountSuffix')
-          a.home-support-widget__link(href=uiPath('/support'))= t('home.supportWidget.cta')
-
-    aside.home-quests-card(aria-labelledby='home-quests-title')
-      .home-quests-card__icon(aria-hidden='true')
-        i.fas.fa-compass
-      .home-quests-card__copy
-        p.home-quests-card__eyebrow= t('home.quests.eyebrow')
-        h2#home-quests-title= t('home.quests.title')
-        p= t('home.quests.description')
-      a.home-quests-card__link(href=uiPath('/quests'))= t('home.quests.cta')
-
+        a.join-room(href=uiPath('/rooms'))= t('home.hero.cta')
+        |  #{t('home.hero.ctaSuffix')}
     .global-stats
       a.stat-item(href=uiPath('/archive'))
-        i.fas.fa-layer-group
+        i.fas.fa-layer-group(aria-hidden='true')
         span.stat-number= globalStats.totalBlocks
         span.stat-label= t('home.stats.blocks')
       a.stat-item(href=uiPath('/rooms'))
-        i.fas.fa-door-open
+        i.fas.fa-door-open(aria-hidden='true')
         span.stat-number= globalStats.totalRooms
         span.stat-label= t('home.stats.rooms')
       a.stat-item(href=uiPath('/tags'))
-        i.fas.fa-hashtag
+        i.fas.fa-hashtag(aria-hidden='true')
         span.stat-number= globalStats.totalTags
         span.stat-label= t('home.stats.tags')
       .stat-item
-        i.fas.fa-users
+        i.fas.fa-users(aria-hidden='true')
         span.stat-number= globalStats.collaborationsToday
         span.stat-label= t('home.stats.collabsToday')
 
-    .live-activity
-      .section-heading
-        h2= t('home.activity.title')
-        p= t('home.activity.subtitle')
-      .activity-grid
-        section.activity-card(aria-labelledby='recent-comments-heading')
-          .activity-card__header
-            h3#recent-comments-heading= t('home.activity.comments.title')
-            a.activity-card__link(href=uiPath('/search'))= t('home.activity.comments.more')
-          if recentComments && recentComments.length
-            ul.activity-list
-              each comment in recentComments
-                li.activity-item
-                  .activity-item__topline
-                    if comment.actorProfilePath
-                      a.activity-item__actor(href=uiPath(comment.actorProfilePath))= comment.actorUsername || t('home.activity.fallbackActor')
-                    else
-                      span.activity-item__actor= comment.actorUsername || t('home.activity.fallbackActor')
-                    span.activity-item__verb= comment.isReply ? t('home.activity.comments.replyVerb') : t('home.activity.comments.commentVerb')
-                    time.activity-item__time(datetime=new Date(comment.createdAt).toISOString())= new Date(comment.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
-                  p.activity-item__summary
-                    a(href=uiPath(comment.commentPath))= comment.blockTitle
-                  if comment.excerpt
-                    p.activity-item__excerpt= comment.excerpt
-                  p.activity-item__meta
-                    | #{t('home.activity.inRoom')} 
-                    if comment.roomPath
-                      a(href=uiPath(comment.roomPath))= comment.roomName
-                    else
-                      span= comment.roomName
-          else
-            p.activity-card__empty= t('home.activity.comments.empty')
-
-        section.activity-card(aria-labelledby='recent-reactions-heading')
-          .activity-card__header
-            h3#recent-reactions-heading= t('home.activity.reactions.title')
-            a.activity-card__link(href=uiPath('/archive/best-of'))= t('home.activity.reactions.more')
-          if recentReactions && recentReactions.length
-            ul.activity-list
-              each reaction in recentReactions
-                li.activity-item
-                  .activity-item__topline
-                    span.activity-item__reaction-emoji(aria-hidden='true')= reaction.reactionEmoji
-                    if reaction.actorProfilePath
-                      a.activity-item__actor(href=uiPath(reaction.actorProfilePath))= reaction.actorUsername || t('home.activity.fallbackActor')
-                    else
-                      span.activity-item__actor= reaction.actorUsername || t('home.activity.fallbackActor')
-                    span.activity-item__verb= t(`home.activity.reactions.types.${reaction.reactionType}`)
-                    time.activity-item__time(datetime=new Date(reaction.createdAt).toISOString())= new Date(reaction.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
-                  p.activity-item__summary
-                    a(href=uiPath(reaction.blockPath))= reaction.blockTitle
-                  p.activity-item__meta
-                    | #{t('home.activity.inRoom')} 
-                    if reaction.roomPath
-                      a(href=uiPath(reaction.roomPath))= reaction.roomName
-                    else
-                      span= reaction.roomName
-          else
-            p.activity-card__empty= t('home.activity.reactions.empty')
-
+  if supportFunding
+    aside.home-support-widget
+      .home-support-widget__copy
+        p.home-support-widget__eyebrow= t('home.supportWidget.eyebrow')
+        h2= t('home.supportWidget.title')
+        p= t('home.supportWidget.text')
+      a.home-support-widget__link(href=uiPath('/support'))= t('home.supportWidget.cta')
 
   if featuredRoom
     .featured-section
       .featured-card
         .featured-ribbon= t('home.featured.roomRibbon')
-        h2.card-title= (featuredRoom.displayName || featuredRoom.name)
-        if featuredRoomPeriod > 1
-          p.card-info
-            -
-              var roomInfo = t('home.featured.roomInfoDays', {
-                days: featuredRoomPeriod,
-                blocks: featuredRoomData.blockCount,
-                votes: featuredRoomData.totalRoomVotes
-              })
-            = roomInfo
-        else
-          p.card-info
-            -
-              var roomInfo = t('home.featured.roomInfo24h', {
-                blocks: featuredRoomData.blockCount,
-                votes: featuredRoomData.totalRoomVotes
-              })
-            = roomInfo
+        h2.card-title= featuredRoom.displayName || featuredRoom.name
+        p.card-info= featuredRoomPeriod > 1 ? t('home.featured.roomInfoDays', { days: featuredRoomPeriod, blocks: featuredRoomData.blockCount, votes: featuredRoomData.totalRoomVotes }) : t('home.featured.roomInfo24h', { blocks: featuredRoomData.blockCount, votes: featuredRoomData.totalRoomVotes })
         a.btn(href=uiPath(`/rooms/${featuredRoom._id}`))= t('home.featured.checkItOut')
 
   if featuredBlock
@@ -202,86 +80,29 @@ block content
       .featured-card
         +blockBanner(featuredBlock, 'featured', featuredBlock.roomId)
         .featured-ribbon= t('home.featured.blockRibbon')
-        // Título del block
-        h2.card-title
-          = featuredBlock.title
-          - const block = featuredBlock
-          include partials/_draft_badge
-        // Votos
+        h2.card-title= featuredBlock.title
         p.card-info= t('home.featured.votes', {n: featuredBlock.voteCount})
-
-        // Preview del contenido (ya convertido a HTML)
         if featuredBlock.contentHTML
-          div.featured-content-preview!= featuredBlock.contentHTML
-
-        // Botón para ver más
+          .featured-content-preview!= featuredBlock.contentHTML
         a.btn(href=`/rooms/${featuredBlock.roomId}/blocks/${featuredBlock._id}`)= t('home.featured.viewBlock')
 
-  
-  //- Sección de Trending Tags
-  .trending-section
-    h2
-      = t('home.trendingTags.title')
-      if tagsPeriod && tagsPeriod.type === 'days' && tagsPeriod.value > 1
-        |  #{t('home.trendingTags.suffixDays', { days: tagsPeriod.value })}
-      else if tagsPeriod && tagsPeriod.type === 'all'
-        |  #{t('home.trendingTags.suffixAllTime')}
-    if trendingTags && trendingTags.length
-      .trending-tags-widget
-        ul.trending-tags
-          each tagObj in trendingTags
-            li.tag-chip
-              i.tag-icon.fas.fa-tag
-              a(href=uiPath(`/tags/${encodeURIComponent(tagObj._id)}`))= tagObj._id
-              span.tag-badge (#{t('home.trendingTags.blocks', {n: tagObj.totalBlocks})}, #{t('home.trendingTags.votes', {n: tagObj.totalVotes})})
-    else
-      p= t('home.trendingTags.empty')
+  main.home-discovery(data-home-discovery)
+    .home-discovery__tabs(role='tablist' aria-label=t('home.hero.subtitle'))
+      button#home-tab-posts.home-discovery__tab.is-active(type='button' role='tab' aria-selected='true' aria-controls='home-panel-posts' tabindex='0' data-home-tab='posts' title=t('home.trendingBlocks.title'))
+        i.fas.fa-stream(aria-hidden='true')
+        span= t('home.stats.blocks')
+      button#home-tab-tags.home-discovery__tab(type='button' role='tab' aria-selected='false' aria-controls='home-panel-tags' tabindex='-1' data-home-tab='tags' title=t('home.trendingTags.title'))
+        i.fas.fa-hashtag(aria-hidden='true')
+        span= t('home.stats.tags')
+      button#home-tab-quests.home-discovery__tab(type='button' role='tab' aria-selected='false' aria-controls='home-panel-quests' tabindex='-1' data-home-tab='quests' title=t('home.quests.title'))
+        i.fas.fa-compass(aria-hidden='true')
+        span= t('nav.quests')
+    .home-discovery__grid
+      include partials/_home_trending_posts
+      aside.home-discovery__sidebar
+        include partials/_home_trending_tags
+        include partials/_home_quests
 
-  // Divider opcional
-  .divider
-
-  // Sección de Trending Posts
-  .trending-section
-    h2
-      = t('home.trendingBlocks.title')
-      if blocksPeriod > 1
-        |  #{t('home.trendingBlocks.suffixDays', {days: blocksPeriod})}
-    if topBlocks.length
-      ul.block-list
-        each block in topBlocks
-          li.block-preview(lang=(block.lang || 'en'))
-            +blockBanner(block, 'card', block.roomId)
-            div.content
-              .title-row(class=block.pinnedAt ? 'title-row--pinned' : null)
-                a.block-title(href=`/rooms/${block.roomId}/blocks/${block._id}` lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))= block.title
-                include partials/_draft_badge
-                if block.pinnedAt
-                  span.home-pinned-badge(title='Pinned post' aria-label='Pinned post')
-                    i.fas.fa-thumbtack(aria-hidden='true')
-              p(lang=(uiLang || 'en'))
-                | #{t('home.trendingBlocks.createdBy')} 
-                - const u = encodeURIComponent(block.creator || '')
-                a.user-profile-link(href=uiPath(`/users/${u}`))= block.creator
-                |  #{t('home.trendingBlocks.in')} 
-                a.room-link(href=uiPath(`/rooms/${block.roomId}`))= block.roomDisplayName || block.roomId || t('home.trendingBlocks.unknownRoom')
-                |  #{t('home.trendingBlocks.on')}
-                = ' '
-                - const blockCreatedAt = new Date(block.createdAt)
-                time(
-                  datetime=blockCreatedAt.toISOString()
-                  data-local-date-time
-                  data-date-style='medium'
-                  data-time-style='short'
-                )= blockCreatedAt.toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
-              +translationAttribution(block)
-              if block.contentHTML
-                div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))!= block.contentHTML
-            +readMoreIfTruncated(block, block.roomId)
-            footer.block-footer
-              include partials/_reaction_counts
-              include partials/_vote_controls
-    else
-      p= t('home.trendingBlocks.empty24h')
-
+  include partials/_home_activity
   include partials/_login_modal
   #toast-container

--- a/views/partials/_home_activity.pug
+++ b/views/partials/_home_activity.pug
@@ -1,0 +1,56 @@
+if showRecentComments || showRecentReactions
+  section.live-activity(aria-labelledby='home-activity-heading')
+    .section-heading
+      div
+        h2#home-activity-heading= t('home.activity.title')
+        p= t('home.activity.subtitle')
+    .activity-grid(class=(showRecentComments && showRecentReactions) ? null : 'activity-grid--single')
+      if showRecentComments
+        section.activity-card(aria-labelledby='recent-comments-heading')
+          .activity-card__header
+            h3#recent-comments-heading= t('home.activity.comments.title')
+            a.activity-card__link(href=uiPath('/search'))= t('home.activity.comments.more')
+          ul.activity-list
+            each comment in recentComments
+              li.activity-item
+                .activity-item__topline
+                  if comment.actorProfilePath
+                    a.activity-item__actor(href=uiPath(comment.actorProfilePath))= comment.actorUsername || t('home.activity.fallbackActor')
+                  else
+                    span.activity-item__actor= comment.actorUsername || t('home.activity.fallbackActor')
+                  span.activity-item__verb= comment.isReply ? t('home.activity.comments.replyVerb') : t('home.activity.comments.commentVerb')
+                  time.activity-item__time(datetime=new Date(comment.createdAt).toISOString())= new Date(comment.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
+                p.activity-item__summary
+                  a(href=uiPath(comment.commentPath))= comment.blockTitle
+                if comment.excerpt
+                  p.activity-item__excerpt= comment.excerpt
+                p.activity-item__meta
+                  | #{t('home.activity.inRoom')} 
+                  if comment.roomPath
+                    a(href=uiPath(comment.roomPath))= comment.roomName
+                  else
+                    span= comment.roomName
+      if showRecentReactions
+        section.activity-card(aria-labelledby='recent-reactions-heading')
+          .activity-card__header
+            h3#recent-reactions-heading= t('home.activity.reactions.title')
+            a.activity-card__link(href=uiPath('/archive/best-of'))= t('home.activity.reactions.more')
+          ul.activity-list
+            each reaction in recentReactions
+              li.activity-item
+                .activity-item__topline
+                  span.activity-item__reaction-emoji(aria-hidden='true')= reaction.reactionEmoji
+                  if reaction.actorProfilePath
+                    a.activity-item__actor(href=uiPath(reaction.actorProfilePath))= reaction.actorUsername || t('home.activity.fallbackActor')
+                  else
+                    span.activity-item__actor= reaction.actorUsername || t('home.activity.fallbackActor')
+                  span.activity-item__verb= t(`home.activity.reactions.types.${reaction.reactionType}`)
+                  time.activity-item__time(datetime=new Date(reaction.createdAt).toISOString())= new Date(reaction.createdAt).toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
+                p.activity-item__summary
+                  a(href=uiPath(reaction.blockPath))= reaction.blockTitle
+                p.activity-item__meta
+                  | #{t('home.activity.inRoom')} 
+                  if reaction.roomPath
+                    a(href=uiPath(reaction.roomPath))= reaction.roomName
+                  else
+                    span= reaction.roomName

--- a/views/partials/_home_quests.pug
+++ b/views/partials/_home_quests.pug
@@ -1,0 +1,25 @@
+section.home-discovery__panel.home-discovery__panel--quests(
+  id='home-panel-quests'
+  role='tabpanel'
+  aria-labelledby='home-tab-quests'
+  data-home-panel='quests'
+)
+  .home-quests-heading
+    div
+      p.home-quests-card__eyebrow= t('home.quests.eyebrow')
+      h2= t('home.quests.title')
+    a.home-quests-card__link(href=uiPath('/quests'))= t('home.quests.cta')
+  if homeQuests && homeQuests.length
+    ul.home-quest-list
+      each quest in homeQuests
+        li.home-quest
+          a.home-quest__link(href=uiPath(`/quests/${quest.slug}`))
+            if quest.badgeAssetPath
+              img.home-quest__badge(src=quest.badgeAssetPath alt=t('quests.badge.alt', { questName: quest.displayName }) width='44' height='44' loading='lazy' decoding='async')
+            .home-quest__body
+              strong= quest.displayName
+              .home-quest__progress
+                progress(value=quest.progress.displayRatio max='1')
+                span= t('quests.progress.percent', { percent: Math.round(quest.progress.displayRatio * 100) })
+  else
+    p.home-quests-empty= t('quests.overview.empty.body')

--- a/views/partials/_home_trending_posts.pug
+++ b/views/partials/_home_trending_posts.pug
@@ -1,0 +1,41 @@
+section.home-discovery__panel.home-discovery__panel--posts.is-active(
+  id='home-panel-posts'
+  role='tabpanel'
+  aria-labelledby='home-tab-posts'
+  data-home-panel='posts'
+)
+  h2
+    = t('home.trendingBlocks.title')
+    if blocksPeriod > 1
+      |  #{t('home.trendingBlocks.suffixDays', {days: blocksPeriod})}
+  if topBlocks.length
+    ul.block-list
+      each block in topBlocks
+        li.block-preview(lang=(block.lang || 'en'))
+          +blockBanner(block, 'card', block.roomId)
+          div.content
+            .title-row(class=block.pinnedAt ? 'title-row--pinned' : null)
+              a.block-title(href=`/rooms/${block.roomId}/blocks/${block._id}` lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))= block.title
+              include _draft_badge
+              if block.pinnedAt
+                span.home-pinned-badge(title=t('home.featured.blockRibbon') aria-label=t('home.featured.blockRibbon'))
+                  i.fas.fa-thumbtack(aria-hidden='true')
+            p(lang=(uiLang || 'en'))
+              | #{t('home.trendingBlocks.createdBy')} 
+              - const u = encodeURIComponent(block.creator || '')
+              a.user-profile-link(href=uiPath(`/users/${u}`))= block.creator
+              |  #{t('home.trendingBlocks.in')} 
+              a.room-link(href=uiPath(`/rooms/${block.roomId}`))= block.roomDisplayName || block.roomId || t('home.trendingBlocks.unknownRoom')
+              |  #{t('home.trendingBlocks.on')}
+              = ' '
+              - const blockCreatedAt = new Date(block.createdAt)
+              time(datetime=blockCreatedAt.toISOString() data-local-date-time data-date-style='medium' data-time-style='short')= blockCreatedAt.toLocaleString(uiLang || undefined, { dateStyle: 'medium', timeStyle: 'short' })
+            +translationAttribution(block)
+            if block.contentHTML
+              div(class=['content-preview', {'fade-footer': block.truncated}], lang=(block.lang || 'en') dir=(textDirForLang ? textDirForLang(block.lang || 'en') : 'ltr'))!= block.contentHTML
+          +readMoreIfTruncated(block, block.roomId)
+          footer.block-footer
+            include _reaction_counts
+            include _vote_controls
+  else
+    p= t('home.trendingBlocks.empty24h')

--- a/views/partials/_home_trending_tags.pug
+++ b/views/partials/_home_trending_tags.pug
@@ -1,0 +1,22 @@
+section.home-discovery__panel.home-discovery__panel--tags(
+  id='home-panel-tags'
+  role='tabpanel'
+  aria-labelledby='home-tab-tags'
+  data-home-panel='tags'
+)
+  h2
+    = t('home.trendingTags.title')
+    if tagsPeriod && tagsPeriod.type === 'days' && tagsPeriod.value > 1
+      |  #{t('home.trendingTags.suffixDays', { days: tagsPeriod.value })}
+    else if tagsPeriod && tagsPeriod.type === 'all'
+      |  #{t('home.trendingTags.suffixAllTime')}
+  if trendingTags && trendingTags.length
+    .trending-tags-widget
+      ul.trending-tags
+        each tagObj in trendingTags
+          li.tag-chip
+            i.tag-icon.fas.fa-tag(aria-hidden='true')
+            a(href=uiPath(`/tags/${encodeURIComponent(tagObj._id)}`))= tagObj._id
+            span.tag-badge (#{t('home.trendingTags.blocks', {n: tagObj.totalBlocks})}, #{t('home.trendingTags.votes', {n: tagObj.totalVotes})})
+  else
+    p= t('home.trendingTags.empty')


### PR DESCRIPTION
## Summary

Redesigns the homepage around Daily Page’s primary discovery experience: trending posts, tags, and community quests.

The new layout brings trending content directly beneath a more compact hero, removes low-value sections from the default experience, and provides a polished responsive interface for both desktop and mobile visitors.

## Changes

- Integrate global statistics into a more compact homepage hero
- Position trending posts as the primary homepage content
- Add a desktop discovery layout with:
  - Trending posts in the main column
  - Trending tags in the sidebar
  - Active quest progress beneath the tags
- Add an accessible mobile tab interface for Posts, Tags, and Quests
  - Compact localized labels and icons
  - Keyboard navigation
  - Horizontal swipe navigation
  - Translation-safe truncation
  - 44px minimum touch targets
- Show recent comments and reactions only when each activity type has at least four public events from the previous seven days
- Allow qualifying activity feeds to render independently
- Move qualifying live activity below the discovery content
- Add homepage feature flags for support and featured content
- Skip disabled sections’ database queries
- Add responsive and dark-theme styling
- Extract homepage sections into focused Pug partials
- Add tests for the activity window and visibility thresholds

## Feature flags

The following homepage sections now default to disabled and can be restored independently:

- `HOME_SHOW_SUPPORT`
- `HOME_SHOW_FEATURED_POST`
- `HOME_SHOW_FEATURED_ROOM`

Accepted enabled values include `1`, `true`, `yes`, and `on`.

## Internationalization

All static UI strings used by the redesigned homepage are sourced from the existing i18n dictionaries. Dynamic community content such as post titles, usernames, room names, tags, and quest names remains data-driven.

## Verification

- [x] ESLint passes
- [x] Pug templates compile
- [x] Browser bundles build successfully
- [x] 527 specs pass
- [x] Homepage activity threshold tests pass
- [x] No whitespace errors