### PR TITLE
fix(home): refine pinned-post badge placement on mobile

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1186,6 +1186,37 @@ html[data-theme='dark'] .home-quests-heading h2 {
   .homepage-header {
     padding: 1rem;
   }
+
+  .home-discovery .title-row--pinned {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 0.25rem 0.5rem;
+  }
+
+  .home-discovery .title-row--pinned .home-pinned-badge {
+    grid-column: 1;
+    grid-row: 1;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin: 0.25rem 0 0;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+  }
+
+  .home-discovery .title-row--pinned .home-pinned-badge i {
+    font-size: 0.7rem;
+  }
+
+  .home-discovery .title-row--pinned .block-title {
+    grid-column: 2;
+    grid-row: 1;
+    width: 100%;
+  }
+
+  .home-discovery .title-row--pinned .badge.badge-draft {
+    grid-column: 2;
+    width: fit-content;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Improves the placement of the pinned-post badge within trending post cards on mobile.

## Changes

- Position the pin immediately before the post title
- Reduce the badge size for limited mobile space
- Align the badge with the title’s first line
- Preserve the full remaining width for wrapping titles
- Keep draft badges organized beneath the title
- Retain the existing right-aligned treatment on wider screens

## Verification

- [x] Pug templates compile
- [x] No whitespace errors