### PR TITLE
feat(forest): add deterministic multi-tree Activity Forest scene

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -233,6 +233,42 @@ Forest Lab owns a narrow process-local in-memory cache of complete generation re
 
 The lab is available in development at `/__dev/views/forest-lab`.
 
+## First static multi-tree composition
+
+The first composed development scene is available at `/__dev/views/activity-forest`. It turns
+the isolated runtime assets into a deterministic 3000 × 1800 world containing 180 placements.
+The scene is still a preview: it has no player, collision, post association, persistence, or
+ambient animation.
+
+`forestSceneLayout.js` owns scene layout version 1. A placement contains only a stable placement
+id, world-space ground anchor, integer scale, phenotype id, specimen seed, and versioned asset
+key. Layout randomness is derived independently for X, Y, phenotype, specimen, and scale from
+the scene seed and candidate index. Rejection sampling enforces trunk spacing and reserves a
+winding central corridor; camera position is never an input to layout or tree identity.
+
+The scene prepares a bounded pool of eight specimens for each registered phenotype. Its
+process-local cache is separate from Forest Lab's diagnostic cache and retains runtime assets
+only. The asset's schema, renderer, phenotype, and seed identities form the invalidation key.
+The development route eagerly generates missing specimens before serializing the scene, and
+the browser receives placements plus JSON-round-tripped runtime assets. Many placements point
+to each asset; generation results and branch diagnostics never cross the scene boundary. The
+cache lives only for the server module/process lifetime and is not production persistence.
+
+The browser draws the prepared scene into one Canvas. Browser-independent math derives each
+scaled visual rectangle from the asset bounds and ground anchor, culls it against the camera,
+and orders visible placements by ground Y with stable id tie-breaking. Rendering preserves the
+asset layer order and integer scaling with image smoothing disabled. Keyboard, pointer, touch,
+resize, and reset-camera events clamp the camera and request one coalesced animation frame;
+there is no idle animation loop and no procedural generation in a frame.
+
+The restrained world-space ground treatment and corridor exist only to make depth and negative
+space legible. This first camera is deliberately orthographic: terrain and trees share the same
+translation, with no viewport-fixed horizon or implied perspective projection. Terrain systems,
+sprites, weather, a player, physics, interaction, perspective projection, and streaming are
+explicitly deferred. The next likely steps are to refine camera/culling and nearby preparation
+if measurement calls for it, add one thin exploration or inspection loop, and then test shared
+ambient wind against this representative workload before expanding the phenotype roster.
+
 ### Historical renderer v2
 
 Renderer v2 produced a `40 × 48` logical-pixel image and compacted adjacent same-color pixels into horizontal SVG rectangle runs. It was deterministic for the same renderer version and post projection. The implementation and tests were committed before retirement so its decisions remain available through Git history without burdening the active codebase.

--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -254,12 +254,16 @@ the browser receives placements plus JSON-round-tripped runtime assets. Many pla
 to each asset; generation results and branch diagnostics never cross the scene boundary. The
 cache lives only for the server module/process lifetime and is not production persistence.
 
-The browser draws the prepared scene into one Canvas. Browser-independent math derives each
-scaled visual rectangle from the asset bounds and ground anchor, culls it against the camera,
-and orders visible placements by ground Y with stable id tie-breaking. Rendering preserves the
-asset layer order and integer scaling with image smoothing disabled. Keyboard, pointer, touch,
-resize, and reset-camera events clamp the camera and request one coalesced animation frame;
-there is no idle animation loop and no procedural generation in a frame.
+The browser draws the prepared scene into one visible Canvas. During initial browser-side
+preparation, each unique runtime asset is rasterized once into a small offscreen Canvas in its
+declared layer order. Placements reuse those 16 prepared bitmaps, reducing ordinary scene draws
+from thousands of color-run operations per tree to one `drawImage` call per visible tree. These
+offscreen surfaces are per asset, never per placement, and are discarded with the page.
+Browser-independent math derives each scaled visual rectangle from the asset bounds and ground
+anchor, culls it against the camera, and orders visible placements by ground Y with stable id
+tie-breaking. Integer scaling and disabled image smoothing preserve crisp pixels. Keyboard,
+pointer, touch, resize, and reset-camera events clamp the camera and request one coalesced
+animation frame; there is no idle animation loop and no procedural generation in a frame.
 
 The restrained world-space ground treatment and corridor exist only to make depth and negative
 space legible. This first camera is deliberately orthographic: terrain and trees share the same

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -1,0 +1,115 @@
+.activity-forest {
+  width: min(1280px, 100%);
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 2rem 0 4rem;
+}
+
+.activity-forest__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.activity-forest__header h1 { margin: 0; }
+
+.activity-forest__eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--highlight-color);
+  font-family: var(--font-rubik-medium);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.activity-forest__lede {
+  max-width: 720px;
+  margin-bottom: 0.6rem;
+  color: var(--muted-text-color);
+  line-height: 1.55;
+}
+
+.activity-forest__reset {
+  flex: 0 0 auto;
+  margin-bottom: 0.6rem;
+}
+
+.activity-forest__help {
+  margin: 0.6rem 0;
+  color: var(--muted-text-color);
+  font-size: 0.85rem;
+}
+
+.activity-forest__viewport {
+  position: relative;
+  height: clamp(420px, 68vh, 760px);
+  overflow: hidden;
+  border: 2px solid #405846;
+  border-radius: 14px;
+  background: #6d815c;
+  box-shadow: 0 16px 45px rgba(14, 31, 27, 0.24);
+  cursor: grab;
+  touch-action: none;
+}
+
+.activity-forest__viewport:active { cursor: grabbing; }
+
+.activity-forest__viewport:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.activity-forest__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  image-rendering: pixelated;
+}
+
+.activity-forest__hint {
+  position: absolute;
+  right: 0.7rem;
+  bottom: 0.7rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  background: rgba(18, 39, 32, 0.72);
+  color: #f2ead1;
+  font-size: 0.72rem;
+  pointer-events: none;
+}
+
+.activity-forest__diagnostics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  margin-top: 0.8rem;
+  background: var(--border-color);
+}
+
+.activity-forest__diagnostics div {
+  padding: 0.6rem 0.7rem;
+  background: var(--surface-raised-bg);
+}
+
+.activity-forest__diagnostics dt {
+  color: var(--muted-text-color);
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.activity-forest__diagnostics dd {
+  margin: 0.15rem 0 0;
+  font-family: var(--font-rubik-medium);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 600px) {
+  .activity-forest { padding-top: 1rem; }
+  .activity-forest__header { align-items: start; flex-direction: column; }
+  .activity-forest__viewport { height: 62vh; min-height: 390px; }
+}

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1,0 +1,153 @@
+import { visibleForestPlacements } from './forest-scene-math.js';
+
+const payload = document.getElementById('activity-forest-scene');
+const viewportElement = document.querySelector('[data-forest-viewport]');
+const canvas = document.querySelector('[data-forest-canvas]');
+
+if (payload && viewportElement && canvas) {
+  const scene = JSON.parse(payload.textContent);
+  const assetsByKey = new Map(scene.assets.map((asset) => [asset.cacheKey, asset]));
+  const context = canvas.getContext('2d');
+  const camera = { x: 0, y: 0, width: 0, height: 0 };
+  const diagnostics = {
+    visible: document.querySelector('[data-forest-visible]'),
+    camera: document.querySelector('[data-forest-camera]'),
+    duration: document.querySelector('[data-forest-duration]')
+  };
+  let scheduledFrame = null;
+  let drag = null;
+
+  function corridorCenter(worldY) {
+    return (scene.world.width / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
+  }
+
+  function clampCamera() {
+    camera.x = Math.max(0, Math.min(scene.world.width - camera.width, Math.round(camera.x)));
+    camera.y = Math.max(0, Math.min(scene.world.height - camera.height, Math.round(camera.y)));
+  }
+
+  function paintGround() {
+    context.fillStyle = '#617858';
+    context.fillRect(0, 0, camera.width, camera.height);
+
+    const bandHeight = 320;
+    const firstBandY = Math.floor(camera.y / bandHeight) * bandHeight;
+    for (let worldY = firstBandY;
+      worldY <= camera.y + camera.height;
+      worldY += bandHeight) {
+      const bandIndex = Math.floor(worldY / bandHeight);
+      context.fillStyle = bandIndex % 2 === 0
+        ? 'rgba(202, 211, 170, 0.045)'
+        : 'rgba(31, 67, 48, 0.035)';
+      context.fillRect(0, worldY - camera.y, camera.width, bandHeight);
+    }
+
+    context.beginPath();
+    for (let screenY = 0; screenY <= camera.height + 16; screenY += 16) {
+      const worldY = camera.y + screenY;
+      const screenX = corridorCenter(worldY) - camera.x - scene.corridor.halfWidth;
+      if (screenY === 0) context.moveTo(screenX, screenY);
+      else context.lineTo(screenX, screenY);
+    }
+    for (let screenY = camera.height + 16; screenY >= 0; screenY -= 16) {
+      const worldY = camera.y + screenY;
+      context.lineTo(
+        corridorCenter(worldY) - camera.x + scene.corridor.halfWidth,
+        screenY
+      );
+    }
+    context.closePath();
+    context.fillStyle = 'rgba(173, 159, 112, 0.42)';
+    context.fill();
+  }
+
+  function paintTree(placement, asset) {
+    const originX = Math.round(placement.worldX - camera.x - (asset.anchor.x * placement.scale));
+    const originY = Math.round(placement.worldY - camera.y - (asset.anchor.y * placement.scale));
+    for (const layer of asset.layers) {
+      for (const run of layer.runs) {
+        context.fillStyle = run.color;
+        context.fillRect(
+          originX + (run.x * placement.scale),
+          originY + (run.y * placement.scale),
+          run.width * placement.scale,
+          placement.scale
+        );
+      }
+    }
+  }
+
+  function render() {
+    scheduledFrame = null;
+    const start = window.performance.now();
+    context.imageSmoothingEnabled = false;
+    paintGround();
+    const visible = visibleForestPlacements(scene.placements, assetsByKey, camera);
+    for (const placement of visible) paintTree(placement, assetsByKey.get(placement.assetKey));
+    diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length}`;
+    diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
+    diagnostics.duration.textContent = `${(window.performance.now() - start).toFixed(1)} ms`;
+  }
+
+  function requestRender() {
+    if (scheduledFrame === null) scheduledFrame = requestAnimationFrame(render);
+  }
+
+  function moveCamera(deltaX, deltaY) {
+    camera.x += deltaX;
+    camera.y += deltaY;
+    clampCamera();
+    requestRender();
+  }
+
+  function resetCamera() {
+    camera.x = (scene.world.width - camera.width) / 2;
+    camera.y = scene.world.height - camera.height - 80;
+    clampCamera();
+    requestRender();
+  }
+
+  function resize() {
+    const rect = viewportElement.getBoundingClientRect();
+    const nextWidth = Math.max(1, Math.round(rect.width));
+    const nextHeight = Math.max(1, Math.round(rect.height));
+    if (canvas.width === nextWidth && canvas.height === nextHeight) return;
+    canvas.width = nextWidth;
+    canvas.height = nextHeight;
+    camera.width = nextWidth;
+    camera.height = nextHeight;
+    clampCamera();
+    requestRender();
+  }
+
+  viewportElement.addEventListener('keydown', (event) => {
+    const directions = {
+      ArrowLeft: [-56, 0], a: [-56, 0], A: [-56, 0],
+      ArrowRight: [56, 0], d: [56, 0], D: [56, 0],
+      ArrowUp: [0, -56], w: [0, -56], W: [0, -56],
+      ArrowDown: [0, 56], s: [0, 56], S: [0, 56]
+    };
+    const direction = directions[event.key];
+    if (!direction) return;
+    event.preventDefault();
+    moveCamera(direction[0], direction[1]);
+  });
+
+  viewportElement.addEventListener('pointerdown', (event) => {
+    drag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    viewportElement.setPointerCapture(event.pointerId);
+    viewportElement.focus();
+  });
+  viewportElement.addEventListener('pointermove', (event) => {
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    moveCamera(drag.x - event.clientX, drag.y - event.clientY);
+    drag.x = event.clientX;
+    drag.y = event.clientY;
+  });
+  viewportElement.addEventListener('pointerup', () => { drag = null; });
+  viewportElement.addEventListener('pointercancel', () => { drag = null; });
+  document.querySelector('[data-forest-reset]').addEventListener('click', resetCamera);
+  window.addEventListener('resize', resize);
+  resize();
+  resetCamera();
+}

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -8,6 +8,7 @@ if (payload && viewportElement && canvas) {
   const scene = JSON.parse(payload.textContent);
   const assetsByKey = new Map(scene.assets.map((asset) => [asset.cacheKey, asset]));
   const context = canvas.getContext('2d');
+  const spritesByKey = new Map();
   const camera = { x: 0, y: 0, width: 0, height: 0 };
   const diagnostics = {
     visible: document.querySelector('[data-forest-visible]'),
@@ -16,6 +17,23 @@ if (payload && viewportElement && canvas) {
   };
   let scheduledFrame = null;
   let drag = null;
+
+  function prepareTreeSprites() {
+    for (const asset of scene.assets) {
+      const sprite = document.createElement('canvas');
+      sprite.width = asset.dimensions.width;
+      sprite.height = asset.dimensions.height;
+      const spriteContext = sprite.getContext('2d');
+      spriteContext.imageSmoothingEnabled = false;
+      for (const layer of asset.layers) {
+        for (const run of layer.runs) {
+          spriteContext.fillStyle = run.color;
+          spriteContext.fillRect(run.x, run.y, run.width, 1);
+        }
+      }
+      spritesByKey.set(asset.cacheKey, sprite);
+    }
+  }
 
   function corridorCenter(worldY) {
     return (scene.world.width / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
@@ -64,17 +82,14 @@ if (payload && viewportElement && canvas) {
   function paintTree(placement, asset) {
     const originX = Math.round(placement.worldX - camera.x - (asset.anchor.x * placement.scale));
     const originY = Math.round(placement.worldY - camera.y - (asset.anchor.y * placement.scale));
-    for (const layer of asset.layers) {
-      for (const run of layer.runs) {
-        context.fillStyle = run.color;
-        context.fillRect(
-          originX + (run.x * placement.scale),
-          originY + (run.y * placement.scale),
-          run.width * placement.scale,
-          placement.scale
-        );
-      }
-    }
+    const sprite = spritesByKey.get(placement.assetKey);
+    context.drawImage(
+      sprite,
+      originX,
+      originY,
+      asset.dimensions.width * placement.scale,
+      asset.dimensions.height * placement.scale
+    );
   }
 
   function render() {
@@ -148,6 +163,7 @@ if (payload && viewportElement && canvas) {
   viewportElement.addEventListener('pointercancel', () => { drag = null; });
   document.querySelector('[data-forest-reset]').addEventListener('click', resetCamera);
   window.addEventListener('resize', resize);
+  prepareTreeSprites();
   resize();
   resetCamera();
 }

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -1,0 +1,23 @@
+export function placementVisualRect(placement, asset) {
+  const scale = placement.scale;
+  return {
+    x: placement.worldX + ((asset.bounds.x - asset.anchor.x) * scale),
+    y: placement.worldY + ((asset.bounds.y - asset.anchor.y) * scale),
+    width: asset.bounds.width * scale,
+    height: asset.bounds.height * scale
+  };
+}
+
+export function visibleForestPlacements(placements, assetsByKey, viewport, margin = 24) {
+  return placements.filter((placement) => {
+    const asset = assetsByKey.get(placement.assetKey);
+    if (!asset) return false;
+    const rect = placementVisualRect(placement, asset);
+    return rect.x + rect.width >= viewport.x - margin
+      && rect.x <= viewport.x + viewport.width + margin
+      && rect.y + rect.height >= viewport.y - margin
+      && rect.y <= viewport.y + viewport.height + margin;
+  }).sort((left, right) => (
+    left.worldY - right.worldY || left.id.localeCompare(right.id)
+  ));
+}

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -3,6 +3,8 @@ import express from 'express';
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
 import { getForestLabTree } from '../services/forestLabTreeCache.js';
+import { prepareForestScene } from '../services/forestSceneAssetPool.js';
+import { generateForestSceneLayout } from '../services/forestSceneLayout.js';
 import {
   DECIDUOUS_PHENOTYPE,
   LANTERNWOOD_PHENOTYPE
@@ -76,6 +78,20 @@ router.get(
       user: req.user || null,
       uiLang: res.locals.uiLang,
       trees: forestFixtures()
+    });
+  }
+);
+
+router.get(
+  '/__dev/views/activity-forest',
+  optionalAuth,
+  (req, res) => {
+    const scene = prepareForestScene(generateForestSceneLayout());
+    res.render('dev/activity-forest', {
+      title: 'Activity Forest Scene',
+      user: req.user || null,
+      uiLang: res.locals.uiLang,
+      scene
     });
   }
 );

--- a/server/services/forestSceneAssetPool.js
+++ b/server/services/forestSceneAssetPool.js
@@ -1,0 +1,42 @@
+import { generateForestTreeAssetV3 } from './forestTreeGeneratorV3.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE
+} from './forest/v3/phenotype.js';
+
+// Scene-owned, process-local runtime assets. No graphs or diagnostics are retained.
+const sceneAssetCache = new Map();
+const phenotypesById = new Map([
+  [DECIDUOUS_PHENOTYPE.id, DECIDUOUS_PHENOTYPE],
+  [LANTERNWOOD_PHENOTYPE.id, LANTERNWOOD_PHENOTYPE]
+]);
+
+export function clearForestSceneAssetPool() {
+  sceneAssetCache.clear();
+}
+
+export function forestSceneAssetPoolSize() {
+  return sceneAssetCache.size;
+}
+
+export function prepareForestScene(layout) {
+  const assets = [];
+  const required = new Map(layout.placements.map((placement) => [placement.assetKey, placement]));
+
+  for (const [assetKey, placement] of required) {
+    if (!sceneAssetCache.has(assetKey)) {
+      const phenotype = phenotypesById.get(placement.phenotypeId);
+      if (!phenotype) throw new Error(`Unknown forest phenotype: ${placement.phenotypeId}`);
+      const asset = generateForestTreeAssetV3(
+        { id: `forest-scene-specimen-${placement.treeSeed}` },
+        { seed: placement.treeSeed, phenotype }
+      );
+      if (asset.cacheKey !== assetKey) throw new Error('Prepared tree asset identity mismatch.');
+      sceneAssetCache.set(assetKey, asset);
+    }
+    assets.push(sceneAssetCache.get(assetKey));
+  }
+
+  return JSON.parse(JSON.stringify({ ...layout, assets }));
+}
+

--- a/server/services/forestSceneLayout.js
+++ b/server/services/forestSceneLayout.js
@@ -1,0 +1,132 @@
+import { FOREST_RENDERER_VERSION_V3 } from './forestTreeGeneratorV3.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE
+} from './forest/v3/phenotype.js';
+import { createRandom, hashSeed } from './forest/v3/random.js';
+import { treeAssetCacheKey } from './forest/v3/treeAsset.js';
+
+export const FOREST_SCENE_VERSION = 1;
+
+export const DEFAULT_FOREST_SCENE_CONFIG = Object.freeze({
+  seed: 'first-grove',
+  world: Object.freeze({ width: 3000, height: 1800 }),
+  placementCount: 180,
+  minimumSpacing: 76,
+  edgeMargin: 90,
+  corridorHalfWidth: 145,
+  scale: Object.freeze({ minimum: 1, maximum: 2 }),
+  specimenPoolSize: 8,
+  phenotypeWeights: Object.freeze({
+    [DECIDUOUS_PHENOTYPE.id]: 68,
+    [LANTERNWOOD_PHENOTYPE.id]: 32
+  })
+});
+
+const PHENOTYPES = [DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE];
+
+function decisionRandom(sceneSeed, candidateIndex, decision) {
+  return createRandom(hashSeed([
+    `forest-scene-v${FOREST_SCENE_VERSION}`, sceneSeed, candidateIndex, decision
+  ].join(':')))();
+}
+
+export function forestCorridorCenter(worldY, worldWidth) {
+  return (worldWidth / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
+}
+
+function selectPhenotype(config, sceneSeed, candidateIndex) {
+  const total = PHENOTYPES.reduce((sum, phenotype) => (
+    sum + (config.phenotypeWeights[phenotype.id] || 0)
+  ), 0);
+  let selection = decisionRandom(sceneSeed, candidateIndex, 'phenotype') * total;
+  return PHENOTYPES.find((phenotype) => {
+    selection -= config.phenotypeWeights[phenotype.id] || 0;
+    return selection < 0;
+  }) || PHENOTYPES[0];
+}
+
+function specimenIdentity(config, sceneSeed, phenotype, specimenIndex) {
+  const treeSeed = hashSeed([
+    `forest-scene-v${FOREST_SCENE_VERSION}`, sceneSeed, phenotype.id, specimenIndex
+  ].join(':'));
+  return {
+    treeSeed,
+    assetKey: treeAssetCacheKey({
+      seed: treeSeed,
+      rendererVersion: FOREST_RENDERER_VERSION_V3,
+      phenotypeId: phenotype.id,
+      phenotypeAssetVersion: phenotype.assetVersion
+    })
+  };
+}
+
+function normalizeConfig(options) {
+  return {
+    ...DEFAULT_FOREST_SCENE_CONFIG,
+    ...options,
+    world: { ...DEFAULT_FOREST_SCENE_CONFIG.world, ...options.world },
+    scale: { ...DEFAULT_FOREST_SCENE_CONFIG.scale, ...options.scale },
+    phenotypeWeights: {
+      ...DEFAULT_FOREST_SCENE_CONFIG.phenotypeWeights,
+      ...options.phenotypeWeights
+    }
+  };
+}
+
+export function generateForestSceneLayout(options = {}) {
+  const config = normalizeConfig(options);
+  const placements = [];
+  const maximumCandidates = config.placementCount * 100;
+
+  for (let candidateIndex = 0;
+    candidateIndex < maximumCandidates && placements.length < config.placementCount;
+    candidateIndex += 1) {
+    const usableWidth = config.world.width - (config.edgeMargin * 2);
+    const usableHeight = config.world.height - (config.edgeMargin * 2);
+    const worldX = Math.round(config.edgeMargin
+      + (decisionRandom(config.seed, candidateIndex, 'x') * usableWidth));
+    const worldY = Math.round(config.edgeMargin
+      + (decisionRandom(config.seed, candidateIndex, 'y') * usableHeight));
+    const pathDistance = Math.abs(worldX - forestCorridorCenter(worldY, config.world.width));
+    const overlapsTrunk = placements.some((placement) => (
+      Math.hypot(placement.worldX - worldX, placement.worldY - worldY)
+        < config.minimumSpacing
+    ));
+    if (pathDistance < config.corridorHalfWidth || overlapsTrunk) continue;
+
+    const phenotype = selectPhenotype(config, config.seed, candidateIndex);
+    const specimenIndex = Math.floor(
+      decisionRandom(config.seed, candidateIndex, 'specimen') * config.specimenPoolSize
+    );
+    const { treeSeed, assetKey } = specimenIdentity(
+      config, config.seed, phenotype, specimenIndex
+    );
+    const scaleRange = config.scale.maximum - config.scale.minimum + 1;
+    const scale = config.scale.minimum + Math.floor(
+      decisionRandom(config.seed, candidateIndex, 'scale') * scaleRange
+    );
+    placements.push({
+      id: `forest-scene-v${FOREST_SCENE_VERSION}-${config.seed}-${candidateIndex}`,
+      worldX,
+      worldY,
+      scale,
+      phenotypeId: phenotype.id,
+      treeSeed,
+      assetKey
+    });
+  }
+
+  if (placements.length !== config.placementCount) {
+    throw new Error(`Could only place ${placements.length} of ${config.placementCount} trees.`);
+  }
+
+  return {
+    version: FOREST_SCENE_VERSION,
+    seed: config.seed,
+    world: config.world,
+    corridor: { halfWidth: config.corridorHalfWidth },
+    placements
+  };
+}
+

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -1,0 +1,102 @@
+import {
+  DEFAULT_FOREST_SCENE_CONFIG,
+  forestCorridorCenter,
+  generateForestSceneLayout
+} from '../server/services/forestSceneLayout.js';
+import {
+  clearForestSceneAssetPool,
+  forestSceneAssetPoolSize,
+  prepareForestScene
+} from '../server/services/forestSceneAssetPool.js';
+import {
+  placementVisualRect,
+  visibleForestPlacements
+} from '../public/js/forest-scene-math.js';
+
+describe('static Activity Forest scene', () => {
+  beforeEach(() => clearForestSceneAssetPool());
+
+  it('generates exactly serializable deterministic placements', () => {
+    const first = generateForestSceneLayout();
+    const repeated = generateForestSceneLayout();
+    const changed = generateForestSceneLayout({ seed: 'another-grove' });
+
+    expect(repeated).toEqual(first);
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+    expect(changed.placements).not.toEqual(first.placements);
+  });
+
+  it('keeps unique placements valid, spaced, mixed, and outside the corridor', () => {
+    const scene = generateForestSceneLayout();
+    const ids = new Set(scene.placements.map((placement) => placement.id));
+    const phenotypes = new Set(scene.placements.map((placement) => placement.phenotypeId));
+
+    expect(ids.size).toBe(scene.placements.length);
+    expect(phenotypes).toEqual(new Set(['open-crown-deciduous', 'sunset-lanternwood']));
+    scene.placements.forEach((placement, index) => {
+      expect(placement.worldX).toBeGreaterThanOrEqual(DEFAULT_FOREST_SCENE_CONFIG.edgeMargin);
+      expect(placement.worldX).toBeLessThanOrEqual(
+        scene.world.width - DEFAULT_FOREST_SCENE_CONFIG.edgeMargin
+      );
+      expect(placement.worldY).toBeGreaterThanOrEqual(DEFAULT_FOREST_SCENE_CONFIG.edgeMargin);
+      expect(placement.worldY).toBeLessThanOrEqual(
+        scene.world.height - DEFAULT_FOREST_SCENE_CONFIG.edgeMargin
+      );
+      expect(placement.scale).toBeGreaterThanOrEqual(
+        DEFAULT_FOREST_SCENE_CONFIG.scale.minimum
+      );
+      expect(placement.scale).toBeLessThanOrEqual(
+        DEFAULT_FOREST_SCENE_CONFIG.scale.maximum
+      );
+      expect(Math.abs(placement.worldX - forestCorridorCenter(
+        placement.worldY, scene.world.width
+      ))).toBeGreaterThanOrEqual(DEFAULT_FOREST_SCENE_CONFIG.corridorHalfWidth);
+      for (const other of scene.placements.slice(index + 1)) {
+        expect(Math.hypot(
+          placement.worldX - other.worldX, placement.worldY - other.worldY
+        )).toBeGreaterThanOrEqual(DEFAULT_FOREST_SCENE_CONFIG.minimumSpacing);
+      }
+    });
+    expect(new Set(scene.placements.map((placement) => placement.worldX)).size)
+      .toBeGreaterThan(scene.placements.length * 0.9);
+  });
+
+  it('prepares and reuses a bounded pool containing runtime assets only', () => {
+    const scene = prepareForestScene(generateForestSceneLayout());
+    const repeated = prepareForestScene(generateForestSceneLayout());
+    const keys = new Set(scene.placements.map((placement) => placement.assetKey));
+    const serialized = JSON.stringify(scene);
+
+    expect(keys.size).toBeLessThan(scene.placements.length);
+    expect(keys.size).toBeLessThanOrEqual(DEFAULT_FOREST_SCENE_CONFIG.specimenPoolSize * 2);
+    expect(scene.assets.length).toBe(keys.size);
+    expect(repeated.assets).toEqual(scene.assets);
+    expect(forestSceneAssetPoolSize()).toBe(keys.size);
+    for (const excluded of ['nodes', 'segments', 'diagnostics', 'attractionPoints']) {
+      expect(serialized).not.toContain(`"${excluded}"`);
+    }
+    expect(JSON.parse(serialized)).toEqual(scene);
+  });
+
+  it('culls by scaled visual bounds and orders visible trees stably by ground Y', () => {
+    const asset = {
+      anchor: { x: 5, y: 10 },
+      bounds: { x: 1, y: 2, width: 8, height: 9 }
+    };
+    const assets = new Map([['tree', asset]]);
+    const placements = [
+      { id: 'tie-b', assetKey: 'tree', worldX: 130, worldY: 60, scale: 2 },
+      { id: 'near', assetKey: 'tree', worldX: 50, worldY: 80, scale: 1 },
+      { id: 'tie-a', assetKey: 'tree', worldX: 80, worldY: 60, scale: 1 },
+      { id: 'partial', assetKey: 'tree', worldX: 5, worldY: 20, scale: 2 },
+      { id: 'offscreen', assetKey: 'tree', worldX: 400, worldY: 400, scale: 1 }
+    ];
+
+    expect(placementVisualRect(placements[0], asset)).toEqual({
+      x: 122, y: 44, width: 16, height: 18
+    });
+    expect(visibleForestPlacements(
+      placements, assets, { x: 0, y: 0, width: 140, height: 100 }, 0
+    ).map((placement) => placement.id)).toEqual(['partial', 'tie-a', 'tie-b', 'near']);
+  });
+});

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -1,0 +1,57 @@
+extends ../layout
+
+block nav
+  include ../navLinks
+
+block append head
+  link(rel='stylesheet' href='/css/activity-forest.css')
+  script(type='module' src='/js/activity-forest.js')
+
+block content
+  main.activity-forest
+    header.activity-forest__header
+      div
+        p.activity-forest__eyebrow Development preview
+        h1 Activity Forest
+        p.activity-forest__lede
+          | A deterministic grove composed from reusable procedural tree assets. The winding
+          | clearing is the first hint of a place to explore rather than a gallery to inspect.
+      button.activity-forest__reset(type='button' data-forest-reset) Reset camera
+
+    p#activity-forest-help.activity-forest__help
+      | Focus the forest, then pan with arrow keys or WASD. You can also drag with a mouse or touch.
+
+    .activity-forest__viewport(
+      tabindex='0'
+      role='application'
+      aria-label='Navigable static Activity Forest scene'
+      aria-describedby='activity-forest-help'
+      data-forest-viewport
+    )
+      canvas.activity-forest__canvas(data-forest-canvas)
+      .activity-forest__hint Drag to explore
+
+    dl.activity-forest__diagnostics(aria-label='Scene diagnostics')
+      div
+        dt Scene
+        dd= scene.seed
+      div
+        dt World
+        dd #{scene.world.width} × #{scene.world.height}
+      div
+        dt Placements
+        dd= scene.placements.length
+      div
+        dt Unique assets
+        dd= scene.assets.length
+      div
+        dt Visible
+        dd(data-forest-visible) —
+      div
+        dt Camera
+        dd(data-forest-camera) —
+      div
+        dt Last render
+        dd(data-forest-duration) —
+
+    script#activity-forest-scene(type='application/json')!= JSON.stringify(scene).replace(/</g, '\\u003c')


### PR DESCRIPTION
## Summary

This PR introduces the first static multi-tree Activity Forest composition: a deterministic,
navigable development scene that turns the existing procedural tree assets into an explorable
grove.

The preview is available in development at:

`/__dev/views/activity-forest`

## What changed

- Add a versioned deterministic scene-layout module with 180 placements in a 3000 × 1800 world.
- Compose both registered phenotypes using explicit weights and a bounded pool of eight specimens
  per phenotype.
- Derive placement position, phenotype, specimen, and integer scale through independent
  deterministic decisions.
- Enforce minimum trunk spacing and reserve a winding open corridor through the grove.
- Add a scene-owned, process-local runtime asset cache that remains separate from Forest Lab's
  diagnostic cache.
- Prepare and serialize runtime assets before the scene becomes drawable; generation results,
  branch graphs, and diagnostics do not cross the scene boundary.
- Render the environment through one visible Canvas with:
  - anchor- and bounds-aware placement
  - viewport culling
  - stable ground-Y draw ordering
  - established rear-foliage, wood, and front-foliage layer order
  - integer scaling and disabled image smoothing
- Add keyboard, pointer, and touch panning, viewport resize handling, camera clamping, and a reset
  control.
- Use event-driven rendering so the scene does no frame work while idle.
- Keep the initial camera deliberately orthographic, with the ground and corridor moving in the
  same world space as the trees.
- Add lightweight diagnostics for scene identity, placement and asset counts, visible trees,
  camera position, and render duration.

## Rendering performance

The initial implementation replayed every serialized horizontal color run for every visible tree.
The 16-asset specimen pool contains roughly 51,000 runs, averaging about 3,200 runs per asset, so
a typical view could issue well over 100,000 `fillRect` and `fillStyle` operations during a camera
update.

Each unique runtime asset is now rasterized once into a small offscreen Canvas during browser-side
preparation. Placements reuse those prepared bitmaps, reducing ordinary scene rendering to roughly
one `drawImage` call per visible tree. Offscreen canvases are allocated per unique asset, not per
placement, and no procedural generation or asset preparation occurs inside rendering frames.

## Determinism and asset reuse

The scene-layout seed is separate from individual tree-generation seeds. Camera movement never
changes placement or tree identity. Versioned asset keys retain the existing schema, renderer,
phenotype, and seed invalidation behavior.

For the default scene:

- 180 placements are generated deterministically.
- 16 unique runtime assets are prepared and reused.
- Both open-crown deciduous and sunset lanternwood trees are represented.
- Placement IDs, positions, scales, phenotype choices, specimen assignments, and asset references
  are stable across repeated generation.

## Testing

Focused scene coverage verifies:

- exact layout determinism and JSON round-tripping
- meaningful differences between scene seeds
- unique and stable placement IDs
- world bounds, scale bounds, minimum spacing, and corridor clearance
- representation of both registered phenotypes
- bounded asset-pool reuse and versioned asset references
- exclusion of generation diagnostics from the runtime payload
- scaled anchor/bounds calculations
- retention of partially visible trees and exclusion of offscreen trees
- ground-Y ordering with stable tie-breaking

Verification completed:

- project lint
- browser scene-script lint
- `549 specs, 0 failures`
- `git diff --check`

## Intentional scope boundaries

This remains a static development preview. It does not add:

- a player, walking physics, or collision
- post inspection or links between trees and real posts
- perspective projection or zoom
- ambient wind or foliage animation
- region streaming or production persistence
- terrain systems, WebGL, or texture atlases

Likely follow-up work is to refine camera and nearby preparation as measurement requires, add one
thin exploration/inspection loop, and then test shared ambient foliage motion against this
representative multi-tree workload.
