### PR TITLE
perf(rooms): warm directory cache before serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ For a personal dev instance, MongoDB Atlas is the path of least resistance becau
 
 The app will connect to `daily-page-test` by default. Set `NODE_ENV=production` only for a real deployment, because that changes database selection, cookie security behavior, compression/view caching, and dotenv loading.
 
+For read-only local diagnostics against the production database, keep development mode and disable scheduled jobs:
+
+```sh
+USE_PRODUCTION_DB=true DISABLE_BACKGROUND_JOBS=true npm start
+```
+
+`USE_PRODUCTION_DB` changes only database selection. `DISABLE_BACKGROUND_JOBS` prevents scheduled cleanup, expiry, featured-content, block-lifecycle, and cache-warming jobs from starting. HTTP write routes remain available, so avoid editing content and use read-only database credentials when possible.
+
 ## Database Notes
 
 The app does not currently ship with a one-command seed for a complete demo instance. An empty database can boot, but pages such as the rooms directory and room dashboards become useful after inserting room metadata and creating posts.
@@ -150,6 +158,7 @@ Then visit `/rooms/general/blocks/new` to create posts through the UI, or use th
 | --- | --- |
 | `MONGO_DB_ADDR` | MongoDB Atlas host, for example `cluster0.example.mongodb.net`. |
 | `MONGO_DB_PW` | Password for the hard-coded Mongo user `daily-page-admin`. |
+| `USE_PRODUCTION_DB` | Selects `daily-page` instead of `daily-page-test` without requiring production mode. |
 
 ### Strongly recommended
 
@@ -159,6 +168,7 @@ Then visit `/rooms/general/blocks/new` to create posts through the UI, or use th
 | `BACKEND_URL` | Base URL passed to the browser editor. Defaults to local port. |
 | `BASE_URL` | Public canonical URL for emails, notifications, and SEO helpers. |
 | `RATE_LIMIT_SALT` | Salt for hashed rate-limit identifiers. Falls back to `MONGO_DB_PW` if absent. |
+| `DISABLE_BACKGROUND_JOBS` | Disables all scheduled and startup background jobs when true. |
 
 ### Optional integrations
 

--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ import {
 } from './server/db/pageService.js';
 import {
   getAllRooms, getRoomMetadata,
-  getTotalRooms
+  getTotalRooms, warmRoomDirectoryCache
 
 } from './server/db/roomService.js'
 import { addHreflangLocals } from './server/middleware/hreflang.js';
@@ -85,7 +85,13 @@ import { uiPrefixAndLangContext } from './server/middleware/uiPrefix.js';
 import { findUserById } from './server/db/userService.js';
 import { toBlockPreviewDTO } from './server/utils/block.js';
 
-startJobs();
+if (['1', 'true', 'yes', 'on'].includes(
+  String(process.env.DISABLE_BACKGROUND_JOBS || '').trim().toLowerCase()
+)) {
+  console.warn('Background jobs disabled by DISABLE_BACKGROUND_JOBS.');
+} else {
+  startJobs();
+}
 
 const app = express();
 const port = config.port || 3000;
@@ -149,6 +155,9 @@ async function getSupportFundingViewModel() {
 
   try {
     await initMongooseConnection();
+    await warmRoomDirectoryCache('en').catch(error => {
+      console.error('Failed to warm room directory cache:', error);
+    });
     google.init();
 
     const whitelist = ['https://dailypage.org', 'http://localhost:3000'];

--- a/server/db/mongoose.js
+++ b/server/db/mongoose.js
@@ -6,7 +6,13 @@ const addr = config.mongoDbAddr;
 const pw = config.mongoDbPw;
 const baseURL = `mongodb+srv://${user}:${pw}@${addr}`;
 
-function resolveDbName({ useProductionDb = process.env.NODE_ENV === 'production' } = {}) {
+function envFlag(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function resolveDbName({
+  useProductionDb = process.env.NODE_ENV === 'production' || envFlag(process.env.USE_PRODUCTION_DB)
+} = {}) {
   return `daily-page${useProductionDb ? '' : '-test'}`;
 }
 

--- a/server/db/roomService.js
+++ b/server/db/roomService.js
@@ -2,8 +2,44 @@ import Room from './models/Room.js';
 import * as cache from '../services/cache.js';
 
 let cachedTopicsByLang = new Map();
+let cachedRawRooms = null;
+let rawRoomsPromise = null;
 
 const ROOM_STALE_TTL = 30 * 60 * 1000;
+const ROOM_DIRECTORY_TTL = 10 * 60 * 1000;
+
+function refreshRawRooms() {
+  if (rawRoomsPromise) return rawRoomsPromise;
+
+  rawRoomsPromise = Room.find({}).lean().then(rooms => {
+    cachedRawRooms = {
+      rooms,
+      exp: Date.now() + ROOM_DIRECTORY_TTL,
+    };
+    cachedTopicsByLang.clear();
+    return rooms;
+  }).finally(() => {
+    rawRoomsPromise = null;
+  });
+
+  return rawRoomsPromise;
+}
+
+async function fetchRawRooms() {
+  const now = Date.now();
+  if (cachedRawRooms && now < cachedRawRooms.exp) {
+    return cachedRawRooms.rooms;
+  }
+
+  if (cachedRawRooms) {
+    void refreshRawRooms().catch(error => {
+      console.error('Failed to refresh room directory cache:', error);
+    });
+    return cachedRawRooms.rooms;
+  }
+
+  return await refreshRawRooms();
+}
 
 function resolveRoomField(room, field, lang) {
   const map = room?.[`${field}_i18n`];
@@ -86,11 +122,13 @@ export async function getTotalRooms() {
 export async function fetchAndGroupRooms(lang = null) {
   const now = Date.now();
   const hit = cachedTopicsByLang.get(lang || 'raw');
-  if (hit && now < hit.exp) return hit.topics;
+  if (hit && now < hit.exp) {
+    return hit.topics;
+  }
 
   try {
-    const docs = (await Room.find({})).map(d => d.toObject());
-    const rooms = lang ? docs.map(r => toRoomI18nDTO(r, lang)) : docs;
+    const rawRooms = await fetchRawRooms();
+    const rooms = lang ? rawRooms.map(r => toRoomI18nDTO(r, lang)) : rawRooms;
 
     const topics = rooms.reduce((grouped, room) => {
       const topicLabel = lang ? (room.displayTopic || room.topic) : room.topic;
@@ -109,12 +147,22 @@ export async function fetchAndGroupRooms(lang = null) {
     topics.forEach(t => t.rooms.sort((a, b) =>
       collator.compare(a.displayName || a.name, b.displayName || b.name)
     ));
-
     // Cache 10 min por lang
-    cachedTopicsByLang.set(lang || 'raw', { topics, exp: now + 10 * 60 * 1000 });
+    cachedTopicsByLang.set(lang || 'raw', { topics, exp: Date.now() + ROOM_DIRECTORY_TTL });
     return topics;
   } catch (error) {
     console.error('Error fetching and grouping rooms:', error.message);
     throw error;
   }
+}
+
+export async function warmRoomDirectoryCache(lang = 'en') {
+  const startedAt = Date.now();
+  const topics = await fetchAndGroupRooms(lang);
+  console.info('[rooms-cache] warmed', {
+    lang,
+    durationMs: Date.now() - startedAt,
+    topicCount: topics.length,
+    roomCount: topics.reduce((count, topic) => count + topic.rooms.length, 0),
+  });
 }


### PR DESCRIPTION
## Summary

- Warm the English room-directory cache after MongoDB connects and before the server begins listening
- Share cached raw room data across localized directory groupings
- Serve stale room data while refreshing it in the background
- Deduplicate concurrent room-directory queries
- Use lean MongoDB results to reduce document-hydration overhead
- Add independent controls for selecting the production database and disabling background jobs during local diagnostics

## Motivation

Profiling showed that the initial room metadata query took approximately 3.3 seconds, accounting for most of the cold `/rooms` response time. Once cached, the page rendered in approximately 60 ms.

This moves the expensive initial query into application startup and prevents later cache refreshes from blocking requests.

## Testing

- Confirmed the first `/rooms` request uses the warmed cache
- Confirmed stale room data remains available during background refresh
- ESLint passes
- 527 Jasmine specs pass
- `git diff --check` passes

## Operational notes

For local read-only diagnostics against production data:

    USE_PRODUCTION_DB=true DISABLE_BACKGROUND_JOBS=true npm start

HTTP write routes remain available, so read-only database credentials are still recommended.