### PR TITLE
refactor(quests): unify quest progress bars across homepage and quest views

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1052,10 +1052,8 @@ html[data-theme="dark"] .home-support-widget__fill {
   font-size: 0.75rem;
 }
 
-.home-quest__progress progress {
-  width: 100%;
+.home-quest__progress .quest-progress__bar {
   height: 0.45rem;
-  accent-color: var(--highlight-color);
 }
 
 .home-quests-empty {

--- a/public/css/quest-progress.css
+++ b/public/css/quest-progress.css
@@ -1,0 +1,24 @@
+.quest-progress__bar {
+  min-width: 0;
+  width: 100%;
+  height: 0.8rem;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  accent-color: var(--highlight-color);
+}
+
+.quest-progress__bar::-webkit-progress-bar {
+  border-radius: 999px;
+  background: var(--secondary-bg);
+}
+
+.quest-progress__bar::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--highlight-color);
+}
+
+.quest-progress__bar::-moz-progress-bar {
+  border-radius: 999px;
+  background: var(--highlight-color);
+}

--- a/public/css/quests.css
+++ b/public/css/quests.css
@@ -361,26 +361,6 @@ html[data-theme="dark"] .quests-page label {
   color: var(--muted-text-color);
 }
 
-.quest-progress__bar {
-  min-width: 0;
-  width: 100%;
-  height: 0.8rem;
-  overflow: hidden;
-  border: 0;
-  border-radius: 999px;
-  accent-color: var(--highlight-color);
-}
-
-.quest-progress__bar::-webkit-progress-bar {
-  border-radius: 999px;
-  background: var(--secondary-bg);
-}
-
-.quest-progress__bar::-webkit-progress-value {
-  border-radius: 999px;
-  background: var(--highlight-color);
-}
-
 .quest-progress__percent {
   color: var(--muted-text-color);
   font-size: 0.86rem;

--- a/views/home.pug
+++ b/views/home.pug
@@ -25,6 +25,7 @@ block append head
   link(rel='stylesheet' href='/css/reaction-counts.css')
   link(rel='stylesheet' href='/css/toast.css')
   link(rel='stylesheet' href='/css/modal.css')
+  link(rel='stylesheet' href='/css/quest-progress.css')
   link(rel='stylesheet' href='/css/home.css')
   link(rel='stylesheet' href='/css/translation-attribution.css')
   link(rel='stylesheet' href='/css/table-scroll-fade.css')

--- a/views/partials/_home_quests.pug
+++ b/views/partials/_home_quests.pug
@@ -19,7 +19,7 @@ section.home-discovery__panel.home-discovery__panel--quests(
             .home-quest__body
               strong= quest.displayName
               .home-quest__progress
-                progress(value=quest.progress.displayRatio max='1')
+                progress.quest-progress__bar(value=quest.progress.displayRatio max='1')
                 span= t('quests.progress.percent', { percent: Math.round(quest.progress.displayRatio * 100) })
   else
     p.home-quests-empty= t('quests.overview.empty.body')

--- a/views/quests/detail.pug
+++ b/views/quests/detail.pug
@@ -6,6 +6,7 @@ block nav
   include ../navLinks
 
 block append head
+  link(rel='stylesheet' href='/css/quest-progress.css')
   link(rel='stylesheet' href='/css/quests.css')
   link(rel='stylesheet' href='/css/pagination.css')
 

--- a/views/quests/index.pug
+++ b/views/quests/index.pug
@@ -4,6 +4,7 @@ block nav
   include ../navLinks
 
 block append head
+  link(rel='stylesheet' href='/css/quest-progress.css')
   link(rel='stylesheet' href='/css/quests.css')
   link(rel='stylesheet' href='/css/pagination.css')
 


### PR DESCRIPTION
## Summary

Introduces a shared quest progress-bar primitive for consistent rendering across the homepage and dedicated quest views.

This also resolves inconsistent native progress-bar rendering in mobile Safari.

## Changes

- Extract common progress-bar styling into `quest-progress.css`
- Use the shared `quest-progress__bar` class on the homepage
- Load the shared stylesheet on:
  - Homepage
  - Quest directory
  - Quest detail page
- Share track, fill, color, radius, and overflow behavior
- Add explicit WebKit/Safari track and value styling
- Add Firefox progress-value styling
- Retain the homepage’s compact height as a local override
- Remove duplicated progress-bar styling from `quests.css`

## Verification

- [x] Homepage and quest templates compile
- [x] All 6 quest-view specs pass
- [x] No whitespace errors