### PR TITLE
Align paragraph spacing across post views and previews

### DIFF
--- a/public/css/archive.css
+++ b/public/css/archive.css
@@ -50,10 +50,6 @@
   margin-bottom: 0.5rem;
 }
 
-.block-content p {
-  margin: 5px 0;
-}
-
 .room-link {
   text-decoration: underline dotted;
   color: #004187;

--- a/public/css/block-common.css
+++ b/public/css/block-common.css
@@ -16,6 +16,13 @@ a.block-title {
   word-break: break-word;
 }
 
+/* Keep rendered post prose equally readable in full views and preview cards. */
+.block-content p,
+.content-preview p,
+.featured-content-preview p {
+  margin: 1em 0;
+}
+
 .block-content img,
 .content-preview img,
 .featured-content-preview img {

--- a/public/css/blocks-dashboard.css
+++ b/public/css/blocks-dashboard.css
@@ -21,7 +21,6 @@ ul {
   flex-grow: 1;
 }
 
-.block-preview p,
 .block-preview h2,
 .block-preview ul,
 .block-preview ol,


### PR DESCRIPTION
## Summary

Standardize paragraph spacing for rendered post content across:

- Full post reading pages
- Main-page and featured preview cards
- Archive, tag, and dashboard previews

## Changes

- Define shared paragraph margins in `block-common.css`
- Remove compressed `5px` paragraph margins from preview cards
- Remove the archive-specific paragraph-spacing override

All post paragraphs now use the same `1em 0` spacing as full reading pages.

## Validation

- Confirmed the shared styles apply to full posts and preview variants
- Ran `git diff --check`