### PR TITLE
Add the first Activity Forest exploration loop

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -237,8 +237,9 @@ The lab is available in development at `/__dev/views/forest-lab`.
 
 The first composed development scene is available at `/__dev/views/activity-forest`. It turns
 the isolated runtime assets into a deterministic 3000 × 1800 world containing 180 placements.
-The scene is still a preview: it has no player, collision, post association, persistence, or
-ambient animation.
+The scene now includes the first fixture-only exploration loop: a deterministic player can walk
+the corridor, approach a tree, inspect fixture writing, close it, and continue from the same place.
+It remains a development preview without persistence, real post queries, or ambient animation.
 
 `forestSceneLayout.js` owns scene layout version 1. A placement contains only a stable placement
 id, world-space ground anchor, integer scale, phenotype id, specimen seed, and versioned asset
@@ -262,16 +263,32 @@ offscreen surfaces are per asset, never per placement, and are discarded with th
 Browser-independent math derives each scaled visual rectangle from the asset bounds and ground
 anchor, culls it against the camera, and orders visible placements by ground Y with stable id
 tie-breaking. Integer scaling and disabled image smoothing preserve crisp pixels. Keyboard,
-pointer, touch, resize, and reset-camera events clamp the camera and request one coalesced
-animation frame; there is no idle animation loop and no procedural generation in a frame.
+resize, and reset events request coalesced frames. The exploration version replaces direct camera
+navigation with a clamped camera
+following a player whose small explicit state has a deterministic, collision-free corridor spawn.
+Arrow-key and WASD movement is normalized and elapsed-time based. Touch and stylus input uses a
+floating direction-only joystick whose origin is the initial contact point; dragging beyond a small
+dead zone selects a normalized direction, while release, cancellation, blur, or inspection stops
+movement. Both input paths resolve movement independently on X and Y against scaled circular trunk
+obstacles, allowing sliding while leaving canopies non-solid.
+
+The player participates in stable ground-Y ordering. A pure proximity query selects the nearest
+in-range placement with stable id tie-breaking. Deterministic placement-to-fixture assignment is
+independent of tree asset identity, and only bounded title, room, date, and excerpt metadata crosses
+the runtime boundary. A native modal inspection dialog stops movement and returns focus without
+changing the player or camera location.
+
+Tree sprites are still prepared only at startup. Active movement frames perform movement math,
+culling, ordering, and bitmap draws, then cease when input stops; no procedural generation or
+color-run replay occurs in those frames. The render-duration diagnostic remains the local
+measurement point, with no new benchmark claim for this first interaction slice.
 
 The restrained world-space ground treatment and corridor exist only to make depth and negative
 space legible. This first camera is deliberately orthographic: terrain and trees share the same
-translation, with no viewport-fixed horizon or implied perspective projection. Terrain systems,
-sprites, weather, a player, physics, interaction, perspective projection, and streaming are
-explicitly deferred. The next likely steps are to refine camera/culling and nearby preparation
-if measurement calls for it, add one thin exploration or inspection loop, and then test shared
-ambient wind against this representative workload before expanding the phenotype roster.
+translation, with no viewport-fixed horizon or implied perspective projection. The next likely
+step is to test shared ambient wind against this representative workload. Real post integration,
+persistence, complex physics, animation systems, tap-to-pathfind movement, zoom, terrain systems,
+perspective projection, streaming, and game-engine abstractions remain non-goals for this slice.
 
 ### Historical renderer v2
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -49,11 +49,8 @@
   border-radius: 14px;
   background: #6d815c;
   box-shadow: 0 16px 45px rgba(14, 31, 27, 0.24);
-  cursor: grab;
   touch-action: none;
 }
-
-.activity-forest__viewport:active { cursor: grabbing; }
 
 .activity-forest__viewport:focus-visible {
   outline: 3px solid var(--focus-ring);
@@ -67,17 +64,74 @@
   image-rendering: pixelated;
 }
 
-.activity-forest__hint {
+.activity-forest__joystick {
   position: absolute;
-  right: 0.7rem;
+  width: 86px;
+  height: 86px;
+  margin: -43px 0 0 -43px;
+  border: 2px solid rgba(255, 245, 202, 0.68);
+  border-radius: 50%;
+  background: rgba(18, 39, 32, 0.42);
+  box-shadow: 0 2px 12px rgba(10, 25, 21, 0.3);
+  pointer-events: none;
+}
+
+.activity-forest__joystick-stick {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 34px;
+  height: 34px;
+  margin: -17px 0 0 -17px;
+  border-radius: 50%;
+  background: rgba(255, 240, 174, 0.9);
+  box-shadow: 0 2px 8px rgba(10, 25, 21, 0.38);
+}
+
+.activity-forest__prompt {
+  position: absolute;
+  left: 50%;
   bottom: 0.7rem;
+  transform: translateX(-50%);
+  border: 1px solid rgba(255, 240, 174, 0.7);
   border-radius: 999px;
   padding: 0.3rem 0.65rem;
   background: rgba(18, 39, 32, 0.72);
   color: #f2ead1;
   font-size: 0.72rem;
-  pointer-events: none;
+  cursor: pointer;
 }
+
+.activity-forest__prompt-touch { display: none; }
+
+@media (hover: none) and (pointer: coarse) {
+  .activity-forest__prompt { min-height: 44px; padding-inline: 1rem; }
+  .activity-forest__prompt-keyboard { display: none; }
+  .activity-forest__prompt-touch { display: inline; }
+}
+
+.activity-forest__dialog {
+  width: min(520px, calc(100% - 2rem));
+  box-sizing: border-box;
+  border: 1px solid #7c795c;
+  border-radius: 14px;
+  padding: 1.5rem;
+  background: #f5efd9;
+  color: #25352f;
+  box-shadow: 0 24px 70px rgba(9, 24, 20, 0.45);
+}
+
+.activity-forest__dialog::backdrop { background: rgba(11, 27, 23, 0.68); }
+.activity-forest__dialog h2 { margin: 0.25rem 0; }
+.activity-forest__dialog-eyebrow {
+  margin: 0;
+  color: #8b4d38;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.activity-forest__dialog-context { margin: 0.3rem 0 1.2rem; color: #5f6a61; }
+.activity-forest__dialog-excerpt { font-size: 1.08rem; line-height: 1.65; }
 
 .activity-forest__diagnostics {
   display: grid;

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1,4 +1,12 @@
-import { visibleForestPlacements } from './forest-scene-math.js';
+import {
+  cameraFollowingPlayer,
+  focusedForestPlacement,
+  forestDepthOrder,
+  moveForestPlayer,
+  normalizedMovement,
+  touchMovement,
+  visibleForestPlacements
+} from './forest-scene-math.js';
 
 const payload = document.getElementById('activity-forest-scene');
 const viewportElement = document.querySelector('[data-forest-viewport]');
@@ -7,119 +15,211 @@ const canvas = document.querySelector('[data-forest-canvas]');
 if (payload && viewportElement && canvas) {
   const scene = JSON.parse(payload.textContent);
   const assetsByKey = new Map(scene.assets.map((asset) => [asset.cacheKey, asset]));
+  const fixturesById = new Map(scene.exploration.fixtures.map((fixture) => [fixture.id, fixture]));
   const context = canvas.getContext('2d');
   const spritesByKey = new Map();
   const camera = { x: 0, y: 0, width: 0, height: 0 };
+  const player = { ...scene.exploration.spawn };
+  const keys = { left: false, right: false, up: false, down: false };
+  const touch = { pointerId: null, originX: 0, originY: 0, x: 0, y: 0 };
+  const dialog = document.querySelector('[data-forest-dialog]');
+  const prompt = document.querySelector('[data-forest-prompt]');
+  const joystick = document.querySelector('[data-forest-joystick]');
+  const joystickStick = joystick.querySelector('[data-forest-joystick-stick]');
   const diagnostics = {
     visible: document.querySelector('[data-forest-visible]'),
     camera: document.querySelector('[data-forest-camera]'),
+    player: document.querySelector('[data-forest-player]'),
+    focus: document.querySelector('[data-forest-focus]'),
     duration: document.querySelector('[data-forest-duration]')
   };
+  let focusedPlacement = null;
   let scheduledFrame = null;
-  let drag = null;
+  let lastFrameTime = null;
 
-  function prepareTreeSprites() {
-    for (const asset of scene.assets) {
-      const sprite = document.createElement('canvas');
-      sprite.width = asset.dimensions.width;
-      sprite.height = asset.dimensions.height;
-      const spriteContext = sprite.getContext('2d');
-      spriteContext.imageSmoothingEnabled = false;
-      for (const layer of asset.layers) {
-        for (const run of layer.runs) {
-          spriteContext.fillStyle = run.color;
-          spriteContext.fillRect(run.x, run.y, run.width, 1);
-        }
+  for (const asset of scene.assets) {
+    const sprite = document.createElement('canvas');
+    sprite.width = asset.dimensions.width;
+    sprite.height = asset.dimensions.height;
+    const spriteContext = sprite.getContext('2d');
+    spriteContext.imageSmoothingEnabled = false;
+    for (const layer of asset.layers) {
+      for (const run of layer.runs) {
+        spriteContext.fillStyle = run.color;
+        spriteContext.fillRect(run.x, run.y, run.width, 1);
       }
-      spritesByKey.set(asset.cacheKey, sprite);
     }
+    spritesByKey.set(asset.cacheKey, sprite);
   }
 
   function corridorCenter(worldY) {
     return (scene.world.width / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
   }
 
-  function clampCamera() {
-    camera.x = Math.max(0, Math.min(scene.world.width - camera.width, Math.round(camera.x)));
-    camera.y = Math.max(0, Math.min(scene.world.height - camera.height, Math.round(camera.y)));
+  function followPlayer() {
+    Object.assign(camera, cameraFollowingPlayer(player, camera, scene.world));
   }
 
   function paintGround() {
     context.fillStyle = '#617858';
     context.fillRect(0, 0, camera.width, camera.height);
-
     const bandHeight = 320;
     const firstBandY = Math.floor(camera.y / bandHeight) * bandHeight;
-    for (let worldY = firstBandY;
-      worldY <= camera.y + camera.height;
-      worldY += bandHeight) {
-      const bandIndex = Math.floor(worldY / bandHeight);
-      context.fillStyle = bandIndex % 2 === 0
-        ? 'rgba(202, 211, 170, 0.045)'
-        : 'rgba(31, 67, 48, 0.035)';
+    for (let worldY = firstBandY; worldY <= camera.y + camera.height; worldY += bandHeight) {
+      context.fillStyle = Math.floor(worldY / bandHeight) % 2 === 0
+        ? 'rgba(202, 211, 170, 0.045)' : 'rgba(31, 67, 48, 0.035)';
       context.fillRect(0, worldY - camera.y, camera.width, bandHeight);
     }
-
     context.beginPath();
     for (let screenY = 0; screenY <= camera.height + 16; screenY += 16) {
-      const worldY = camera.y + screenY;
-      const screenX = corridorCenter(worldY) - camera.x - scene.corridor.halfWidth;
+      const screenX = corridorCenter(camera.y + screenY) - camera.x
+        - scene.corridor.halfWidth;
       if (screenY === 0) context.moveTo(screenX, screenY);
       else context.lineTo(screenX, screenY);
     }
     for (let screenY = camera.height + 16; screenY >= 0; screenY -= 16) {
-      const worldY = camera.y + screenY;
-      context.lineTo(
-        corridorCenter(worldY) - camera.x + scene.corridor.halfWidth,
-        screenY
-      );
+      context.lineTo(corridorCenter(camera.y + screenY) - camera.x
+        + scene.corridor.halfWidth, screenY);
     }
     context.closePath();
     context.fillStyle = 'rgba(173, 159, 112, 0.42)';
     context.fill();
   }
 
-  function paintTree(placement, asset) {
-    const originX = Math.round(placement.worldX - camera.x - (asset.anchor.x * placement.scale));
-    const originY = Math.round(placement.worldY - camera.y - (asset.anchor.y * placement.scale));
-    const sprite = spritesByKey.get(placement.assetKey);
-    context.drawImage(
-      sprite,
-      originX,
-      originY,
-      asset.dimensions.width * placement.scale,
-      asset.dimensions.height * placement.scale
-    );
+  function paintTree(placement) {
+    const asset = assetsByKey.get(placement.assetKey);
+    const originX = Math.round(placement.worldX - camera.x - asset.anchor.x * placement.scale);
+    const originY = Math.round(placement.worldY - camera.y - asset.anchor.y * placement.scale);
+    if (placement.id === focusedPlacement?.id) {
+      context.beginPath();
+      context.ellipse(Math.round(placement.worldX - camera.x),
+        Math.round(placement.worldY - camera.y), placement.collisionRadius + 10, 8, 0, 0,
+        Math.PI * 2);
+      context.fillStyle = 'rgba(255, 239, 164, 0.42)';
+      context.fill();
+      context.strokeStyle = '#fff0ae';
+      context.lineWidth = 2;
+      context.stroke();
+    }
+    context.drawImage(spritesByKey.get(placement.assetKey), originX, originY,
+      asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+  }
+
+  function paintPlayer() {
+    const x = Math.round(player.worldX - camera.x);
+    const y = Math.round(player.worldY - camera.y);
+    context.fillStyle = 'rgba(22, 35, 31, 0.28)';
+    context.fillRect(x - 8, y - 3, 16, 5);
+    context.fillStyle = '#ead9b6';
+    context.fillRect(x - 4, y - 19, 8, 8);
+    context.fillStyle = '#263b3b';
+    context.fillRect(x - 6, y - 12, 12, 11);
+    context.fillStyle = '#b96045';
+    context.fillRect(x - 7, y - 21, 14, 4);
+    context.fillRect(x - 5, y - 24, 10, 3);
+  }
+
+  function updateFocus() {
+    focusedPlacement = focusedForestPlacement(player, scene.placements,
+      scene.exploration.interactionRadius);
+    prompt.hidden = !focusedPlacement;
+    diagnostics.focus.textContent = focusedPlacement?.id || 'None';
   }
 
   function render() {
-    scheduledFrame = null;
     const start = window.performance.now();
     context.imageSmoothingEnabled = false;
     paintGround();
     const visible = visibleForestPlacements(scene.placements, assetsByKey, camera);
-    for (const placement of visible) paintTree(placement, assetsByKey.get(placement.assetKey));
+    for (const item of forestDepthOrder(visible, player)) {
+      if (item.kind === 'player') paintPlayer();
+      else paintTree(item.placement);
+    }
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length}`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
+    diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
     diagnostics.duration.textContent = `${(window.performance.now() - start).toFixed(1)} ms`;
   }
 
+  function hasMovement() {
+    return keys.left || keys.right || keys.up || keys.down || touch.x || touch.y;
+  }
+
+  function movementDirection() {
+    if (touch.x || touch.y) return { x: touch.x, y: touch.y };
+    return normalizedMovement(keys);
+  }
+
+  function frame(timestamp) {
+    scheduledFrame = null;
+    if (lastFrameTime === null) lastFrameTime = timestamp;
+    const elapsed = Math.min(0.05, (timestamp - lastFrameTime) / 1000);
+    lastFrameTime = timestamp;
+    if (hasMovement() && !dialog.open) {
+      Object.assign(player, moveForestPlayer(player, movementDirection(), elapsed,
+        scene.world, scene.placements));
+      followPlayer();
+      updateFocus();
+    }
+    render();
+    if (hasMovement() && !dialog.open) scheduledFrame = requestAnimationFrame(frame);
+    else lastFrameTime = null;
+  }
+
   function requestRender() {
-    if (scheduledFrame === null) scheduledFrame = requestAnimationFrame(render);
+    if (scheduledFrame === null) scheduledFrame = requestAnimationFrame(frame);
   }
 
-  function moveCamera(deltaX, deltaY) {
-    camera.x += deltaX;
-    camera.y += deltaY;
-    clampCamera();
+  function clearMovement() {
+    Object.keys(keys).forEach((key) => { keys[key] = false; });
+    touch.pointerId = null;
+    touch.x = 0;
+    touch.y = 0;
+    joystick.hidden = true;
+    joystickStick.style.transform = '';
+    lastFrameTime = null;
+  }
+
+  function updateTouchMovement(event) {
+    const deltaX = event.clientX - touch.originX;
+    const deltaY = event.clientY - touch.originY;
+    Object.assign(touch, touchMovement(deltaX, deltaY));
+    const distance = Math.min(34, Math.hypot(deltaX, deltaY));
+    const angle = Math.atan2(deltaY, deltaX);
+    joystickStick.style.transform = `translate(${Math.cos(angle) * distance}px, ${
+      Math.sin(angle) * distance}px)`;
     requestRender();
   }
 
-  function resetCamera() {
-    camera.x = (scene.world.width - camera.width) / 2;
-    camera.y = scene.world.height - camera.height - 80;
-    clampCamera();
+  function stopTouchMovement(event) {
+    if (touch.pointerId === null || (event && event.pointerId !== touch.pointerId)) return;
+    touch.pointerId = null;
+    touch.x = 0;
+    touch.y = 0;
+    joystick.hidden = true;
+    joystickStick.style.transform = '';
+    lastFrameTime = null;
+  }
+
+  function openInspection() {
+    if (!focusedPlacement || dialog.open) return;
+    clearMovement();
+    const fixture = fixturesById.get(focusedPlacement.fixtureId);
+    dialog.querySelector('[data-forest-post-title]').textContent = fixture.title;
+    dialog.querySelector('[data-forest-post-room]').textContent = fixture.roomName;
+    dialog.querySelector('[data-forest-post-date]').textContent = new Intl.DateTimeFormat(undefined,
+      { dateStyle: 'long' }).format(new Date(`${fixture.createdAt}T12:00:00Z`));
+    dialog.querySelector('[data-forest-post-excerpt]').textContent = fixture.excerpt;
+    dialog.showModal();
+  }
+
+  function resetPlayer() {
+    clearMovement();
+    Object.assign(player, scene.exploration.spawn);
+    followPlayer();
+    updateFocus();
     requestRender();
+    viewportElement.focus();
   }
 
   function resize() {
@@ -131,39 +231,66 @@ if (payload && viewportElement && canvas) {
     canvas.height = nextHeight;
     camera.width = nextWidth;
     camera.height = nextHeight;
-    clampCamera();
+    followPlayer();
     requestRender();
   }
 
+  const directionForKey = {
+    arrowleft: 'left', a: 'left', arrowright: 'right', d: 'right',
+    arrowup: 'up', w: 'up', arrowdown: 'down', s: 'down'
+  };
   viewportElement.addEventListener('keydown', (event) => {
-    const directions = {
-      ArrowLeft: [-56, 0], a: [-56, 0], A: [-56, 0],
-      ArrowRight: [56, 0], d: [56, 0], D: [56, 0],
-      ArrowUp: [0, -56], w: [0, -56], W: [0, -56],
-      ArrowDown: [0, 56], s: [0, 56], S: [0, 56]
-    };
-    const direction = directions[event.key];
-    if (!direction) return;
-    event.preventDefault();
-    moveCamera(direction[0], direction[1]);
+    const direction = directionForKey[event.key.toLowerCase?.() || event.key];
+    if (direction) {
+      event.preventDefault();
+      keys[direction] = true;
+      requestRender();
+    } else if ((event.key === 'e' || event.key === 'E' || event.key === 'Enter')
+      && focusedPlacement) {
+      event.preventDefault();
+      openInspection();
+    }
   });
-
+  viewportElement.addEventListener('keyup', (event) => {
+    const direction = directionForKey[event.key.toLowerCase?.() || event.key];
+    if (direction) {
+      event.preventDefault();
+      keys[direction] = false;
+    }
+  });
   viewportElement.addEventListener('pointerdown', (event) => {
-    drag = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    if (event.pointerType === 'mouse' || event.target.closest('button') || dialog.open) return;
+    event.preventDefault();
+    touch.pointerId = event.pointerId;
+    touch.originX = event.clientX;
+    touch.originY = event.clientY;
+    touch.x = 0;
+    touch.y = 0;
+    const viewportRect = viewportElement.getBoundingClientRect();
+    joystick.style.left = `${event.clientX - viewportRect.left}px`;
+    joystick.style.top = `${event.clientY - viewportRect.top}px`;
+    joystick.hidden = false;
     viewportElement.setPointerCapture(event.pointerId);
     viewportElement.focus();
   });
   viewportElement.addEventListener('pointermove', (event) => {
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    moveCamera(drag.x - event.clientX, drag.y - event.clientY);
-    drag.x = event.clientX;
-    drag.y = event.clientY;
+    if (event.pointerId !== touch.pointerId) return;
+    event.preventDefault();
+    updateTouchMovement(event);
   });
-  viewportElement.addEventListener('pointerup', () => { drag = null; });
-  viewportElement.addEventListener('pointercancel', () => { drag = null; });
-  document.querySelector('[data-forest-reset]').addEventListener('click', resetCamera);
+  viewportElement.addEventListener('pointerup', stopTouchMovement);
+  viewportElement.addEventListener('pointercancel', stopTouchMovement);
+  viewportElement.addEventListener('lostpointercapture', stopTouchMovement);
+  window.addEventListener('blur', clearMovement);
+  dialog.addEventListener('close', () => {
+    clearMovement();
+    viewportElement.focus();
+    requestRender();
+  });
+  dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
+  prompt.addEventListener('click', openInspection);
+  document.querySelector('[data-forest-reset]').addEventListener('click', resetPlayer);
   window.addEventListener('resize', resize);
-  prepareTreeSprites();
   resize();
-  resetCamera();
+  resetPlayer();
 }

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -21,3 +21,75 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
     left.worldY - right.worldY || left.id.localeCompare(right.id)
   ));
 }
+
+export function normalizedMovement(keys) {
+  const x = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
+  const y = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);
+  const length = Math.hypot(x, y);
+  return length ? { x: x / length, y: y / length } : { x: 0, y: 0 };
+}
+
+export function touchMovement(deltaX, deltaY, deadZone = 10) {
+  const distance = Math.hypot(deltaX, deltaY);
+  if (distance <= deadZone) return { x: 0, y: 0 };
+  return { x: deltaX / distance, y: deltaY / distance };
+}
+
+export function playerCollides(player, placements) {
+  return placements.some((placement) => (
+    Math.hypot(player.worldX - placement.worldX, player.worldY - placement.worldY)
+      < player.radius + placement.collisionRadius
+  ));
+}
+
+export function moveForestPlayer(player, direction, elapsedSeconds, world, placements) {
+  const distance = player.movementSpeed * elapsedSeconds;
+  const next = { ...player };
+  const limits = {
+    left: player.radius,
+    right: world.width - player.radius,
+    top: player.radius,
+    bottom: world.height - player.radius
+  };
+  const candidateX = {
+    ...next,
+    worldX: Math.max(limits.left, Math.min(limits.right, next.worldX + direction.x * distance))
+  };
+  if (!playerCollides(candidateX, placements)) next.worldX = candidateX.worldX;
+  const candidateY = {
+    ...next,
+    worldY: Math.max(limits.top, Math.min(limits.bottom, next.worldY + direction.y * distance))
+  };
+  if (!playerCollides(candidateY, placements)) next.worldY = candidateY.worldY;
+  return next;
+}
+
+export function cameraFollowingPlayer(player, viewport, world) {
+  return {
+    ...viewport,
+    x: Math.max(0, Math.min(Math.max(0, world.width - viewport.width),
+      Math.round(player.worldX - viewport.width / 2))),
+    y: Math.max(0, Math.min(Math.max(0, world.height - viewport.height),
+      Math.round(player.worldY - viewport.height / 2)))
+  };
+}
+
+export function focusedForestPlacement(player, placements, interactionRadius) {
+  return placements.map((placement) => ({
+    placement,
+    distance: Math.hypot(player.worldX - placement.worldX, player.worldY - placement.worldY)
+  })).filter(({ placement, distance }) => (
+    distance <= interactionRadius + placement.collisionRadius
+  )).sort((left, right) => (
+    left.distance - right.distance || left.placement.id.localeCompare(right.placement.id)
+  ))[0]?.placement || null;
+}
+
+export function forestDepthOrder(placements, player) {
+  return [
+    ...placements.map((placement) => ({ kind: 'tree', id: placement.id,
+      worldY: placement.worldY, placement })),
+    { kind: 'player', id: '~player', worldY: player.worldY, player }
+  ].sort((left, right) => left.worldY - right.worldY
+    || (left.kind === right.kind ? left.id.localeCompare(right.id) : left.kind === 'player' ? 1 : -1));
+}

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -5,6 +5,7 @@ import { addI18n } from '../services/i18n.js';
 import { getForestLabTree } from '../services/forestLabTreeCache.js';
 import { prepareForestScene } from '../services/forestSceneAssetPool.js';
 import { generateForestSceneLayout } from '../services/forestSceneLayout.js';
+import { createForestExploration } from '../services/forestSceneExploration.js';
 import {
   DECIDUOUS_PHENOTYPE,
   LANTERNWOOD_PHENOTYPE
@@ -86,7 +87,7 @@ router.get(
   '/__dev/views/activity-forest',
   optionalAuth,
   (req, res) => {
-    const scene = prepareForestScene(generateForestSceneLayout());
+    const scene = prepareForestScene(createForestExploration(generateForestSceneLayout()));
     res.render('dev/activity-forest', {
       title: 'Activity Forest Scene',
       user: req.user || null,

--- a/server/services/forestSceneExploration.js
+++ b/server/services/forestSceneExploration.js
@@ -1,0 +1,54 @@
+import { forestCorridorCenter } from './forestSceneLayout.js';
+import { hashSeed } from './forest/v3/random.js';
+
+export const FOREST_PLAYER_RADIUS = 10;
+export const FOREST_PLAYER_SPEED = 150;
+export const FOREST_INTERACTION_RADIUS = 70;
+
+const FIXTURES = Object.freeze([
+  ['storm-notes', 'Notes from a Summer Thunderstorm', 'Daily Inspiration', '2025-07-14',
+    'Rain arrived softly at first, silvering the porch steps before the whole sky opened.'],
+  ['quiet-repair', 'The Quiet Work of Repair', 'History', '2024-11-08',
+    'Some repairs announce themselves. Others simply let a familiar thing remain in the world.'],
+  ['bird-names', 'On Learning the Names of Birds', 'Daily Inspiration', '2026-04-19',
+    'The names did not make the birds less mysterious; they made attention easier to practice.'],
+  ['winter-harbor', 'Postcard from a Winter Harbor', 'United States', '2025-01-23',
+    'At low tide the boats leaned together, their ropes drawing patient lines across the cold air.'],
+  ['memory-recipe', 'A Recipe Written from Memory', 'Daily Inspiration', '2024-09-12',
+    'There were no measurements in the kitchen, only the old blue bowl and the sound of the spoon.'],
+  ['kindness-map', 'A Map of Neighborhood Kindness', 'United States', '2026-02-07',
+    'A map can hold more than streets: the borrowed ladder, the soup left quietly at a door.']
+].map(([id, title, roomName, createdAt, excerpt]) => ({
+  id: `forest-fixture-${id}`, title, roomName, createdAt, excerpt
+})));
+
+export function forestPlacementCollisionRadius(placement) {
+  const phenotypeRadius = placement.phenotypeId === 'sunset-lanternwood' ? 13 : 11;
+  return phenotypeRadius * placement.scale;
+}
+
+export function createForestExploration(scene) {
+  const spawn = {
+    worldX: Math.round(forestCorridorCenter(scene.world.height - 180, scene.world.width)),
+    worldY: scene.world.height - 180,
+    radius: FOREST_PLAYER_RADIUS,
+    facing: 'down',
+    movementSpeed: FOREST_PLAYER_SPEED
+  };
+  const fixtures = FIXTURES.map((fixture) => ({ ...fixture }));
+  const placements = scene.placements.map((placement) => ({
+    ...placement,
+    collisionRadius: forestPlacementCollisionRadius(placement),
+    fixtureId: fixtures[hashSeed(`forest-fixture:${placement.id}`) % fixtures.length].id
+  }));
+
+  return {
+    ...scene,
+    placements,
+    exploration: {
+      spawn,
+      interactionRadius: FOREST_INTERACTION_RADIUS,
+      fixtures
+    }
+  };
+}

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -9,9 +9,20 @@ import {
   prepareForestScene
 } from '../server/services/forestSceneAssetPool.js';
 import {
+  cameraFollowingPlayer,
+  focusedForestPlacement,
+  forestDepthOrder,
+  moveForestPlayer,
+  normalizedMovement,
+  playerCollides,
+  touchMovement,
   placementVisualRect,
   visibleForestPlacements
 } from '../public/js/forest-scene-math.js';
+import {
+  createForestExploration,
+  forestPlacementCollisionRadius
+} from '../server/services/forestSceneExploration.js';
 
 describe('static Activity Forest scene', () => {
   beforeEach(() => clearForestSceneAssetPool());
@@ -98,5 +109,88 @@ describe('static Activity Forest scene', () => {
     expect(visibleForestPlacements(
       placements, assets, { x: 0, y: 0, width: 140, height: 100 }, 0
     ).map((placement) => placement.id)).toEqual(['partial', 'tie-a', 'tie-b', 'near']);
+  });
+
+  it('adds a deterministic, safe spawn and bounded fixture metadata', () => {
+    const scene = prepareForestScene(createForestExploration(generateForestSceneLayout()));
+    const repeated = createForestExploration(generateForestSceneLayout());
+    const serialized = JSON.stringify(scene);
+
+    expect(repeated.exploration).toEqual(scene.exploration);
+    expect(scene.exploration.spawn.worldX).toBeGreaterThan(0);
+    expect(scene.exploration.spawn.worldX).toBeLessThan(scene.world.width);
+    expect(scene.exploration.spawn.worldY).toBeGreaterThan(0);
+    expect(scene.exploration.spawn.worldY).toBeLessThan(scene.world.height);
+    expect(playerCollides(scene.exploration.spawn, scene.placements)).toBeFalse();
+    expect(scene.exploration.fixtures.length).toBeLessThan(scene.placements.length);
+    expect(scene.placements.every((placement) => placement.fixtureId)).toBeTrue();
+    expect(scene.assets.length).toBeGreaterThan(0);
+    for (const excluded of ['nodes', 'segments', 'diagnostics', 'attractionPoints', 'wordCount']) {
+      expect(serialized).not.toContain(`"${excluded}"`);
+    }
+    expect(JSON.parse(JSON.stringify(scene))).toEqual(scene);
+  });
+
+  it('normalizes elapsed-time movement and keeps the player inside world bounds', () => {
+    const player = { worldX: 50, worldY: 50, radius: 10, movementSpeed: 100 };
+    const diagonal = normalizedMovement({ right: true, down: true });
+    const moved = moveForestPlayer(player, diagonal, 0.5, { width: 200, height: 200 }, []);
+    const clamped = moveForestPlayer(player, { x: -1, y: -1 }, 10,
+      { width: 200, height: 200 }, []);
+
+    expect(Math.hypot(diagonal.x, diagonal.y)).toBeCloseTo(1, 8);
+    expect(Math.hypot(moved.worldX - 50, moved.worldY - 50)).toBeCloseTo(50, 8);
+    expect(moveForestPlayer(player, diagonal, 0.5, { width: 200, height: 200 }, []))
+      .toEqual(moved);
+    expect(clamped.worldX).toBe(10);
+    expect(clamped.worldY).toBe(10);
+  });
+
+  it('turns touch displacement into constant-speed directional input after a dead zone', () => {
+    expect(touchMovement(4, 6, 10)).toEqual({ x: 0, y: 0 });
+    expect(touchMovement(30, 40, 10)).toEqual({ x: 0.6, y: 0.8 });
+    expect(touchMovement(-30, 0, 10)).toEqual({ x: -1, y: 0 });
+  });
+
+  it('blocks trunk entry, supports axis sliding, and scales collision radii', () => {
+    const player = { worldX: 50, worldY: 50, radius: 10, movementSpeed: 40 };
+    const obstacle = { id: 'tree', worldX: 80, worldY: 50, collisionRadius: 12 };
+    const blocked = moveForestPlayer(player, { x: 1, y: 0 }, 0.5,
+      { width: 200, height: 200 }, [obstacle]);
+    const sliding = moveForestPlayer(player, { x: 1, y: 1 }, 0.5,
+      { width: 200, height: 200 }, [obstacle]);
+
+    expect(blocked.worldX).toBe(50);
+    expect(sliding.worldX).toBe(50);
+    expect(sliding.worldY).toBe(70);
+    expect(forestPlacementCollisionRadius({ phenotypeId: 'sunset-lanternwood', scale: 2 }))
+      .toBe(26);
+    expect(playerCollides({ ...player, worldX: 30 }, [obstacle])).toBeFalse();
+  });
+
+  it('follows the player with camera edge clamping', () => {
+    const viewport = { x: 0, y: 0, width: 100, height: 80 };
+    const world = { width: 300, height: 200 };
+    expect(cameraFollowingPlayer({ worldX: 150, worldY: 100 }, viewport, world))
+      .toEqual({ x: 100, y: 60, width: 100, height: 80 });
+    expect(cameraFollowingPlayer({ worldX: 0, worldY: 0 }, viewport, world).x).toBe(0);
+    expect(cameraFollowingPlayer({ worldX: 300, worldY: 200 }, viewport, world))
+      .toEqual({ x: 200, y: 120, width: 100, height: 80 });
+  });
+
+  it('orders the player by ground Y and selects proximity with stable ties', () => {
+    const player = { worldX: 0, worldY: 50 };
+    const placements = [
+      { id: 'below', worldX: 0, worldY: 60, collisionRadius: 5 },
+      { id: 'tie-b', worldX: 10, worldY: 50, collisionRadius: 5 },
+      { id: 'tie-a', worldX: -10, worldY: 50, collisionRadius: 5 },
+      { id: 'above', worldX: 0, worldY: 40, collisionRadius: 5 },
+      { id: 'far', worldX: 200, worldY: 50, collisionRadius: 5 }
+    ];
+
+    expect(forestDepthOrder(placements, player).map((item) => item.id))
+      .toEqual(['above', 'far', 'tie-a', 'tie-b', '~player', 'below']);
+    expect(focusedForestPlacement(player, placements.slice(1, 3), 10).id).toBe('tie-a');
+    expect(focusedForestPlacement(player, [placements[4]], 10)).toBeNull();
   });
 });

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -14,22 +14,26 @@ block content
         p.activity-forest__eyebrow Development preview
         h1 Activity Forest
         p.activity-forest__lede
-          | A deterministic grove composed from reusable procedural tree assets. The winding
-          | clearing is the first hint of a place to explore rather than a gallery to inspect.
-      button.activity-forest__reset(type='button' data-forest-reset) Reset camera
+          | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
+          | The grove remains deterministic and is composed from reusable procedural tree assets.
+      button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
 
     p#activity-forest-help.activity-forest__help
-      | Focus the forest, then pan with arrow keys or WASD. You can also drag with a mouse or touch.
+      | Move with arrow keys or WASD, or touch and drag in the forest. Near a tree, inspect its writing.
 
     .activity-forest__viewport(
       tabindex='0'
       role='application'
-      aria-label='Navigable static Activity Forest scene'
+      aria-label='Activity Forest exploration scene'
       aria-describedby='activity-forest-help'
       data-forest-viewport
     )
       canvas.activity-forest__canvas(data-forest-canvas)
-      .activity-forest__hint Drag to explore
+      .activity-forest__joystick(data-forest-joystick hidden aria-hidden='true')
+        .activity-forest__joystick-stick(data-forest-joystick-stick)
+      button.activity-forest__prompt(type='button' data-forest-prompt hidden)
+        span.activity-forest__prompt-keyboard Press E or Enter to inspect
+        span.activity-forest__prompt-touch Tap to inspect
 
     dl.activity-forest__diagnostics(aria-label='Scene diagnostics')
       div
@@ -51,7 +55,23 @@ block content
         dt Camera
         dd(data-forest-camera) —
       div
+        dt Player
+        dd(data-forest-player) —
+      div
+        dt Nearby tree
+        dd(data-forest-focus) None
+      div
         dt Last render
         dd(data-forest-duration) —
+
+    dialog.activity-forest__dialog(data-forest-dialog aria-labelledby='forest-post-title')
+      p.activity-forest__dialog-eyebrow A writing remembered here
+      h2#forest-post-title(data-forest-post-title)
+      p.activity-forest__dialog-context
+        span(data-forest-post-room)
+        span(aria-hidden='true')  ·
+        time(data-forest-post-date)
+      p.activity-forest__dialog-excerpt(data-forest-post-excerpt)
+      button(type='button' data-forest-dialog-close) Return to the forest
 
     script#activity-forest-scene(type='application/json')!= JSON.stringify(scene).replace(/</g, '\\u003c')


### PR DESCRIPTION
## Summary

Add the first playable exploration loop to the Activity Forest development scene.

Players can now enter the deterministic grove, move through it with keyboard or touch controls, approach trees, inspect associated fixture writing, and return to exploration without losing their position.

## Changes

- Add a deterministic, collision-free player spawn in the forest corridor
- Support elapsed-time movement with arrow keys and WASD
- Add a floating touch joystick with directional dragging and a dead zone
- Follow the player with a world-bounded orthographic camera
- Add scaled circular trunk collision with axis-based sliding
- Integrate the player into stable ground-Y depth ordering
- Select the nearest interactable tree with deterministic tie-breaking
- Associate placements with a bounded fixture-post catalog independently of tree assets
- Add a visible nearby-tree focus indicator and responsive inspection prompt
- Add an accessible fixture-writing dialog with clean focus restoration
- Stop movement on inspection, pointer cancellation, focus loss, and input release
- Preserve viewport culling, pre-rasterized tree assets, and idle rendering
- Extend scene diagnostics with player and nearby-tree information
- Update the Activity Forest design documentation

## Interaction

### Keyboard

- Move with arrow keys or WASD
- Inspect a nearby tree with E or Enter
- Close inspection with Escape or the return button

### Touch

- Touch and hold inside the forest to establish a floating joystick
- Drag to choose a movement direction
- Release to stop
- Tap the nearby-tree prompt to inspect its writing

## Architecture

The exploration payload remains deterministic and JSON-serializable. It contains only runtime tree assets, placements, explicit player configuration, and limited fixture metadata.

Procedural generation and offscreen sprite preparation remain outside active movement frames. While moving, frames perform only movement and collision math, camera following, proximity selection, culling, depth ordering, and bitmap drawing. Rendering returns to idle when movement stops.

## Non-goals

This change does not add:

- Production post or database integration
- Persistence
- Ambient foliage animation
- Character animation
- Running, acceleration, stamina, or complex physics
- Pathfinding or tap-to-move
- Inventories, rewards, progression, or other game systems
- WebGL or generalized scene-engine infrastructure

## Verification

- Project lint passes
- Browser-script lint passes
- 10 focused forest specs pass
- Full test suite passes: 555 specs
- `git diff --check` passes
- Keyboard and touch exploration were manually verified