### PR TITLE
Add deterministic trunk lean to the pilot tree phenotype

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -173,7 +173,7 @@ Renderer v2 established the original deterministic visual grammar and is preserv
 
 - Deterministic three-dimensional, space-colonization-inspired branch growth projected into two dimensions.
 - Persistent trunk and branch hierarchy with bounded growth and explicit termination.
-- Seed-derived specimen architecture with bounded branch-start height, trunk-base thickness, and trunk-taper variation.
+- Seed-derived specimen architecture with bounded branch-start height, trunk-base thickness, trunk-taper, and trunk-lean variation.
 - Back-propagated branch thickness, trunk taper, root flare, and leafless wood rasterization.
 - Depth-aware individual foliage attached to eligible branch growth.
 - Coverage repair that preserves negative space without producing detached canopy masses.
@@ -184,7 +184,7 @@ The initial graph, wood, and foliage milestones should therefore be treated as t
 
 The recommended near-term technical sequence is:
 
-1. Add trunk and architectural variance to the pilot phenotype: crown start, trunk lean, major forks, split-trunk height, and weight balance between leaders. Branch-start height, base thickness, and taper are complete.
+1. Add trunk and architectural variance to the pilot phenotype: major forks, split-trunk height, and weight balance between leaders. Branch-start height, base thickness, taper, and lean are complete.
 2. Build a genuinely distinct second phenotype to discover which parameters are species grammar and which assumptions remain hard-coded to the pilot tree.
 3. Begin deterministic forest composition and basic exploration before designing a substantial resource economy. Experiencing many trees as one place should reveal which curatorial and playful interactions the forest naturally invites.
 

--- a/server/services/forest/v3/architecture.js
+++ b/server/services/forest/v3/architecture.js
@@ -20,6 +20,18 @@ export function deriveTreeArchitecture(seed, phenotype) {
   const trunkTaper = roundTo(
     sampleRange(random, phenotype.architecture.trunkTaper), 2
   );
+  const trunkLeanAngle = roundTo(
+    sampleRange(random, phenotype.architecture.trunkLeanAngle), 3
+  );
+  const trunkLeanAzimuth = roundTo(
+    sampleRange(random, phenotype.architecture.trunkLeanAzimuth), 3
+  );
 
-  return Object.freeze({ branchStartHeight, trunkBaseRadius, trunkTaper });
+  return Object.freeze({
+    branchStartHeight,
+    trunkBaseRadius,
+    trunkTaper,
+    trunkLeanAngle,
+    trunkLeanAzimuth
+  });
 }

--- a/server/services/forest/v3/growth.js
+++ b/server/services/forest/v3/growth.js
@@ -156,16 +156,25 @@ function appendSegment(segments, parent, child) {
 function buildScaffold(nodes, segments, phenotype, architecture, random) {
   let leader = nodes[0];
   const trunkNodes = [];
+  const leanDirection = normalize({
+    x: Math.cos(architecture.trunkLeanAzimuth) * Math.sin(architecture.trunkLeanAngle),
+    y: -Math.cos(architecture.trunkLeanAngle),
+    z: Math.sin(architecture.trunkLeanAzimuth) * Math.sin(architecture.trunkLeanAngle)
+  });
+  leader.direction = leanDirection;
+  leader.axisDirection = leanDirection;
   while (leader.worldY - phenotype.internodeLength > phenotype.trunkTopY) {
     const direction = normalize({
-      x: leader.direction.x * 0.8 + ((random() - 0.5) * 0.025),
-      y: -1,
-      z: leader.direction.z * 0.8 + ((random() - 0.5) * 0.025)
+      x: (leader.direction.x * 0.55) + (leanDirection.x * 0.45)
+        + ((random() - 0.5) * 0.025),
+      y: leanDirection.y,
+      z: (leader.direction.z * 0.55) + (leanDirection.z * 0.45)
+        + ((random() - 0.5) * 0.025)
     });
     const child = appendNode(nodes, leader, direction, phenotype, {
       generation: 0,
       step: leader.step + 1,
-      axisDirection: { x: 0, y: -1, z: 0 }
+      axisDirection: leanDirection
     });
     appendSegment(segments, leader, child);
     leader = child;

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -18,7 +18,9 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
   architecture: Object.freeze({
     branchStartHeight: Object.freeze([22, 38]),
     trunkBaseRadius: Object.freeze([3.1, 4.1]),
-    trunkTaper: Object.freeze([0.72, 1.32])
+    trunkTaper: Object.freeze([0.72, 1.32]),
+    trunkLeanAngle: Object.freeze([0.025, 0.085]),
+    trunkLeanAzimuth: Object.freeze([0, Math.PI * 2])
   }),
   trunkTopY: 43,
   primaryBranchCount: 5,

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -46,6 +46,8 @@ describe('v3 forest branch graph generator', () => {
   it('derives deterministic, bounded, meaningfully varied trunk architecture', () => {
     const observedBaseRadii = new Set();
     const observedTapers = new Set();
+    const observedLeanAngles = new Set();
+    const observedLeanAzimuths = new Set();
     for (let seed = 0; seed < 100; seed += 1) {
       const first = generateForestTreeGraph(post, { seed });
       const repeated = generateForestTreeGraph(post, { seed });
@@ -57,14 +59,56 @@ describe('v3 forest branch graph generator', () => {
       expect(architecture.trunkBaseRadius).toBeLessThanOrEqual(ranges.trunkBaseRadius[1]);
       expect(architecture.trunkTaper).toBeGreaterThanOrEqual(ranges.trunkTaper[0]);
       expect(architecture.trunkTaper).toBeLessThanOrEqual(ranges.trunkTaper[1]);
+      expect(architecture.trunkLeanAngle).toBeGreaterThanOrEqual(ranges.trunkLeanAngle[0]);
+      expect(architecture.trunkLeanAngle).toBeLessThanOrEqual(ranges.trunkLeanAngle[1]);
+      expect(architecture.trunkLeanAzimuth).toBeGreaterThanOrEqual(ranges.trunkLeanAzimuth[0]);
+      expect(architecture.trunkLeanAzimuth).toBeLessThanOrEqual(ranges.trunkLeanAzimuth[1]);
       expect(first.nodes[0].radius + 1e-9).toBeGreaterThanOrEqual(
         architecture.trunkBaseRadius
       );
       observedBaseRadii.add(architecture.trunkBaseRadius);
       observedTapers.add(architecture.trunkTaper);
+      observedLeanAngles.add(architecture.trunkLeanAngle);
+      observedLeanAzimuths.add(architecture.trunkLeanAzimuth);
     }
     expect(observedBaseRadii.size).toBeGreaterThan(20);
     expect(observedTapers.size).toBeGreaterThan(20);
+    expect(observedLeanAngles.size).toBeGreaterThan(20);
+    expect(observedLeanAzimuths.size).toBeGreaterThan(80);
+  });
+
+  it('applies trunk lean as a coherent scaffold direction', () => {
+    const phenotype = generateForestTreeGraph(post, { seed: 202 }).phenotype;
+    const architecture = {
+      ...phenotype.architecture,
+      trunkLeanAzimuth: [0, 0]
+    };
+    const upright = generateForestTreeGraph(post, {
+      seed: 202,
+      phenotype: {
+        ...phenotype,
+        architecture: { ...architecture, trunkLeanAngle: [0, 0] }
+      }
+    });
+    const leaned = generateForestTreeGraph(post, {
+      seed: 202,
+      phenotype: {
+        ...phenotype,
+        architecture: { ...architecture, trunkLeanAngle: [0.08, 0.08] }
+      }
+    });
+    const uprightScaffoldEnd = upright.nodes.findIndex(node => node.generation === 1);
+    const leanedScaffoldEnd = leaned.nodes.findIndex(node => node.generation === 1);
+    const uprightTrunk = upright.nodes.slice(0, uprightScaffoldEnd);
+    const leanedTrunk = leaned.nodes.slice(0, leanedScaffoldEnd);
+
+    expect(leanedTrunk.length).toBe(uprightTrunk.length);
+    expect(leanedTrunk.at(-1).worldX).toBeGreaterThan(uprightTrunk.at(-1).worldX + 4);
+    expect(Math.abs(leanedTrunk.at(-1).worldZ - uprightTrunk.at(-1).worldZ))
+      .toBeLessThan(0.5);
+    expect(leanedTrunk.slice(1).every((node, index) => (
+      node.worldX > uprightTrunk[index + 1].worldX
+    ))).toBeTrue();
   });
 
   it('applies trunk traits without changing growth geometry or branch radii', () => {

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -104,6 +104,8 @@ block content
             |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
             |  base radius #{item.tree.architecture.trunkBaseRadius.toFixed(2)} ·
             |  taper #{item.tree.architecture.trunkTaper.toFixed(2)} ·
+            |  lean #{(item.tree.architecture.trunkLeanAngle * 180 / Math.PI).toFixed(1)}°
+            |  @ #{(item.tree.architecture.trunkLeanAzimuth * 180 / Math.PI).toFixed(0)}° ·
             |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·
             |  #{item.tree.foliage.leaves.length} leaves ·
             |  #{item.tree.diagnostics.crossingCount} projected overlaps ·


### PR DESCRIPTION
## Summary

- derive bounded, deterministic trunk lean angle and azimuth values from each tree seed
- apply lean as a coherent 3D axis during trunk scaffold growth
- preserve subtle internode irregularity and natural branch attachment
- expose lean angle and azimuth in Forest Lab metadata
- document trunk lean as a completed pilot-phenotype capability

## Testing

- `npm test -- spec/forestTreeGeneratorV3Spec.js`
- `npm test`

All 530 specs pass.