### PR TITLE
Add sunset lanternwood phenotype and weighted foliage palettes

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -178,6 +178,8 @@ Renderer v2 established the original deterministic visual grammar and is preserv
 - Back-propagated branch thickness, trunk taper, root flare, and leafless wood rasterization.
 - Depth-aware individual foliage attached to eligible branch growth.
 - Coverage repair that preserves negative space without producing detached canopy masses.
+- Deterministic weighted foliage palettes, with a common signature colorway and rarer whole-tree
+  variants registered independently by each phenotype.
 - Debug views for the branch graph and leafless wood alongside the final grown tree.
 - Automated coverage for determinism, graph validity, bounds, termination, hierarchy, rasterization, and foliage behavior.
 
@@ -186,7 +188,8 @@ The initial graph, wood, and foliage milestones should therefore be treated as t
 The recommended near-term technical sequence is:
 
 1. Establish the versioned runtime tree-asset boundary described below.
-2. Build a genuinely distinct second phenotype against the shared asset contract.
+2. Build a genuinely distinct second phenotype against the shared asset contract. (Complete:
+   the broad, warm-colored sunset lanternwood now contrasts with the pilot open-crown deciduous.)
 3. Begin deterministic forest composition and basic exploration.
 4. Add shared ambient motion once a representative multi-tree scene exists.
 
@@ -216,7 +219,8 @@ Forest Lab owns a narrow process-local in-memory cache of complete generation re
 
 - `server/services/forestTreeGeneratorV3.js`: experimental v3 orchestration.
 - `server/services/forest/v3/architecture.js`: deterministic per-tree architectural traits.
-- `server/services/forest/v3/phenotype.js`: pilot phenotype and growth tendencies.
+- `server/services/forest/v3/phenotype.js`: registered deciduous and lanternwood phenotypes and
+  their distinct growth, architecture, foliage, and palette tendencies.
 - `server/services/forest/v3/growth.js`: deterministic three-dimensional branch growth.
 - `server/services/forest/v3/rasterizeWood.js`: tapered wood, root flare, and bark rendering.
 - `server/services/forest/v3/rasterizeFoliage.js`: leaf-bearing shoots, foliage coverage, depth, and rasterization.

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -3,6 +3,10 @@ import express from 'express';
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
 import { getForestLabTree } from '../services/forestLabTreeCache.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE
+} from '../services/forest/v3/phenotype.js';
 
 const router = express.Router();
 
@@ -52,7 +56,8 @@ function forestFixtures() {
       questApproved: index % 4 === 0,
       excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.'
     };
-    const { generation: tree, asset } = getForestLabTree(post);
+    const phenotype = index % 2 === 0 ? DECIDUOUS_PHENOTYPE : LANTERNWOOD_PHENOTYPE;
+    const { generation: tree, asset } = getForestLabTree(post, { phenotype });
     return {
       ...post,
       url: `/rooms/${post.roomId}/blocks/${post.id}`,

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -1,5 +1,7 @@
 export const DECIDUOUS_PHENOTYPE_ID = 'open-crown-deciduous';
-export const DECIDUOUS_PHENOTYPE_ASSET_VERSION = 1;
+export const DECIDUOUS_PHENOTYPE_ASSET_VERSION = 2;
+export const LANTERNWOOD_PHENOTYPE_ID = 'sunset-lanternwood';
+export const LANTERNWOOD_PHENOTYPE_ASSET_VERSION = 2;
 
 export const DECIDUOUS_PHENOTYPE = Object.freeze({
   id: DECIDUOUS_PHENOTYPE_ID,
@@ -74,6 +76,146 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
   leafRadiusX: Object.freeze([1.75, 2.6]),
   leafRadiusY: Object.freeze([2.65, 4]),
   leafShootSpread: Object.freeze([4, 8.5]),
+  foliagePalettes: Object.freeze([
+    Object.freeze({
+      id: 'summer-green', weight: 78,
+      colors: Object.freeze({
+        highlight: '#9fbe59', light: '#73a34a', mid: '#4f843f',
+        dark: '#2e6339', deep: '#214a35'
+      })
+    }),
+    Object.freeze({
+      id: 'meadow-green', weight: 14,
+      colors: Object.freeze({
+        highlight: '#d1d96b', light: '#9fbd55', mid: '#669545',
+        dark: '#3d6f40', deep: '#28513b'
+      })
+    }),
+    Object.freeze({
+      id: 'blue-grove', weight: 6,
+      colors: Object.freeze({
+        highlight: '#9acb9b', light: '#65aa83', mid: '#428575',
+        dark: '#326369', deep: '#294858'
+      })
+    }),
+    Object.freeze({
+      id: 'early-gold', weight: 2,
+      colors: Object.freeze({
+        highlight: '#f4dc78', light: '#d8b958', mid: '#ad8842',
+        dark: '#795d3e', deep: '#51443a'
+      })
+    })
+  ]),
   rootFlareHeight: 11,
   rootFlareStrength: 3.8
 });
+
+export const LANTERNWOOD_PHENOTYPE = Object.freeze({
+  id: LANTERNWOOD_PHENOTYPE_ID,
+  assetVersion: LANTERNWOOD_PHENOTYPE_ASSET_VERSION,
+  name: 'sunset lanternwood',
+  width: 112,
+  height: 120,
+  groundY: 112,
+  crown: Object.freeze({ centerX: 56, centerY: 52, radiusX: 48, radiusY: 34, radiusZ: 36 }),
+  cameraYaw: -0.32,
+  perspectiveStrength: 0.09,
+  growthEnvelopeOverscan: 1.06,
+  attractionPointCount: 210,
+  attractionGap: 0.06,
+  architecture: Object.freeze({
+    branchStartHeight: Object.freeze([28, 40]),
+    trunkBaseRadius: Object.freeze([3.8, 5]),
+    trunkTaper: Object.freeze([0.62, 1.05]),
+    trunkLeanAngle: Object.freeze([0.07, 0.15]),
+    trunkLeanAzimuth: Object.freeze([0, Math.PI * 2]),
+    splitTrunkProbability: 0.12,
+    splitTrunkHeight: Object.freeze([38, 48]),
+    splitTrunkAngle: Object.freeze([0.22, 0.32]),
+    splitTrunkAzimuth: Object.freeze([0, Math.PI * 2]),
+    leaderBalance: Object.freeze([0.86, 1])
+  }),
+  trunkTopY: 44,
+  primaryBranchCount: 7,
+  primaryBranchAngle: 1.16,
+  internodeLength: 3.2,
+  influenceRadius: 27,
+  killRadius: 4,
+  maxIterations: 68,
+  maxNodes: 460,
+  maxGeneration: 4,
+  apicalDominance: 0.08,
+  parentDirectionWeight: 0.42,
+  maximumTurnAngle: 0.34,
+  maximumAxisDeviation: 0.94,
+  lowerBranchFloorY: 70,
+  lowerBranchTransitionHeight: 18,
+  lowerBranchMaximumDroop: 0.24,
+  phototropism: 0.1,
+  forkProbability: 0.2,
+  minimumForkPoints: 6,
+  forkSeparation: 0.25,
+  minimumVigor: 0.07,
+  vigorDecay: 0.97,
+  terminalRadius: 0.58,
+  pipeExponent: 2.1,
+  foliageMinimumOrder: 2,
+  foliageTerminalCoverage: 1,
+  foliageCoverageColumns: 7,
+  foliageCoverageRows: 5,
+  foliageCoverageSamples: 3,
+  foliageMinimumCellCoverage: 0.42,
+  foliageMaximumTopUpCells: 12,
+  foliageTopUpSupportsPerCell: 3,
+  foliageSupplementalLeafCount: Object.freeze([10, 15]),
+  foliageSupportRadius: 19,
+  foliageMinimumLeafSpacing: 1.05,
+  terminalLeafCount: Object.freeze([13, 19]),
+  highOrderLeafCount: Object.freeze([7, 11]),
+  secondaryLeafCount: Object.freeze([3, 6]),
+  secondaryShootProbability: 0.58,
+  leafRadiusX: Object.freeze([2.15, 3.25]),
+  leafRadiusY: Object.freeze([2.3, 3.45]),
+  leafShootSpread: Object.freeze([4.8, 9.5]),
+  foliagePalettes: Object.freeze([
+    Object.freeze({
+      id: 'sunset', weight: 76,
+      colors: Object.freeze({
+        highlight: '#ffe38a', light: '#f6bd60', mid: '#e88b5b',
+        dark: '#b95756', deep: '#743f52'
+      })
+    }),
+    Object.freeze({
+      id: 'harvest', weight: 14,
+      colors: Object.freeze({
+        highlight: '#fff0a0', light: '#efcb68', mid: '#cf9849',
+        dark: '#986044', deep: '#603f43'
+      })
+    }),
+    Object.freeze({
+      id: 'enchanted-plum', weight: 7,
+      colors: Object.freeze({
+        highlight: '#efb4cf', light: '#d988b6', mid: '#a85c9a',
+        dark: '#713f79', deep: '#472f5e'
+      })
+    }),
+    Object.freeze({
+      id: 'spring-bloom', weight: 3,
+      colors: Object.freeze({
+        highlight: '#fff0c4', light: '#f0bfa7', mid: '#cf8494',
+        dark: '#925b79', deep: '#593f60'
+      })
+    })
+  ]),
+  woodPalette: Object.freeze({
+    light: '#d8b987', mid: '#aa795d', dark: '#704b4b', deep: '#49333f'
+  }),
+  rootFlareHeight: 13,
+  rootFlareStrength: 5.2
+});
+
+export const FOREST_PHENOTYPES = Object.freeze([DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE]);
+
+export function isRegisteredForestPhenotype(phenotype) {
+  return FOREST_PHENOTYPES.includes(phenotype);
+}

--- a/server/services/forest/v3/rasterizeFoliage.js
+++ b/server/services/forest/v3/rasterizeFoliage.js
@@ -10,6 +10,21 @@ export const FOLIAGE_PALETTE = Object.freeze({
   deep: '#214a35'
 });
 
+export function selectFoliagePalette(phenotype, seed) {
+  const variants = phenotype.foliagePalettes;
+  if (!variants?.length) {
+    return { id: 'default', colors: phenotype.foliagePalette || FOLIAGE_PALETTE };
+  }
+  const totalWeight = variants.reduce((sum, variant) => sum + variant.weight, 0);
+  if (!(totalWeight > 0)) throw new Error('Foliage palette weights must total more than zero.');
+  let choice = createRandom(seed ^ 0xC0104A11)() * totalWeight;
+  for (const variant of variants) {
+    choice -= variant.weight;
+    if (choice < 0) return variant;
+  }
+  return variants.at(-1);
+}
+
 function makeGrid(width, height, value = EMPTY) {
   return Array.from({ length: height }, () => Array(width).fill(value));
 }
@@ -283,7 +298,7 @@ function paintLeaf(mask, owner, leaf, phenotype) {
   }
 }
 
-function shadeLeaves(mask, owner) {
+function shadeLeaves(mask, owner, palette) {
   const pixels = makeGrid(mask[0].length, mask.length);
   for (let y = 0; y < mask.length; y += 1) {
     for (let x = 0; x < mask[y].length; x += 1) {
@@ -293,14 +308,14 @@ function shadeLeaves(mask, owner) {
       const upperLeft = sample.normalizedX + sample.normalizedY < -0.38;
       const centralVein = Math.abs(sample.localX) < 0.48;
       if (upperLeft && leaf.massLight > 0.68 && leaf.tone > 0.62) {
-        pixels[y][x] = FOLIAGE_PALETTE.highlight;
+        pixels[y][x] = palette.highlight;
       } else if (centralVein && sample.normalizedY < 0.35
         && leaf.massLight > 0.52 && leaf.tone > 0.42) {
-        pixels[y][x] = FOLIAGE_PALETTE.light;
+        pixels[y][x] = palette.light;
       } else if (leaf.massLight < 0.3 || leaf.depth < -8 || leaf.tone < 0.14) {
-        pixels[y][x] = FOLIAGE_PALETTE.deep;
-      } else if (sample.normalizedX > 0.3) pixels[y][x] = FOLIAGE_PALETTE.dark;
-      else pixels[y][x] = FOLIAGE_PALETTE.mid;
+        pixels[y][x] = palette.deep;
+      } else if (sample.normalizedX > 0.3) pixels[y][x] = palette.dark;
+      else pixels[y][x] = palette.mid;
     }
   }
   return pixels;
@@ -324,21 +339,23 @@ function compactRuns(pixels) {
   return runs;
 }
 
-function rasterizeLayer(leaves, layer, phenotype) {
+function rasterizeLayer(leaves, layer, phenotype, palette) {
   const mask = makeGrid(phenotype.width, phenotype.height, false);
   const owner = makeGrid(phenotype.width, phenotype.height);
   const layerLeaves = leaves
     .filter(leaf => (leaf.depth >= 0 ? 'front' : 'back') === layer)
     .sort((first, second) => first.depth - second.depth || first.id - second.id);
   for (const leaf of layerLeaves) paintLeaf(mask, owner, leaf, phenotype);
-  const pixels = shadeLeaves(mask, owner);
+  const pixels = shadeLeaves(mask, owner, palette);
   return { mask, pixels, runs: compactRuns(pixels) };
 }
 
 export function rasterizeFoliage(graph, phenotype, seed) {
+  const paletteVariant = selectFoliagePalette(phenotype, seed);
+  const palette = paletteVariant.colors;
   const { shoots, leaves, coverageCells } = generateLeafBearingShoots(graph, phenotype, seed);
-  const back = rasterizeLayer(leaves, 'back', phenotype);
-  const front = rasterizeLayer(leaves, 'front', phenotype);
+  const back = rasterizeLayer(leaves, 'back', phenotype, palette);
+  const front = rasterizeLayer(leaves, 'front', phenotype, palette);
   const mask = makeGrid(phenotype.width, phenotype.height, false);
   const pixels = makeGrid(phenotype.width, phenotype.height);
   for (let y = 0; y < phenotype.height; y += 1) {
@@ -358,6 +375,7 @@ export function rasterizeFoliage(graph, phenotype, seed) {
     shoots,
     leaves,
     coverageCells,
-    palette: FOLIAGE_PALETTE
+    paletteId: paletteVariant.id,
+    palette
   };
 }

--- a/server/services/forest/v3/rasterizeWood.js
+++ b/server/services/forest/v3/rasterizeWood.js
@@ -64,7 +64,7 @@ function paintRootFlare(mask, owner, root, phenotype) {
   }
 }
 
-function shadeWood(mask, owner, seed) {
+function shadeWood(mask, owner, seed, palette) {
   const height = mask.length;
   const width = mask[0].length;
   const pixels = makeGrid(width, height);
@@ -75,10 +75,10 @@ function shadeWood(mask, owner, seed) {
       const side = surface.lateral / Math.max(0.5, surface.radius);
       const noise = coordinateNoise(seed, x, y);
       const verticalBarkMark = y > 18 && noise % 41 < 3 && mask[Math.max(0, y - 1)][x];
-      if (side < -0.35 && noise % 5 !== 0) pixels[y][x] = WOOD_PALETTE.light;
-      else if (side > 0.48) pixels[y][x] = WOOD_PALETTE.dark;
-      else if (verticalBarkMark) pixels[y][x] = WOOD_PALETTE.deep;
-      else pixels[y][x] = WOOD_PALETTE.mid;
+      if (side < -0.35 && noise % 5 !== 0) pixels[y][x] = palette.light;
+      else if (side > 0.48) pixels[y][x] = palette.dark;
+      else if (verticalBarkMark) pixels[y][x] = palette.deep;
+      else pixels[y][x] = palette.mid;
     }
   }
   return pixels;
@@ -103,6 +103,7 @@ function compactRuns(pixels) {
 }
 
 export function rasterizeWood(graph, phenotype, seed) {
+  const palette = phenotype.woodPalette || WOOD_PALETTE;
   const mask = makeGrid(phenotype.width, phenotype.height, false);
   const owner = makeGrid(phenotype.width, phenotype.height);
   for (const segment of graph.segments) {
@@ -115,7 +116,7 @@ export function rasterizeWood(graph, phenotype, seed) {
     );
   }
   paintRootFlare(mask, owner, graph.nodes[0], phenotype);
-  const pixels = shadeWood(mask, owner, seed ^ 0xB47C0DE);
+  const pixels = shadeWood(mask, owner, seed ^ 0xB47C0DE, palette);
   return {
     width: phenotype.width,
     height: phenotype.height,
@@ -123,6 +124,6 @@ export function rasterizeWood(graph, phenotype, seed) {
     mask,
     pixels,
     runs: compactRuns(pixels),
-    palette: WOOD_PALETTE
+    palette
   };
 }

--- a/server/services/forestLabTreeCache.js
+++ b/server/services/forestLabTreeCache.js
@@ -1,6 +1,9 @@
 import { generateForestTreeV3 } from './forestTreeGeneratorV3.js';
 import { buildForestTreeAsset, treeAssetCacheKey } from './forest/v3/treeAsset.js';
-import { DECIDUOUS_PHENOTYPE } from './forest/v3/phenotype.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  isRegisteredForestPhenotype
+} from './forest/v3/phenotype.js';
 import { hashSeed } from './forest/v3/random.js';
 import { FOREST_RENDERER_VERSION_V3 } from './forestTreeGeneratorV3.js';
 
@@ -18,7 +21,7 @@ export function forestLabTreeCacheSize() {
 export function getForestLabTree(post, options = {}) {
   const phenotype = options.phenotype || DECIDUOUS_PHENOTYPE;
   const seed = (options.seed ?? hashSeed(`${FOREST_RENDERER_VERSION_V3}:${post.id}`)) >>> 0;
-  const identity = phenotype === DECIDUOUS_PHENOTYPE
+  const identity = isRegisteredForestPhenotype(phenotype)
     ? { id: phenotype.id, version: phenotype.assetVersion }
     : options.phenotypeIdentity;
   const cacheable = typeof identity?.id === 'string'
@@ -34,7 +37,7 @@ export function getForestLabTree(post, options = {}) {
     phenotypeAssetVersion: identity.version
   });
   if (fixtureCache.has(key)) return { ...fixtureCache.get(key), cacheHit: true };
-  const identifiedPhenotype = phenotype === DECIDUOUS_PHENOTYPE ? phenotype : {
+  const identifiedPhenotype = isRegisteredForestPhenotype(phenotype) ? phenotype : {
     ...phenotype,
     id: identity.id,
     assetVersion: identity.version

--- a/spec/forestTreeAssetSpec.js
+++ b/spec/forestTreeAssetSpec.js
@@ -1,5 +1,6 @@
 import {
   generateForestTreeAssetV3,
+  generateForestTreeGraph,
   generateForestTreeV3
 } from '../server/services/forestTreeGeneratorV3.js';
 import {
@@ -7,7 +8,11 @@ import {
   FOREST_TREE_ASSET_SCHEMA_VERSION,
   treeAssetCacheKey
 } from '../server/services/forest/v3/treeAsset.js';
-import { DECIDUOUS_PHENOTYPE } from '../server/services/forest/v3/phenotype.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE
+} from '../server/services/forest/v3/phenotype.js';
+import { selectFoliagePalette } from '../server/services/forest/v3/rasterizeFoliage.js';
 import {
   clearForestLabTreeCache,
   forestLabTreeCacheSize,
@@ -70,6 +75,55 @@ describe('v3 forest runtime tree assets', () => {
       .toEqual(generateForestTreeAssetV3(post, { seed: 303 }));
   });
 
+  it('emits the same contract for a distinct registered phenotype', () => {
+    const deciduous = generateForestTreeAssetV3(post, {
+      seed: 303, phenotype: DECIDUOUS_PHENOTYPE
+    });
+    const lanternwood = generateForestTreeAssetV3(post, {
+      seed: 303, phenotype: LANTERNWOOD_PHENOTYPE
+    });
+
+    expect(lanternwood.layers.map(layer => layer.id)).toEqual(
+      deciduous.layers.map(layer => layer.id)
+    );
+    expect(lanternwood.dimensions).toEqual({ width: 112, height: 120 });
+    expect(lanternwood.phenotype).toEqual({ id: 'sunset-lanternwood', version: 2 });
+    expect(lanternwood.cacheKey).not.toBe(deciduous.cacheKey);
+    const lanternColors = new Set(LANTERNWOOD_PHENOTYPE.foliagePalettes
+      .flatMap(variant => Object.values(variant.colors)));
+    expect(lanternwood.layers.filter(layer => layer.id.includes('foliage'))
+      .flatMap(layer => layer.runs).every(run => lanternColors.has(run.color))).toBeTrue();
+  });
+
+  it('selects deterministic whole-tree foliage palettes with weighted rarity', () => {
+    for (const phenotype of [DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE]) {
+      const selections = Array.from({ length: 1000 }, (_, seed) => (
+        selectFoliagePalette(phenotype, seed).id
+      ));
+      const repeated = Array.from({ length: 1000 }, (_, seed) => (
+        selectFoliagePalette(phenotype, seed).id
+      ));
+      const common = phenotype.foliagePalettes[0].id;
+
+      expect(repeated).toEqual(selections);
+      expect(selections.filter(id => id === common).length).toBeGreaterThan(700);
+      expect(new Set(selections)).toEqual(new Set(
+        phenotype.foliagePalettes.map(variant => variant.id)
+      ));
+    }
+  });
+
+  it('normally completes lanternwood growth before reaching its safety cap', () => {
+    const graphs = Array.from({ length: 24 }, (_, seed) => generateForestTreeGraph(post, {
+      seed, phenotype: LANTERNWOOD_PHENOTYPE
+    }));
+
+    expect(graphs.filter(graph => graph.stats.terminationReason === 'node-limit').length)
+      .toBeLessThan(4);
+    expect(graphs.filter(graph => graph.stats.terminationReason === 'growth-exhausted').length)
+      .toBeGreaterThan(18);
+  });
+
   it('reuses development fixtures by visual identity, independent of post identity', () => {
     const first = getForestLabTree(post, { seed: 404 });
     const repeated = getForestLabTree({ id: 'another-post' }, { seed: 404 });
@@ -79,6 +133,17 @@ describe('v3 forest runtime tree assets', () => {
     expect(repeated.asset).toBe(first.asset);
     expect(repeated.generation).toBe(first.generation);
     expect(forestLabTreeCacheSize()).toBe(1);
+  });
+
+  it('caches each registered phenotype under its own identity', () => {
+    const first = getForestLabTree(post, { seed: 404, phenotype: LANTERNWOOD_PHENOTYPE });
+    const repeated = getForestLabTree(post, { seed: 404, phenotype: LANTERNWOOD_PHENOTYPE });
+    const deciduous = getForestLabTree(post, { seed: 404, phenotype: DECIDUOUS_PHENOTYPE });
+
+    expect(first.cacheHit).toBeFalse();
+    expect(repeated.cacheHit).toBeTrue();
+    expect(deciduous.cacheHit).toBeFalse();
+    expect(forestLabTreeCacheSize()).toBe(2);
   });
 
   it('does not silently cache custom phenotype overrides without a stable identity', () => {

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -13,7 +13,7 @@ block content
       p.forest-lab__eyebrow Development preview
       h1 Activity Forest Lab
       p.forest-lab__lede
-        | The pilot procedural phenotype is shown as a finished tree, a leafless wood raster, and
+        | Two procedural phenotypes are shown as finished trees, leafless wood rasters, and
         | its deterministic branch graph so structural and rendering changes remain diagnosable.
 
     section.forest-lab__legend(aria-labelledby='forest-lab-legend')
@@ -23,7 +23,7 @@ block content
         li Three-dimensional radial growth is projected into a crisp two-dimensional tree.
         li Branch hierarchy and specimen architecture shape taper from the trunk through terminal twigs.
         li Individual leaves grow from eligible branches while preserving intentional crown gaps.
-        li Post semantics, ornaments, additional phenotypes, and further trunk variance remain future layers.
+        li Open-crown deciduous trees and fantastical sunset lanternwoods share one runtime asset contract.
 
     section.forest-gallery(aria-label='Generated post tree gallery')
       each item, treeIndex in trees
@@ -90,7 +90,8 @@ block content
           h2.forest-comparison__title= item.title
           p.forest-comparison__meta
             - const maximumOrder = Math.max(...item.tree.nodes.map(node => node.generation))
-            | Seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
+            | #{item.tree.phenotype.name} · #{item.tree.foliage.paletteId} foliage ·
+            |  seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
             |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
             |  base radius #{item.tree.architecture.trunkBaseRadius.toFixed(2)} ·
             |  taper #{item.tree.architecture.trunkTaper.toFixed(2)} ·


### PR DESCRIPTION
## Summary

- add the fantastical `sunset-lanternwood` as the second procedural tree phenotype
- give lanternwoods a broad crown, lateral branching, pale bark, and dense warm foliage
- support phenotype-defined wood and foliage palettes without changing the runtime tree-asset contract
- deterministically select weighted whole-tree foliage colorways for both registered phenotypes
- register built-in phenotypes for safe automatic cache identity handling
- display both phenotypes and their selected foliage palettes in Forest Lab
- tune lanternwood growth so the node cap remains a safety limit rather than its usual termination condition
- document the completed second-phenotype milestone

## Foliage variants

Open-crown deciduous trees now primarily use their established summer green, with rarer meadow-green, blue-grove, and early-gold variants.

Sunset lanternwoods primarily retain their established coral-and-gold palette, with rarer harvest, enchanted-plum, and spring-bloom variants.

Palette selection is deterministic per seed and applies coherently to the entire tree. It does not affect procedural growth decisions.

## Asset and cache behavior

Both phenotypes emit the same versioned runtime tree-asset contract:

- rear foliage
- wood
- front foliage
- dimensions, bounds, and anchor
- renderer and phenotype identity
- limited architecture metadata

Only exact registered phenotype objects receive automatic cache identities. Modified phenotype configurations still require an explicit identity, preventing accidental reuse of a built-in phenotype’s cache key.

Both phenotype asset versions are incremented to invalidate renderings produced before the palette changes.

## Validation

- `npm run lint`
- `npm test` — 545 specs passing
- `git diff --check`
- verified that all current Forest Lab lanternwood fixtures complete growth without reaching the node cap