### PR TITLE
Add a versioned runtime asset boundary for procedural trees

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -185,8 +185,32 @@ The initial graph, wood, and foliage milestones should therefore be treated as t
 
 The recommended near-term technical sequence is:
 
-1. Build a genuinely distinct second phenotype to discover which parameters are species grammar and which assumptions remain hard-coded to the pilot tree. The planned pilot architectural variation—branch-start height, base thickness, taper, lean, major forks, split-trunk height, and competing-leader balance—is complete.
-2. Begin deterministic forest composition and basic exploration before designing a substantial resource economy. Experiencing many trees as one place should reveal which curatorial and playful interactions the forest naturally invites.
+1. Establish the versioned runtime tree-asset boundary described below.
+2. Build a genuinely distinct second phenotype against the shared asset contract.
+3. Begin deterministic forest composition and basic exploration.
+4. Add shared ambient motion once a representative multi-tree scene exists.
+
+### Generation results and runtime tree assets
+
+The procedural generation result is an authoring and diagnostic object. It retains the mutable inputs and derived architecture, three-dimensional branch graph, attraction points, termination diagnostics, foliage shoots and leaves, logical masks, shaded pixel grids, and compact color runs. Forest Lab needs this complete result to explain why a specimen has its shape, but a game-facing renderer does not.
+
+The runtime tree asset is a phenotype-independent, JSON-serializable projection built after generation. Schema version 1 contains:
+
+- asset schema version; renderer id and version; phenotype id and asset version
+- deterministic seed and the derived visual cache key
+- logical width and height, ground anchor, and occupied visual bounds
+- ordered `rear-foliage`, `wood`, and `front-foliage` horizontal color-run layers
+- limited architectural identity and maximum branch order for inspection and later composition
+
+It deliberately excludes masks, full pixel grids, nodes, segments, attraction points, diagnostics, leaves, shoots, and coverage cells. JSON stringify/parse is the serialization boundary: consumers render the parsed asset without procedural growth. Separate foliage and wood layers preserve depth order now and provide stable layer-level attachment points for future shared ambient motion or foliage-cluster metadata; no animation data is defined yet.
+
+### Identity, caching, and invalidation
+
+The visual cache key is composed from the tree-asset schema version, stable renderer id/version, stable phenotype id/asset version, and unsigned deterministic seed. Post identity is used only to derive the default seed and is not retained as a separate cache dimension. Explicit seeds therefore behave identically regardless of post id.
+
+Any output-affecting renderer change must increment the renderer version. Any output-affecting phenotype change must increment that phenotype's asset version. Contract changes increment the asset schema version. Changing any component produces a different key. Custom phenotype overrides are not cacheable merely because they were spread from a named phenotype: callers must provide a deliberate stable id/version.
+
+Forest Lab owns a narrow process-local in-memory cache of complete generation results plus their projected assets. Its lifetime is the development server process/module lifetime, and it is invalidated by restart or the versioned key. This lets the Lab preserve graph diagnostics while proving that finished and leafless canvases consume only reusable assets. It is not production persistence or a proposed game cache.
 
 ### Files
 

--- a/public/css/forest-lab.css
+++ b/public/css/forest-lab.css
@@ -148,12 +148,18 @@
   background: linear-gradient(#aec7cb 0 79%, #80936a 79% 100%);
 }
 
-.forest-grown-svg,
-.forest-wood-svg {
+.forest-grown-canvas,
+.forest-wood-canvas {
   display: block;
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   height: 100%;
   image-rendering: pixelated;
+}
+
+.forest-comparison {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 300px;
 }
 
 .forest-graph-svg {

--- a/public/js/forest-lab.js
+++ b/public/js/forest-lab.js
@@ -1,4 +1,26 @@
 (function () {
+  function paintRuns(context, runs) {
+    runs.forEach(function (run) {
+      context.fillStyle = run.color;
+      context.fillRect(run.x, run.y, run.width, 1);
+    });
+  }
+
+  function renderTreeAssets() {
+    const payload = document.getElementById('forest-tree-assets');
+    if (!payload) return;
+    const assets = JSON.parse(payload.textContent);
+    document.querySelectorAll('[data-forest-asset]').forEach(function (canvas) {
+      const asset = assets[Number(canvas.dataset.forestAsset)];
+      const context = canvas.getContext('2d');
+      context.imageSmoothingEnabled = false;
+      const layers = canvas.classList.contains('forest-wood-canvas')
+        ? asset.layers.filter(function (layer) { return layer.id === 'wood'; })
+        : asset.layers;
+      layers.forEach(function (layer) { paintRuns(context, layer.runs); });
+    });
+  }
+
   function humanDate(value) {
     const date = new Date(value);
     return Number.isNaN(date.getTime())
@@ -9,6 +31,7 @@
   }
 
   document.addEventListener('DOMContentLoaded', function () {
+    renderTreeAssets();
     const dialog = document.querySelector('[data-forest-tree-dialog]');
     if (!dialog) return;
 

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -2,7 +2,7 @@ import express from 'express';
 
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
-import { generateForestTreeV3 } from '../services/forestTreeGeneratorV3.js';
+import { getForestLabTree } from '../services/forestLabTreeCache.js';
 
 const router = express.Router();
 
@@ -52,10 +52,12 @@ function forestFixtures() {
       questApproved: index % 4 === 0,
       excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.'
     };
+    const { generation: tree, asset } = getForestLabTree(post);
     return {
       ...post,
       url: `/rooms/${post.roomId}/blocks/${post.id}`,
-      tree: generateForestTreeV3(post)
+      tree,
+      asset
     };
   });
 }

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -1,4 +1,9 @@
+export const DECIDUOUS_PHENOTYPE_ID = 'open-crown-deciduous';
+export const DECIDUOUS_PHENOTYPE_ASSET_VERSION = 1;
+
 export const DECIDUOUS_PHENOTYPE = Object.freeze({
+  id: DECIDUOUS_PHENOTYPE_ID,
+  assetVersion: DECIDUOUS_PHENOTYPE_ASSET_VERSION,
   name: 'open-crown deciduous',
   width: 96,
   height: 128,

--- a/server/services/forest/v3/treeAsset.js
+++ b/server/services/forest/v3/treeAsset.js
@@ -1,0 +1,72 @@
+export const FOREST_TREE_ASSET_SCHEMA_VERSION = 1;
+export const FOREST_RENDERER_ID = 'daily-page-forest-v3';
+
+function visualBounds(layers, width, height) {
+  const runs = layers.flatMap(layer => layer.runs);
+  if (!runs.length) return { x: 0, y: 0, width: 0, height: 0 };
+  const left = Math.min(...runs.map(run => run.x));
+  const top = Math.min(...runs.map(run => run.y));
+  const right = Math.max(...runs.map(run => run.x + run.width));
+  const bottom = Math.min(height, Math.max(...runs.map(run => run.y + 1)));
+  return { x: left, y: top, width: Math.min(width, right) - left, height: bottom - top };
+}
+
+export function treeAssetCacheKey({
+  seed,
+  rendererVersion,
+  phenotypeId,
+  phenotypeAssetVersion,
+  schemaVersion = FOREST_TREE_ASSET_SCHEMA_VERSION
+}) {
+  if (!phenotypeId || !Number.isInteger(phenotypeAssetVersion)) {
+    throw new Error('Cached tree assets require an explicit phenotype id and asset version.');
+  }
+  return [
+    `tree-asset-v${schemaVersion}`,
+    `${FOREST_RENDERER_ID}@${rendererVersion}`,
+    `${phenotypeId}@${phenotypeAssetVersion}`,
+    `seed-${seed >>> 0}`
+  ].join(':');
+}
+
+export function buildForestTreeAsset(generationResult) {
+  const { phenotype, rendererVersion, seed, wood, foliage, architecture } = generationResult;
+  const cacheKey = treeAssetCacheKey({
+    seed,
+    rendererVersion,
+    phenotypeId: phenotype.id,
+    phenotypeAssetVersion: phenotype.assetVersion
+  });
+  const layers = [
+    { id: 'rear-foliage', runs: foliage.backRuns },
+    { id: 'wood', runs: wood.runs },
+    { id: 'front-foliage', runs: foliage.frontRuns }
+  ];
+  return {
+    schemaVersion: FOREST_TREE_ASSET_SCHEMA_VERSION,
+    renderer: { id: FOREST_RENDERER_ID, version: rendererVersion },
+    phenotype: { id: phenotype.id, version: phenotype.assetVersion },
+    seed,
+    cacheKey,
+    dimensions: { width: wood.width, height: wood.height },
+    anchor: { x: generationResult.nodes[0].x, y: wood.groundY },
+    bounds: visualBounds(layers, wood.width, wood.height),
+    layers,
+    identity: {
+      architecture: {
+        branchStartHeight: architecture.branchStartHeight,
+        trunkBaseRadius: architecture.trunkBaseRadius,
+        trunkTaper: architecture.trunkTaper,
+        trunkLeanAngle: architecture.trunkLeanAngle,
+        trunkLeanAzimuth: architecture.trunkLeanAzimuth,
+        hasSplitTrunk: architecture.hasSplitTrunk,
+        splitTrunkHeight: architecture.splitTrunkHeight,
+        splitTrunkAngle: architecture.splitTrunkAngle,
+        splitTrunkAzimuth: architecture.splitTrunkAzimuth,
+        leaderBalance: architecture.leaderBalance,
+        dominantLeaderIndex: architecture.dominantLeaderIndex
+      },
+      maximumBranchOrder: Math.max(...generationResult.nodes.map(node => node.generation))
+    }
+  };
+}

--- a/server/services/forestLabTreeCache.js
+++ b/server/services/forestLabTreeCache.js
@@ -1,0 +1,46 @@
+import { generateForestTreeV3 } from './forestTreeGeneratorV3.js';
+import { buildForestTreeAsset, treeAssetCacheKey } from './forest/v3/treeAsset.js';
+import { DECIDUOUS_PHENOTYPE } from './forest/v3/phenotype.js';
+import { hashSeed } from './forest/v3/random.js';
+import { FOREST_RENDERER_VERSION_V3 } from './forestTreeGeneratorV3.js';
+
+// Process-local and development-only: entries live until the server restarts or this module is reloaded.
+const fixtureCache = new Map();
+
+export function clearForestLabTreeCache() {
+  fixtureCache.clear();
+}
+
+export function forestLabTreeCacheSize() {
+  return fixtureCache.size;
+}
+
+export function getForestLabTree(post, options = {}) {
+  const phenotype = options.phenotype || DECIDUOUS_PHENOTYPE;
+  const seed = (options.seed ?? hashSeed(`${FOREST_RENDERER_VERSION_V3}:${post.id}`)) >>> 0;
+  const identity = phenotype === DECIDUOUS_PHENOTYPE
+    ? { id: phenotype.id, version: phenotype.assetVersion }
+    : options.phenotypeIdentity;
+  const cacheable = typeof identity?.id === 'string'
+    && Number.isInteger(identity?.version);
+  if (!cacheable) {
+    const generation = generateForestTreeV3(post, options);
+    return { generation, asset: null, cacheHit: false };
+  }
+  const key = treeAssetCacheKey({
+    seed,
+    rendererVersion: FOREST_RENDERER_VERSION_V3,
+    phenotypeId: identity.id,
+    phenotypeAssetVersion: identity.version
+  });
+  if (fixtureCache.has(key)) return { ...fixtureCache.get(key), cacheHit: true };
+  const identifiedPhenotype = phenotype === DECIDUOUS_PHENOTYPE ? phenotype : {
+    ...phenotype,
+    id: identity.id,
+    assetVersion: identity.version
+  };
+  const generation = generateForestTreeV3(post, { ...options, seed, phenotype: identifiedPhenotype });
+  const value = { generation, asset: buildForestTreeAsset(generation) };
+  fixtureCache.set(key, value);
+  return { ...value, cacheHit: false };
+}

--- a/server/services/forestTreeGeneratorV3.js
+++ b/server/services/forestTreeGeneratorV3.js
@@ -4,6 +4,7 @@ import { DECIDUOUS_PHENOTYPE } from './forest/v3/phenotype.js';
 import { hashSeed } from './forest/v3/random.js';
 import { rasterizeFoliage } from './forest/v3/rasterizeFoliage.js';
 import { rasterizeWood } from './forest/v3/rasterizeWood.js';
+import { buildForestTreeAsset } from './forest/v3/treeAsset.js';
 
 export const FOREST_RENDERER_VERSION_V3 = 3;
 
@@ -28,4 +29,8 @@ export function generateForestTreeV3(post, options = {}) {
     wood: rasterizeWood(graph, graph.phenotype, graph.seed),
     foliage: rasterizeFoliage(graph, graph.phenotype, graph.seed)
   };
+}
+
+export function generateForestTreeAssetV3(post, options = {}) {
+  return buildForestTreeAsset(generateForestTreeV3(post, options));
 }

--- a/spec/forestTreeAssetSpec.js
+++ b/spec/forestTreeAssetSpec.js
@@ -1,0 +1,107 @@
+import {
+  generateForestTreeAssetV3,
+  generateForestTreeV3
+} from '../server/services/forestTreeGeneratorV3.js';
+import {
+  buildForestTreeAsset,
+  FOREST_TREE_ASSET_SCHEMA_VERSION,
+  treeAssetCacheKey
+} from '../server/services/forest/v3/treeAsset.js';
+import { DECIDUOUS_PHENOTYPE } from '../server/services/forest/v3/phenotype.js';
+import {
+  clearForestLabTreeCache,
+  forestLabTreeCacheSize,
+  getForestLabTree
+} from '../server/services/forestLabTreeCache.js';
+
+describe('v3 forest runtime tree assets', () => {
+  const post = { id: 'tree-asset-post' };
+
+  beforeEach(() => clearForestLabTreeCache());
+
+  it('is deterministic, versioned, and exactly JSON round-trippable', () => {
+    const first = generateForestTreeAssetV3(post, { seed: 101 });
+    const repeated = generateForestTreeAssetV3(post, { seed: 101 });
+    const roundTrip = JSON.parse(JSON.stringify(first));
+
+    expect(first).toEqual(repeated);
+    expect(roundTrip).toEqual(first);
+    expect(first.schemaVersion).toBe(FOREST_TREE_ASSET_SCHEMA_VERSION);
+    expect(first.layers.map(layer => layer.id)).toEqual([
+      'rear-foliage', 'wood', 'front-foliage'
+    ]);
+    expect(first.dimensions).toEqual({ width: 96, height: 128 });
+    expect(first.anchor.y).toBe(120);
+    expect(first.bounds.width).toBeGreaterThan(0);
+    expect(first.bounds.height).toBeGreaterThan(0);
+  });
+
+  it('contains display runs and limited identity but excludes generation diagnostics', () => {
+    const asset = generateForestTreeAssetV3(post, { seed: 202 });
+    const serialized = JSON.stringify(asset);
+
+    for (const excluded of [
+      'nodes', 'segments', 'attractionPoints', 'diagnostics', 'mask', 'pixels',
+      'leaves', 'shoots', 'coverageCells'
+    ]) expect(serialized).not.toContain(`"${excluded}"`);
+    expect(asset.identity.architecture.hasSplitTrunk).toBeDefined();
+    expect(asset.layers.every(layer => Array.isArray(layer.runs))).toBeTrue();
+  });
+
+  it('varies cache identity with seed, renderer, phenotype, and schema versions', () => {
+    const identity = {
+      seed: 1,
+      rendererVersion: 3,
+      phenotypeId: 'deciduous',
+      phenotypeAssetVersion: 1,
+      schemaVersion: 1
+    };
+    const key = treeAssetCacheKey(identity);
+
+    for (const change of [
+      { seed: 2 }, { rendererVersion: 4 }, { phenotypeId: 'conifer' },
+      { phenotypeAssetVersion: 2 }, { schemaVersion: 2 }
+    ]) expect(treeAssetCacheKey({ ...identity, ...change })).not.toBe(key);
+  });
+
+  it('builds the same visual asset from an existing generation result', () => {
+    const generation = generateForestTreeV3(post, { seed: 303 });
+    expect(buildForestTreeAsset(generation))
+      .toEqual(generateForestTreeAssetV3(post, { seed: 303 }));
+  });
+
+  it('reuses development fixtures by visual identity, independent of post identity', () => {
+    const first = getForestLabTree(post, { seed: 404 });
+    const repeated = getForestLabTree({ id: 'another-post' }, { seed: 404 });
+
+    expect(first.cacheHit).toBeFalse();
+    expect(repeated.cacheHit).toBeTrue();
+    expect(repeated.asset).toBe(first.asset);
+    expect(repeated.generation).toBe(first.generation);
+    expect(forestLabTreeCacheSize()).toBe(1);
+  });
+
+  it('does not silently cache custom phenotype overrides without a stable identity', () => {
+    const custom = { ...DECIDUOUS_PHENOTYPE, maxIterations: 1 };
+    const first = getForestLabTree(post, { seed: 505, phenotype: custom });
+    const repeated = getForestLabTree(post, { seed: 505, phenotype: custom });
+
+    expect(first.cacheHit).toBeFalse();
+    expect(repeated.cacheHit).toBeFalse();
+    expect(first.asset).toBeNull();
+    expect(forestLabTreeCacheSize()).toBe(0);
+  });
+
+  it('caches explicitly identified custom phenotypes without conflating identities', () => {
+    const custom = { ...DECIDUOUS_PHENOTYPE, maxIterations: 1 };
+    const first = getForestLabTree(post, {
+      seed: 606, phenotype: custom, phenotypeIdentity: { id: 'lab-short-growth', version: 1 }
+    });
+    const second = getForestLabTree(post, {
+      seed: 606, phenotype: custom, phenotypeIdentity: { id: 'lab-short-growth', version: 2 }
+    });
+
+    expect(first.asset.cacheKey).not.toBe(second.asset.cacheKey);
+    expect(forestLabTreeCacheSize()).toBe(2);
+  });
+});

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -26,7 +26,7 @@ block content
         li Post semantics, ornaments, additional phenotypes, and further trunk variance remain future layers.
 
     section.forest-gallery(aria-label='Generated post tree gallery')
-      each item in trees
+      each item, treeIndex in trees
         article.forest-comparison
           .forest-comparison__views
             button.forest-grown-card(
@@ -41,33 +41,23 @@ block content
             )
               span.forest-comparison__label Grown tree
               .forest-grown-stage
-                svg.forest-grown-svg(
-                  viewBox=`0 0 ${item.tree.wood.width} ${item.tree.wood.height}`
+                canvas.forest-grown-canvas(
+                  width=item.asset.dimensions.width
+                  height=item.asset.dimensions.height
+                  data-forest-asset=treeIndex
                   role='img'
                   aria-label=`Procedural tree with supported foliage for ${item.title}`
-                  shape-rendering='crispEdges'
-                  preserveAspectRatio='xMidYMax meet'
                 )
-                  title= `Procedural tree with terminal-supported foliage for ${item.title}`
-                  each run in item.tree.foliage.backRuns
-                    rect(x=run.x y=run.y width=run.width height='1' fill=run.color)
-                  each run in item.tree.wood.runs
-                    rect(x=run.x y=run.y width=run.width height='1' fill=run.color)
-                  each run in item.tree.foliage.frontRuns
-                    rect(x=run.x y=run.y width=run.width height='1' fill=run.color)
             figure.forest-wood-card
               figcaption.forest-comparison__label Leafless wood
               .forest-wood-stage
-                svg.forest-wood-svg(
-                  viewBox=`0 0 ${item.tree.wood.width} ${item.tree.wood.height}`
+                canvas.forest-wood-canvas(
+                  width=item.asset.dimensions.width
+                  height=item.asset.dimensions.height
+                  data-forest-asset=treeIndex
                   role='img'
                   aria-label=`Leafless wood raster for ${item.title}`
-                  shape-rendering='crispEdges'
-                  preserveAspectRatio='xMidYMax meet'
                 )
-                  title= `Leafless wood raster for ${item.title}`
-                  each run in item.tree.wood.runs
-                    rect(x=run.x y=run.y width=run.width height='1' fill=run.color)
             figure.forest-graph-card
               figcaption.forest-comparison__label Branch graph
               svg.forest-graph-svg(
@@ -117,6 +107,8 @@ block content
             |  #{item.tree.foliage.leaves.length} leaves ·
             |  #{item.tree.diagnostics.crossingCount} projected overlaps ·
             |  #{item.tree.stats.terminationReason}
+
+    script#forest-tree-assets(type='application/json')!= JSON.stringify(trees.map(item => item.asset)).replace(/</g, '\\u003c')
 
     dialog.forest-tree-dialog(data-forest-tree-dialog aria-labelledby='forest-tree-dialog-title')
       form(method='dialog')


### PR DESCRIPTION
## Summary

- Introduce a versioned, JSON-serializable runtime asset contract for v3 procedural trees
- Separate reusable visual layers from generation and diagnostic data
- Add stable renderer and phenotype identities for deterministic cache invalidation
- Cache Forest Lab fixtures in memory for the lifetime of the development server
- Render grown-tree and leafless-wood previews on canvas instead of creating thousands of SVG rectangles
- Preserve SVG branch-graph diagnostics and existing accessibility behavior
- Document the asset boundary, invalidation model, and revised Activity Forest roadmap

## Asset contract

Runtime tree assets contain:

- Asset schema, renderer, and phenotype identities and versions
- Deterministic seed and visual cache key
- Logical dimensions, ground anchor, and visual bounds
- Ordered rear-foliage, wood, and front-foliage run layers
- Limited architectural metadata for inspection and future composition

They intentionally exclude complete branch graphs, attraction points, diagnostics, masks, pixel grids, foliage shoots, leaves, and coverage data.

Cache identity is derived from:

```text
asset schema version
+ renderer identity/version
+ phenotype identity/version
+ deterministic seed
```

Post identity is not retained after deriving the default seed. Custom phenotype overrides are not cached without an explicit stable identity and version.

## Forest Lab performance

Before:

- Every request regenerated all 24 fixtures
- Approximately 99,568 SVG rectangles represented grown-tree and wood rasters
- Approximately 118,255 total SVG child elements were created
- Warm fixture generation took approximately 1.10–1.15 seconds

After:

- Repeated fixture requests reuse all 24 cached generation results and assets
- Grown-tree and wood displays use 48 canvas elements
- The diagnostic graph remains SVG
- Estimated total canvas and graph element burden is approximately 18,735 elements
- A cached 24-fixture lookup takes approximately 0.12 ms
- Offscreen cards use `content-visibility` containment

## Compatibility

- `generateForestTreeGraph()` remains unchanged
- `generateForestTreeV3()` remains unchanged
- `generateForestTreeAssetV3()` provides the new serialized display boundary
- Forest Lab remains development-only
- Production-facing Activity Forest behavior is unchanged

## Testing

- [x] Focused asset and v3 generator specs: 31 passing
- [x] Full test suite: 541 passing
- [x] Full lint suite
- [x] Forest Lab Pug compilation
- [x] JSON round-trip and cache invalidation coverage
- [x] Existing determinism, graph, wood, foliage, and architecture coverage
- [x] Manual Forest Lab performance and visual verification

## Deferred work

- Additional phenotypes
- Production persistence or object storage
- Forest composition and exploration
- Texture atlases or alternative rendering engines
- Ambient motion and foliage clustering
