### PR TITLE
Add deterministic trunk thickness and taper variation

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -173,7 +173,7 @@ Renderer v2 established the original deterministic visual grammar and is preserv
 
 - Deterministic three-dimensional, space-colonization-inspired branch growth projected into two dimensions.
 - Persistent trunk and branch hierarchy with bounded growth and explicit termination.
-- Seed-derived specimen architecture, beginning with bounded branch-start height variation.
+- Seed-derived specimen architecture with bounded branch-start height, trunk-base thickness, and trunk-taper variation.
 - Back-propagated branch thickness, trunk taper, root flare, and leafless wood rasterization.
 - Depth-aware individual foliage attached to eligible branch growth.
 - Coverage repair that preserves negative space without producing detached canopy masses.
@@ -184,7 +184,7 @@ The initial graph, wood, and foliage milestones should therefore be treated as t
 
 The recommended near-term technical sequence is:
 
-1. Add trunk and architectural variance to the pilot phenotype: base thickness, taper, crown start, trunk lean, major forks, split-trunk height, and weight balance between leaders.
+1. Add trunk and architectural variance to the pilot phenotype: crown start, trunk lean, major forks, split-trunk height, and weight balance between leaders. Branch-start height, base thickness, and taper are complete.
 2. Build a genuinely distinct second phenotype to discover which parameters are species grammar and which assumptions remain hard-coded to the pilot tree.
 3. Begin deterministic forest composition and basic exploration before designing a substantial resource economy. Experiencing many trees as one place should reveal which curatorial and playful interactions the forest naturally invites.
 

--- a/server/services/forest/v3/architecture.js
+++ b/server/services/forest/v3/architecture.js
@@ -4,11 +4,22 @@ function sampleRange(random, range) {
   return range[0] + ((range[1] - range[0]) * random());
 }
 
+function roundTo(value, precision) {
+  const scale = 10 ** precision;
+  return Math.round(value * scale) / scale;
+}
+
 export function deriveTreeArchitecture(seed, phenotype) {
   const random = createRandom(seed ^ 0xA2C417EC);
   const branchStartHeight = Math.round(
     sampleRange(random, phenotype.architecture.branchStartHeight) * 2
   ) / 2;
+  const trunkBaseRadius = roundTo(
+    sampleRange(random, phenotype.architecture.trunkBaseRadius), 2
+  );
+  const trunkTaper = roundTo(
+    sampleRange(random, phenotype.architecture.trunkTaper), 2
+  );
 
-  return Object.freeze({ branchStartHeight });
+  return Object.freeze({ branchStartHeight, trunkBaseRadius, trunkTaper });
 }

--- a/server/services/forest/v3/growth.js
+++ b/server/services/forest/v3/growth.js
@@ -291,7 +291,26 @@ function directionIsClear(parent, direction, nodes, phenotype) {
   return true;
 }
 
-function calculateRadii(nodes, segments, phenotype) {
+function applyTrunkProfile(nodes, radii, phenotype, architecture) {
+  const trunkNodes = nodes.filter(node => node.generation === 0);
+  const trunkTop = trunkNodes.at(-1);
+  const trunkHeight = phenotype.groundY - trunkTop.worldY;
+  const topRadius = radii[trunkTop.id];
+  for (const node of trunkNodes) {
+    const heightProgress = clamp(
+      (phenotype.groundY - node.worldY) / Math.max(phenotype.internodeLength, trunkHeight),
+      0,
+      1
+    );
+    const profiledRadius = topRadius + (
+      (architecture.trunkBaseRadius - topRadius)
+      * ((1 - heightProgress) ** architecture.trunkTaper)
+    );
+    radii[node.id] = Math.max(radii[node.id], profiledRadius);
+  }
+}
+
+function calculateRadii(nodes, segments, phenotype, architecture) {
   const children = Array.from({ length: nodes.length }, () => []);
   for (const segment of segments) children[segment.fromId].push(segment.toId);
   const radii = Array(nodes.length).fill(phenotype.terminalRadius);
@@ -306,6 +325,7 @@ function calculateRadii(nodes, segments, phenotype) {
       area ** (1 / phenotype.pipeExponent)
     );
   }
+  applyTrunkProfile(nodes, radii, phenotype, architecture);
   for (const node of nodes) node.radius = radii[node.id];
   for (const segment of segments) {
     segment.fromRadius = radii[segment.fromId];
@@ -395,7 +415,7 @@ export function growBranchGraph(seed, phenotype) {
     terminals = nextTerminals;
   }
 
-  calculateRadii(nodes, segments, phenotype);
+  calculateRadii(nodes, segments, phenotype, architecture);
   const terminalNodeIds = new Set(nodes.map(node => node.id));
   for (const segment of segments) terminalNodeIds.delete(segment.fromId);
   const terminationReason = nodes.length >= phenotype.maxNodes

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -16,7 +16,9 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
   attractionPointCount: 180,
   attractionGap: 0.1,
   architecture: Object.freeze({
-    branchStartHeight: Object.freeze([22, 38])
+    branchStartHeight: Object.freeze([22, 38]),
+    trunkBaseRadius: Object.freeze([3.1, 4.1]),
+    trunkTaper: Object.freeze([0.72, 1.32])
   }),
   trunkTopY: 43,
   primaryBranchCount: 5,

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -43,6 +43,64 @@ describe('v3 forest branch graph generator', () => {
     expect(observedHeights.size).toBeGreaterThan(10);
   });
 
+  it('derives deterministic, bounded, meaningfully varied trunk architecture', () => {
+    const observedBaseRadii = new Set();
+    const observedTapers = new Set();
+    for (let seed = 0; seed < 100; seed += 1) {
+      const first = generateForestTreeGraph(post, { seed });
+      const repeated = generateForestTreeGraph(post, { seed });
+      const architecture = first.architecture;
+      const ranges = first.phenotype.architecture;
+
+      expect(repeated.architecture).toEqual(architecture);
+      expect(architecture.trunkBaseRadius).toBeGreaterThanOrEqual(ranges.trunkBaseRadius[0]);
+      expect(architecture.trunkBaseRadius).toBeLessThanOrEqual(ranges.trunkBaseRadius[1]);
+      expect(architecture.trunkTaper).toBeGreaterThanOrEqual(ranges.trunkTaper[0]);
+      expect(architecture.trunkTaper).toBeLessThanOrEqual(ranges.trunkTaper[1]);
+      expect(first.nodes[0].radius + 1e-9).toBeGreaterThanOrEqual(
+        architecture.trunkBaseRadius
+      );
+      observedBaseRadii.add(architecture.trunkBaseRadius);
+      observedTapers.add(architecture.trunkTaper);
+    }
+    expect(observedBaseRadii.size).toBeGreaterThan(20);
+    expect(observedTapers.size).toBeGreaterThan(20);
+  });
+
+  it('applies trunk traits without changing growth geometry or branch radii', () => {
+    const phenotype = generateForestTreeGraph(post, { seed: 202 }).phenotype;
+    const thinArchitecture = {
+      ...phenotype.architecture,
+      trunkBaseRadius: [3.1, 3.1],
+      trunkTaper: [0.72, 0.72]
+    };
+    const thickArchitecture = {
+      ...phenotype.architecture,
+      trunkBaseRadius: [4.1, 4.1],
+      trunkTaper: [1.32, 1.32]
+    };
+    const thin = generateForestTreeGraph(post, {
+      seed: 202,
+      phenotype: { ...phenotype, architecture: thinArchitecture }
+    });
+    const thick = generateForestTreeGraph(post, {
+      seed: 202,
+      phenotype: { ...phenotype, architecture: thickArchitecture }
+    });
+
+    expect(thick.nodes.map(node => [node.x, node.y, node.depth, node.parentId, node.generation]))
+      .toEqual(thin.nodes.map(node => [node.x, node.y, node.depth, node.parentId, node.generation]));
+    expect(thick.nodes.filter(node => node.generation > 0).map(node => node.radius))
+      .toEqual(thin.nodes.filter(node => node.generation > 0).map(node => node.radius));
+    expect(thick.nodes[0].radius).toBeGreaterThan(thin.nodes[0].radius);
+    for (const graph of [thin, thick]) {
+      const trunkRadii = graph.nodes.filter(node => node.generation === 0)
+        .map(node => node.radius);
+      expect(trunkRadii.every((radius, index) => index === 0
+        || radius <= trunkRadii[index - 1] + 1e-9)).toBeTrue();
+    }
+  });
+
   it('creates a valid rooted graph with one parent per non-root node', () => {
     const graph = generateForestTreeGraph(post);
     const incoming = Array(graph.nodes.length).fill(0);

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -21,9 +21,9 @@ block content
       ul
         li Post identity supplies the stable seed for every growth and rendering decision.
         li Three-dimensional radial growth is projected into a crisp two-dimensional tree.
-        li Branch hierarchy determines taper from the trunk through terminal twigs.
+        li Branch hierarchy and specimen architecture shape taper from the trunk through terminal twigs.
         li Individual leaves grow from eligible branches while preserving intentional crown gaps.
-        li Post semantics, ornaments, additional phenotypes, and trunk variance remain future layers.
+        li Post semantics, ornaments, additional phenotypes, and further trunk variance remain future layers.
 
     section.forest-gallery(aria-label='Generated post tree gallery')
       each item in trees
@@ -102,6 +102,8 @@ block content
             - const maximumOrder = Math.max(...item.tree.nodes.map(node => node.generation))
             | Seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
             |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
+            |  base radius #{item.tree.architecture.trunkBaseRadius.toFixed(2)} ·
+            |  taper #{item.tree.architecture.trunkTaper.toFixed(2)} ·
             |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·
             |  #{item.tree.foliage.leaves.length} leaves ·
             |  #{item.tree.diagnostics.crossingCount} projected overlaps ·


### PR DESCRIPTION
## Summary

- derive bounded, deterministic trunk base radius and taper traits from each tree seed
- keep trait ranges in the deciduous phenotype and sampled values in the tree architecture
- apply the specimen profile only to generation-zero trunk radii
- preserve pipe-model radii as a floor for natural major-branch transitions
- expose trunk base radius and taper in Forest Lab metadata
- update the procedural tree design document

## Testing

- added coverage for trait determinism, bounds, and meaningful seed variation
- verified trunk traits do not change branch geometry or non-trunk radii
- verified trunk radii narrow monotonically toward the crown
- focused v3 specs: 19 passing
- full test suite: 529 passing
- ESLint and `git diff --check` passing

## Scope

This is a renderer-v3 architectural variance change only. It does not alter the production-facing Activity Forest feature state.