### PR TITLE
Add deterministic competing-leader variation to forest trees

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -173,7 +173,8 @@ Renderer v2 established the original deterministic visual grammar and is preserv
 
 - Deterministic three-dimensional, space-colonization-inspired branch growth projected into two dimensions.
 - Persistent trunk and branch hierarchy with bounded growth and explicit termination.
-- Seed-derived specimen architecture with bounded branch-start height, trunk-base thickness, trunk-taper, trunk-lean, and major-fork variation.
+- Seed-derived specimen architecture with bounded branch-start height, trunk-base thickness, trunk-taper, trunk-lean, major-fork, and competing-leader balance variation.
+- Split specimens retain two persistent leaders while a seed-derived balance trait modestly biases leader vigor, scaffold support, attraction-point competition, crown occupancy, and resulting pipe-model weight.
 - Back-propagated branch thickness, trunk taper, root flare, and leafless wood rasterization.
 - Depth-aware individual foliage attached to eligible branch growth.
 - Coverage repair that preserves negative space without producing detached canopy masses.
@@ -184,9 +185,8 @@ The initial graph, wood, and foliage milestones should therefore be treated as t
 
 The recommended near-term technical sequence is:
 
-1. Add trunk and architectural variance to the pilot phenotype: weight balance between competing leaders. Branch-start height, base thickness, taper, lean, major forks, and split-trunk height are complete.
-2. Build a genuinely distinct second phenotype to discover which parameters are species grammar and which assumptions remain hard-coded to the pilot tree.
-3. Begin deterministic forest composition and basic exploration before designing a substantial resource economy. Experiencing many trees as one place should reveal which curatorial and playful interactions the forest naturally invites.
+1. Build a genuinely distinct second phenotype to discover which parameters are species grammar and which assumptions remain hard-coded to the pilot tree. The planned pilot architectural variation—branch-start height, base thickness, taper, lean, major forks, split-trunk height, and competing-leader balance—is complete.
+2. Begin deterministic forest composition and basic exploration before designing a substantial resource economy. Experiencing many trees as one place should reveal which curatorial and playful interactions the forest naturally invites.
 
 ### Files
 

--- a/server/services/forest/v3/architecture.js
+++ b/server/services/forest/v3/architecture.js
@@ -11,6 +11,7 @@ function roundTo(value, precision) {
 
 export function deriveTreeArchitecture(seed, phenotype) {
   const random = createRandom(seed ^ 0xA2C417EC);
+  const leaderRandom = createRandom(seed ^ 0x1EADE4B4);
   const branchStartHeight = Math.round(
     sampleRange(random, phenotype.architecture.branchStartHeight) * 2
   ) / 2;
@@ -36,6 +37,10 @@ export function deriveTreeArchitecture(seed, phenotype) {
   const splitTrunkAzimuth = roundTo(
     sampleRange(random, phenotype.architecture.splitTrunkAzimuth), 3
   );
+  const leaderBalance = roundTo(
+    sampleRange(leaderRandom, phenotype.architecture.leaderBalance), 3
+  );
+  const dominantLeaderIndex = leaderRandom() < 0.5 ? 0 : 1;
 
   return Object.freeze({
     branchStartHeight,
@@ -46,6 +51,8 @@ export function deriveTreeArchitecture(seed, phenotype) {
     hasSplitTrunk,
     splitTrunkHeight,
     splitTrunkAngle,
-    splitTrunkAzimuth
+    splitTrunkAzimuth,
+    leaderBalance,
+    dominantLeaderIndex
   });
 }

--- a/server/services/forest/v3/growth.js
+++ b/server/services/forest/v3/growth.js
@@ -138,7 +138,8 @@ function appendNode(nodes, parent, direction, phenotype, properties = {}) {
     step: properties.step ?? parent.step,
     direction,
     axisDirection: properties.axisDirection || parent.axisDirection,
-    trunkProfile: properties.trunkProfile ?? parent.trunkProfile
+    trunkProfile: properties.trunkProfile ?? parent.trunkProfile,
+    leaderIndex: properties.leaderIndex ?? parent.leaderIndex
   };
   nodes.push(node);
   return node;
@@ -164,7 +165,7 @@ function buildScaffold(nodes, segments, phenotype, architecture, random) {
   });
   leader.direction = leanDirection;
   leader.axisDirection = leanDirection;
-  const appendLeaderNode = (parent, axisDirection, trunkProfile) => {
+  const appendLeaderNode = (parent, axisDirection, trunkProfile, properties = {}) => {
     const direction = normalize({
       x: (parent.direction.x * 0.55) + (axisDirection.x * 0.45)
         + ((random() - 0.5) * 0.025),
@@ -176,7 +177,8 @@ function buildScaffold(nodes, segments, phenotype, architecture, random) {
       generation: 0,
       step: parent.step + 1,
       axisDirection,
-      trunkProfile
+      trunkProfile,
+      ...properties
     });
     appendSegment(segments, parent, child);
     return child;
@@ -200,13 +202,15 @@ function buildScaffold(nodes, segments, phenotype, architecture, random) {
       y: 0,
       z: Math.sin(architecture.splitTrunkAzimuth)
     };
-    leaders = [-1, 1].map(side => {
+    leaders = [-1, 1].map((side, leaderIndex) => {
       const axisDirection = normalize({
         x: leanDirection.x + (forkAxis.x * Math.sin(architecture.splitTrunkAngle) * side),
         y: leanDirection.y * Math.cos(architecture.splitTrunkAngle),
         z: leanDirection.z + (forkAxis.z * Math.sin(architecture.splitTrunkAngle) * side)
       });
-      return appendLeaderNode(leader, axisDirection, false);
+      const vigor = leaderIndex === architecture.dominantLeaderIndex
+        ? 1 : architecture.leaderBalance;
+      return appendLeaderNode(leader, axisDirection, false, { leaderIndex, vigor });
     });
     leaderNodes.length = 0;
     for (const splitLeader of leaders) {
@@ -226,7 +230,11 @@ function buildScaffold(nodes, segments, phenotype, architecture, random) {
   const azimuthOffset = random() * Math.PI * 2;
   const goldenAngle = Math.PI * (3 - Math.sqrt(5));
   for (let index = 0; index < phenotype.primaryBranchCount; index += 1) {
-    const lineageIndex = index % leaderNodes.length;
+    const lineageIndex = leaderNodes.length === 1
+      ? 0
+      : index % 2 === 0
+        ? architecture.dominantLeaderIndex
+        : 1 - architecture.dominantLeaderIndex;
     const usableTrunkNodes = leaderNodes[lineageIndex].slice(1, -2);
     const lineageBranchCount = Math.ceil(
       (phenotype.primaryBranchCount - lineageIndex) / leaderNodes.length
@@ -248,10 +256,11 @@ function buildScaffold(nodes, segments, phenotype, architecture, random) {
     });
     const child = appendNode(nodes, parent, direction, phenotype, {
       generation: 1,
-      vigor: 0.8 - (heightProgress * 0.08),
+      vigor: (0.8 - (heightProgress * 0.08)) * (parent.vigor ?? 1),
       step: 0,
       axisDirection: direction,
-      trunkProfile: false
+      trunkProfile: false,
+      leaderIndex: parent.leaderIndex
     });
     appendSegment(segments, parent, child);
     primaryTips.push(child);
@@ -407,7 +416,8 @@ export function growBranchGraph(seed, phenotype) {
     step: 0,
     direction: { x: 0, y: -1, z: 0 },
     axisDirection: { x: 0, y: -1, z: 0 },
-    trunkProfile: true
+    trunkProfile: true,
+    leaderIndex: null
   }];
   const segments = [];
   let terminals = buildScaffold(nodes, segments, phenotype, architecture, random);
@@ -428,9 +438,15 @@ export function growBranchGraph(seed, phenotype) {
         );
         if (distance < phenotype.killRadius) return false;
         const influence = phenotype.influenceRadius * (1 - (terminal.generation * 0.08));
-        if (distance < nearestDistance && distance <= influence) {
+        const rawLeaderCapacity = terminal.leaderIndex === null
+          || terminal.leaderIndex === undefined
+          || terminal.leaderIndex === architecture.dominantLeaderIndex
+          ? 1 : architecture.leaderBalance;
+        const leaderCapacity = 0.25 + (rawLeaderCapacity * 0.75);
+        const competitiveDistance = distance / leaderCapacity;
+        if (competitiveDistance < nearestDistance && distance <= influence * leaderCapacity) {
           nearest = terminal;
-          nearestDistance = distance;
+          nearestDistance = competitiveDistance;
         }
       }
       if (nearest) assignments.get(nearest.id).push(point);
@@ -492,7 +508,8 @@ export function growBranchGraph(seed, phenotype) {
       generation: node.generation,
       vigor: node.vigor,
       step: node.step,
-      radius: node.radius
+      radius: node.radius,
+      leaderIndex: node.leaderIndex
     })),
     segments,
     terminalNodeIds: [...terminalNodeIds].sort((a, b) => a - b),

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -24,7 +24,8 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
     splitTrunkProbability: 0.65,
     splitTrunkHeight: Object.freeze([32, 46]),
     splitTrunkAngle: Object.freeze([0.3, 0.4]),
-    splitTrunkAzimuth: Object.freeze([0, Math.PI * 2])
+    splitTrunkAzimuth: Object.freeze([0, Math.PI * 2]),
+    leaderBalance: Object.freeze([0.78, 1])
   }),
   trunkTopY: 43,
   primaryBranchCount: 5,

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -6,6 +6,17 @@ import {
 describe('v3 forest branch graph generator', () => {
   const post = { id: 'post-forest-v3-1' };
 
+  function splitLeaderWeights(graph) {
+    const children = graph.nodes.map(() => []);
+    for (const segment of graph.segments) children[segment.fromId].push(segment.toId);
+    const fork = graph.nodes.find(node => node.generation === 0
+      && children[node.id].filter(id => graph.nodes[id].generation === 0).length === 2);
+    const leaderRoots = children[fork.id]
+      .map(id => graph.nodes[id])
+      .filter(node => node.generation === 0);
+    return leaderRoots.map(node => node.radius ** graph.phenotype.pipeExponent);
+  }
+
   it('is structurally deterministic for the same post and seed', () => {
     const first = generateForestTreeGraph(post);
     const second = generateForestTreeGraph({ ...post });
@@ -51,6 +62,8 @@ describe('v3 forest branch graph generator', () => {
     const observedSplitHeights = new Set();
     const observedSplitAngles = new Set();
     const observedSplitStates = new Set();
+    const observedLeaderBalances = new Set();
+    const observedDominantLeaders = new Set();
     for (let seed = 0; seed < 100; seed += 1) {
       const first = generateForestTreeGraph(post, { seed });
       const repeated = generateForestTreeGraph(post, { seed });
@@ -72,6 +85,9 @@ describe('v3 forest branch graph generator', () => {
       expect(architecture.splitTrunkAngle).toBeLessThanOrEqual(ranges.splitTrunkAngle[1]);
       expect(architecture.splitTrunkAzimuth).toBeGreaterThanOrEqual(ranges.splitTrunkAzimuth[0]);
       expect(architecture.splitTrunkAzimuth).toBeLessThanOrEqual(ranges.splitTrunkAzimuth[1]);
+      expect(architecture.leaderBalance).toBeGreaterThanOrEqual(ranges.leaderBalance[0]);
+      expect(architecture.leaderBalance).toBeLessThanOrEqual(ranges.leaderBalance[1]);
+      expect([0, 1]).toContain(architecture.dominantLeaderIndex);
       expect(first.nodes[0].radius + 1e-9).toBeGreaterThanOrEqual(
         architecture.trunkBaseRadius
       );
@@ -82,6 +98,8 @@ describe('v3 forest branch graph generator', () => {
       observedSplitHeights.add(architecture.splitTrunkHeight);
       observedSplitAngles.add(architecture.splitTrunkAngle);
       observedSplitStates.add(architecture.hasSplitTrunk);
+      observedLeaderBalances.add(architecture.leaderBalance);
+      observedDominantLeaders.add(architecture.dominantLeaderIndex);
     }
     expect(observedBaseRadii.size).toBeGreaterThan(20);
     expect(observedTapers.size).toBeGreaterThan(20);
@@ -90,6 +108,73 @@ describe('v3 forest branch graph generator', () => {
     expect(observedSplitHeights.size).toBeGreaterThan(15);
     expect(observedSplitAngles.size).toBeGreaterThan(20);
     expect(observedSplitStates).toEqual(new Set([true, false]));
+    expect(observedLeaderBalances.size).toBeGreaterThan(50);
+    expect(observedDominantLeaders).toEqual(new Set([0, 1]));
+  });
+
+  it('keeps leader balance isolated from forced single-trunk growth', () => {
+    const phenotype = generateForestTreeGraph(post, { seed: 202 }).phenotype;
+    const generate = leaderBalance => generateForestTreeGraph(post, {
+      seed: 202,
+      phenotype: {
+        ...phenotype,
+        architecture: {
+          ...phenotype.architecture,
+          splitTrunkProbability: 0,
+          leaderBalance: [leaderBalance, leaderBalance]
+        }
+      }
+    });
+    const balanced = generate(1);
+    const asymmetric = generate(0.78);
+
+    expect(balanced.architecture.hasSplitTrunk).toBeFalse();
+    expect(asymmetric.architecture.hasSplitTrunk).toBeFalse();
+    expect(asymmetric.nodes).toEqual(balanced.nodes);
+    expect(asymmetric.segments).toEqual(balanced.segments);
+    expect(asymmetric.remainingAttractionPointIds).toEqual(balanced.remainingAttractionPointIds);
+  });
+
+  it('keeps two viable leaders while balance predicts downstream pipe weight', () => {
+    let strongerLeaderWins = 0;
+    let asymmetricRatioTotal = 0;
+    let balancedRatioTotal = 0;
+    const seeds = Array.from({ length: 50 }, (_, seed) => seed);
+
+    for (const seed of seeds) {
+      const phenotype = generateForestTreeGraph(post, { seed }).phenotype;
+      const generate = leaderBalance => generateForestTreeGraph(post, {
+        seed,
+        phenotype: {
+          ...phenotype,
+          architecture: {
+            ...phenotype.architecture,
+            splitTrunkProbability: 1,
+            leaderBalance: [leaderBalance, leaderBalance]
+          }
+        }
+      });
+      const asymmetric = generate(0.78);
+      const balanced = generate(1);
+      const dominant = asymmetric.architecture.dominantLeaderIndex;
+      const weak = 1 - dominant;
+      const asymmetricWeights = splitLeaderWeights(asymmetric);
+      const balancedWeights = splitLeaderWeights(balanced);
+      const descendants = [0, 1].map(leaderIndex => (
+        asymmetric.nodes.filter(node => node.leaderIndex === leaderIndex)
+      ));
+
+      expect(descendants.every(nodes => nodes.length > 20)).toBeTrue();
+      expect(asymmetricWeights.every(weight => weight
+        > asymmetric.phenotype.terminalRadius ** asymmetric.phenotype.pipeExponent)).toBeTrue();
+      if (asymmetricWeights[dominant] > asymmetricWeights[weak]) strongerLeaderWins += 1;
+      asymmetricRatioTotal += asymmetricWeights[dominant] / asymmetricWeights[weak];
+      balancedRatioTotal += balancedWeights[dominant] / balancedWeights[weak];
+    }
+
+    expect(strongerLeaderWins).toBeGreaterThanOrEqual(45);
+    expect(asymmetricRatioTotal / seeds.length)
+      .toBeGreaterThan((balancedRatioTotal / seeds.length) + 0.5);
   });
 
   it('builds a bounded major fork with two persistent trunk leaders when enabled', () => {

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -109,6 +109,8 @@ block content
             if item.tree.architecture.hasSplitTrunk
               |  split #{item.tree.architecture.splitTrunkHeight.toFixed(1)} high
               |  @ #{(item.tree.architecture.splitTrunkAngle * 180 / Math.PI).toFixed(1)}° ·
+              |  balance #{item.tree.architecture.leaderBalance.toFixed(3)}
+              |  (leader #{item.tree.architecture.dominantLeaderIndex + 1} stronger) ·
             else
               |  single trunk ·
             |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·


### PR DESCRIPTION
## Summary

- add a bounded, deterministic leader-balance trait for split-trunk specimens
- track descendants by leader lineage
- express leader balance through vigor, scaffold support, attraction-point competition, crown occupancy, and pipe-model thickness
- preserve two viable persistent leaders and natural taper through the fork crotch
- expose leader balance and the dominant leader in Forest Lab metadata
- document the completed pilot architectural capability

## Random-stream stability

Leader balance and dominant-leader selection use a dedicated architecture random substream. Overriding the new trait does not shift existing architectural or growth random decisions.

The trait affects only split-trunk specimens. Forced single-trunk trees retain identical nodes, segments, radii, and remaining attraction points across leader-balance overrides.

## Visual verification

Inspected fixed Forest Lab fixtures representing both nearly balanced and asymmetric splits:

- near-balanced leaders continue to read as co-dominant
- asymmetric leaders show distinct branch load, thickness, and crown occupancy
- weaker leaders remain structurally viable and visually present
- shared-trunk and fork-crotch taper remain natural
- the open-crown character is preserved

## Testing

- focused v3 specs: 24 specs, 0 failures
- full test suite: 534 specs, 0 failures
- ESLint passed
- `git diff --check` passed