### PR TITLE
Add pressure-tested regional asset loading to Activity Forest

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -247,17 +247,17 @@ key. Layout randomness is derived independently for X, Y, phenotype, specimen, a
 the scene seed and candidate index. Rejection sampling enforces trunk spacing and reserves a
 winding central corridor; camera position is never an input to layout or tree identity.
 
-The scene prepares a bounded pool of eight specimens for each registered phenotype. Its
-process-local cache is separate from Forest Lab's diagnostic cache and retains runtime assets
-only. The asset's schema, renderer, phenotype, and seed identities form the invalidation key.
-The development route eagerly generates missing specimens before serializing the scene, and
-the browser receives placements plus JSON-round-tripped runtime assets. Many placements point
-to each asset; generation results and branch diagnostics never cross the scene boundary. The
-cache lives only for the server module/process lifetime and is not production persistence.
+The representative scene uses a bounded pool of eight specimens for each registered phenotype;
+pressure profiles can deliberately select broader pools. Its process-local cache is separate from
+Forest Lab's diagnostic cache and retains runtime assets only. The asset's schema, renderer,
+phenotype, and seed identities form the invalidation key. The browser receives the complete compact
+placement manifest, but only nearby JSON-round-tripped runtime assets. Many placements can point to
+each asset; generation results and branch diagnostics never cross the scene boundary. The cache
+lives only for the server module/process lifetime and is not production persistence.
 
-The browser draws the prepared scene into one visible Canvas. During initial browser-side
-preparation, each unique runtime asset is rasterized once into a small offscreen Canvas in its
-declared layer order. Placements reuse those 16 prepared bitmaps, reducing ordinary scene draws
+The browser draws the prepared scene into one visible Canvas. As each runtime asset arrives, it is
+rasterized once into a small offscreen Canvas in its declared layer order. Placements reuse prepared
+bitmaps, reducing ordinary scene draws
 from thousands of color-run operations per tree to one `drawImage` call per visible tree. These
 offscreen surfaces are per asset, never per placement, and are discarded with the page.
 Browser-independent math derives each scaled visual rectangle from the asset bounds and ground
@@ -278,17 +278,65 @@ independent of tree asset identity, and only bounded title, room, date, and exce
 the runtime boundary. A native modal inspection dialog stops movement and returns focus without
 changing the player or camera location.
 
-Tree sprites are still prepared only at startup. Active movement frames perform movement math,
-culling, ordering, and bitmap draws, then cease when input stops; no procedural generation or
-color-run replay occurs in those frames. The render-duration diagnostic remains the local
-measurement point, with no new benchmark claim for this first interaction slice.
+Active movement frames perform movement math, region-set comparison, culling, ordering, and bitmap
+draws, then cease when input stops. Procedural generation, response decoding, and color-run replay
+remain outside the animation frame. The render-duration diagnostic remains the local measurement
+point, with no universal benchmark claim for this interaction slice.
+
+### Development pressure profiles
+
+The development route accepts four labeled profiles through its on-page profile links:
+
+| Profile | Placements | Unique runtime assets | Purpose |
+| --- | ---: | ---: | --- |
+| Representative grove | 180 | up to 16 | The unchanged calm default and normal comparison point. |
+| Asset variety | 180 | 60 | Isolates the cost of a moderately broader asset set. |
+| Unique assets | 180 | 180 | Exercises the current eager asset boundary at maximum variety. |
+| Large world | 600 | 60 | Separates placement, culling, and movement cost from asset variety. |
+
+Only this development route can select the pressure profiles. An explicit cold-cache link clears
+the scene asset pool before preparation so a cold generation run can be compared with ordinary
+warm-cache reloads. The initial route reports the UTF-8 serialized scene payload size, preparation
+time, and generated-versus-reused server asset counts for its initial region. Preparation timing
+includes asset lookup or generation plus creation of JSON-safe assets; it does not claim to measure
+network transfer or template rendering.
+
+The measured eager results justified a narrow regional-loading experiment. The world is divided
+into deterministic 480-pixel square cells. The initial response includes assets whose placement
+anchors occupy the spawn cell and its one-cell neighbors. In the browser, the current camera extent
+plus a one-cell preload ring determines subsequent cell requests. The development-only asset route
+regenerates the same deterministic layout, validates and caps requested cells, prepares only their
+unique asset keys, and returns those assets. Loaded and in-flight cell sets prevent duplicate
+requests. Before requesting a cell set, the browser subtracts asset keys for canvases it already
+owns; cells whose assets are all prepared require no response, and the server validates requested
+keys against the requested cells. Returned assets are prepared asynchronously and retained for the
+page lifetime; there is
+an approximately six-millisecond active-work budget before preparation yields to an idle callback.
+There is no eviction, persistence, generalized loading framework, or change to placement and asset
+identity.
+
+The browser reports initial and last-regional sprite-preparation time, prepared canvas count,
+regional request/server timing, time from navigation start to the first completed scene render,
+visible placement count, last render duration, and rolling last/average/maximum movement-render
+duration. It also remembers which placements and asset keys have appeared in prior views. When
+movement reveals placements outside the previously seen set, the diagnostic records the new
+placement and asset counts, render duration, and animation-frame gap.
+
+These values are local instrumentation, not a committed cross-device benchmark. Compare cold
+runs on the intended baseline browser and device, repeat each profile enough to distinguish a
+consistent regression from generator and browser noise, and use the representative grove as the
+control. Compare the regional results with the recorded eager baseline to determine how much asset
+staging alone improves startup and whether the preload ring prevents region-entry stalls. A compact
+raster transport may be evaluated separately if JSON color-run payloads remain material. Asset
+eviction, WebGL, atlases, and generalized loading remain out of scope until further evidence and
+explicit approval.
 
 The restrained world-space ground treatment and corridor exist only to make depth and negative
 space legible. This first camera is deliberately orthographic: terrain and trees share the same
 translation, with no viewport-fixed horizon or implied perspective projection. The next likely
 step is to test shared ambient wind against this representative workload. Real post integration,
 persistence, complex physics, animation systems, tap-to-pathfind movement, zoom, terrain systems,
-perspective projection, streaming, and game-engine abstractions remain non-goals for this slice.
+perspective projection, asset eviction, and game-engine abstractions remain non-goals for this slice.
 
 ### Historical renderer v2
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -41,6 +41,29 @@
   font-size: 0.85rem;
 }
 
+.activity-forest__profiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.8rem 0;
+}
+
+.activity-forest__profiles a {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  background: var(--surface-raised-bg);
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+
+.activity-forest__profiles a[aria-current='page'] {
+  border-color: var(--highlight-color);
+  color: var(--highlight-color);
+}
+
+.activity-forest__profiles .activity-forest__cold { margin-left: auto; }
+
 .activity-forest__viewport {
   position: relative;
   height: clamp(420px, 68vh, 760px);
@@ -166,4 +189,5 @@
   .activity-forest { padding-top: 1rem; }
   .activity-forest__header { align-items: start; flex-direction: column; }
   .activity-forest__viewport { height: 62vh; min-height: 390px; }
+  .activity-forest__profiles .activity-forest__cold { margin-left: 0; }
 }

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1,6 +1,8 @@
 import {
   cameraFollowingPlayer,
   focusedForestPlacement,
+  forestSceneAssetKeysForCells,
+  forestSceneCellIdsForViewport,
   forestDepthOrder,
   moveForestPlayer,
   normalizedMovement,
@@ -13,8 +15,9 @@ const viewportElement = document.querySelector('[data-forest-viewport]');
 const canvas = document.querySelector('[data-forest-canvas]');
 
 if (payload && viewportElement && canvas) {
+  const scriptStartedAt = window.performance.now();
   const scene = JSON.parse(payload.textContent);
-  const assetsByKey = new Map(scene.assets.map((asset) => [asset.cacheKey, asset]));
+  const assetsByKey = new Map();
   const fixturesById = new Map(scene.exploration.fixtures.map((fixture) => [fixture.id, fixture]));
   const context = canvas.getContext('2d');
   const spritesByKey = new Map();
@@ -31,26 +34,155 @@ if (payload && viewportElement && canvas) {
     camera: document.querySelector('[data-forest-camera]'),
     player: document.querySelector('[data-forest-player]'),
     focus: document.querySelector('[data-forest-focus]'),
-    duration: document.querySelector('[data-forest-duration]')
+    duration: document.querySelector('[data-forest-duration]'),
+    spriteDuration: document.querySelector('[data-forest-sprite-duration]'),
+    prepared: document.querySelector('[data-forest-prepared]'),
+    firstRender: document.querySelector('[data-forest-first-render]'),
+    movementDuration: document.querySelector('[data-forest-movement-duration]'),
+    regionEntry: document.querySelector('[data-forest-region-entry]'),
+    regionLoading: document.querySelector('[data-forest-region-loading]')
   };
+  const loadedCellIds = new Set(scene.assetLoading.initialCellIds);
+  const pendingCellIds = new Set();
+  const totalCellCount = forestSceneCellIdsForViewport({
+    x: 0, y: 0, width: scene.world.width, height: scene.world.height
+  }, scene.world, scene.assetLoading.cellSize).length;
+  const seenPlacementIds = new Set();
+  const seenAssetKeys = new Set();
+  const movementRenders = { count: 0, total: 0, maximum: 0 };
   let focusedPlacement = null;
   let scheduledFrame = null;
   let lastFrameTime = null;
+  let firstRenderRecorded = false;
+  let regionRetryAfter = 0;
+  let regionalRequestActive = false;
 
-  for (const asset of scene.assets) {
-    const sprite = document.createElement('canvas');
-    sprite.width = asset.dimensions.width;
-    sprite.height = asset.dimensions.height;
-    const spriteContext = sprite.getContext('2d');
-    spriteContext.imageSmoothingEnabled = false;
-    for (const layer of asset.layers) {
-      for (const run of layer.runs) {
-        spriteContext.fillStyle = run.color;
-        spriteContext.fillRect(run.x, run.y, run.width, 1);
+  function prepareRuntimeAssets(assets) {
+    let preparedCount = 0;
+    for (const asset of assets) {
+      if (spritesByKey.has(asset.cacheKey)) continue;
+      const sprite = document.createElement('canvas');
+      sprite.width = asset.dimensions.width;
+      sprite.height = asset.dimensions.height;
+      const spriteContext = sprite.getContext('2d');
+      spriteContext.imageSmoothingEnabled = false;
+      for (const layer of asset.layers) {
+        for (const run of layer.runs) {
+          spriteContext.fillStyle = run.color;
+          spriteContext.fillRect(run.x, run.y, run.width, 1);
+        }
+      }
+      assetsByKey.set(asset.cacheKey, asset);
+      spritesByKey.set(asset.cacheKey, sprite);
+      preparedCount += 1;
+    }
+    diagnostics.prepared.textContent = `${spritesByKey.size} / ${
+      scene.assetLoading.totalAssetCount} asset canvases`;
+    return preparedCount;
+  }
+
+  function waitForAssetPreparationTime() {
+    return new Promise((resolve) => {
+      if (window.requestIdleCallback) {
+        window.requestIdleCallback(resolve, { timeout: 50 });
+      } else {
+        window.setTimeout(resolve, 0);
+      }
+    });
+  }
+
+  async function prepareRegionalRuntimeAssets(assets) {
+    let activeDuration = 0;
+    let batchDuration = 0;
+    let preparedCount = 0;
+    for (const [index, asset] of assets.entries()) {
+      const assetStartedAt = window.performance.now();
+      preparedCount += prepareRuntimeAssets([asset]);
+      const assetDuration = window.performance.now() - assetStartedAt;
+      activeDuration += assetDuration;
+      batchDuration += assetDuration;
+      if (batchDuration >= 6 && index < assets.length - 1) {
+        await waitForAssetPreparationTime();
+        batchDuration = 0;
       }
     }
-    spritesByKey.set(asset.cacheKey, sprite);
+    return { activeDuration, preparedCount };
   }
+
+  const spritePreparationStartedAt = window.performance.now();
+  prepareRuntimeAssets(scene.assets);
+  const spritePreparationDuration = window.performance.now() - spritePreparationStartedAt;
+  diagnostics.spriteDuration.textContent = `${spritePreparationDuration.toFixed(1)} ms initial`;
+
+  function updateRegionLoading(message = '') {
+    diagnostics.regionLoading.textContent = `${loadedCellIds.size} / ${totalCellCount} cells loaded · ${
+      pendingCellIds.size} pending${message ? ` · ${message}` : ''}`;
+  }
+
+  async function requestRequiredRegions() {
+    if (!camera.width || !camera.height || regionalRequestActive
+      || window.performance.now() < regionRetryAfter) return;
+    const requiredCellIds = forestSceneCellIdsForViewport(
+      camera,
+      scene.world,
+      scene.assetLoading.cellSize,
+      scene.assetLoading.preloadCellCount
+    );
+    const missingCellIds = requiredCellIds.filter((cellId) => (
+      !loadedCellIds.has(cellId) && !pendingCellIds.has(cellId)
+    ));
+    if (!missingCellIds.length) return;
+    const missingAssetKeys = forestSceneAssetKeysForCells(
+      scene.placements,
+      missingCellIds,
+      scene.assetLoading.cellSize,
+      spritesByKey.keys()
+    );
+    if (!missingAssetKeys.length) {
+      missingCellIds.forEach((cellId) => loadedCellIds.add(cellId));
+      updateRegionLoading(`${missingCellIds.length} cells reused prepared assets`);
+      return;
+    }
+    regionalRequestActive = true;
+    missingCellIds.forEach((cellId) => pendingCellIds.add(cellId));
+    updateRegionLoading('requesting nearby assets');
+    const requestStartedAt = window.performance.now();
+    let completionMessage = '';
+    try {
+      const query = new URLSearchParams({
+        pressure: scene.assetLoading.profileId,
+        cells: missingCellIds.join(','),
+        assetKeys: missingAssetKeys.join(',')
+      });
+      const response = await window.fetch(`/__dev/api/activity-forest/assets?${query}`);
+      if (!response.ok) throw new Error(`Regional asset request failed (${response.status}).`);
+      const region = await response.json();
+      const responseReceivedAt = window.performance.now();
+      const {
+        activeDuration: preparationDuration,
+        preparedCount
+      } = await prepareRegionalRuntimeAssets(region.assets);
+      region.cellIds.forEach((cellId) => loadedCellIds.add(cellId));
+      diagnostics.spriteDuration.textContent = `${spritePreparationDuration.toFixed(1)} ms initial / ${
+        preparationDuration.toFixed(1)} ms last regional`;
+      completionMessage = `${preparedCount} new assets · ${
+        region.serverPreparation.serializedAssetBytes.toLocaleString()} bytes · ${
+        (responseReceivedAt - requestStartedAt).toFixed(1)} ms fetch · ${
+        region.serverPreparation.durationMilliseconds.toFixed(1)} ms server`;
+      updateFocus();
+      requestRender();
+    } catch (error) {
+      completionMessage = error.message;
+      regionRetryAfter = window.performance.now() + 1000;
+    } finally {
+      missingCellIds.forEach((cellId) => pendingCellIds.delete(cellId));
+      regionalRequestActive = false;
+      updateRegionLoading(completionMessage);
+      requestRequiredRegions();
+    }
+  }
+
+  updateRegionLoading();
 
   function corridorCenter(worldY) {
     return (scene.world.width / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
@@ -58,6 +190,7 @@ if (payload && viewportElement && canvas) {
 
   function followPlayer() {
     Object.assign(camera, cameraFollowingPlayer(player, camera, scene.world));
+    requestRequiredRegions();
   }
 
   function paintGround() {
@@ -120,13 +253,15 @@ if (payload && viewportElement && canvas) {
   }
 
   function updateFocus() {
-    focusedPlacement = focusedForestPlacement(player, scene.placements,
+    focusedPlacement = focusedForestPlacement(player, scene.placements.filter(
+      ({ assetKey }) => assetsByKey.has(assetKey)
+    ),
       scene.exploration.interactionRadius);
     prompt.hidden = !focusedPlacement;
     diagnostics.focus.textContent = focusedPlacement?.id || 'None';
   }
 
-  function render() {
+  function render({ moving = false, frameGap = null } = {}) {
     const start = window.performance.now();
     context.imageSmoothingEnabled = false;
     paintGround();
@@ -138,7 +273,37 @@ if (payload && viewportElement && canvas) {
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length}`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
-    diagnostics.duration.textContent = `${(window.performance.now() - start).toFixed(1)} ms`;
+    const duration = window.performance.now() - start;
+    diagnostics.duration.textContent = `${duration.toFixed(1)} ms`;
+
+    const newlySeen = visible.filter(({ id }) => !seenPlacementIds.has(id));
+    const newlySeenAssets = new Set(newlySeen.map(({ assetKey }) => assetKey)
+      .filter((assetKey) => !seenAssetKeys.has(assetKey)));
+    visible.forEach(({ id, assetKey }) => {
+      seenPlacementIds.add(id);
+      seenAssetKeys.add(assetKey);
+    });
+
+    if (moving) {
+      movementRenders.count += 1;
+      movementRenders.total += duration;
+      movementRenders.maximum = Math.max(movementRenders.maximum, duration);
+      diagnostics.movementDuration.textContent = `${duration.toFixed(1)} ms last / ${
+        (movementRenders.total / movementRenders.count).toFixed(1)} ms avg / ${
+        movementRenders.maximum.toFixed(1)} ms max`;
+      if (newlySeen.length) {
+        diagnostics.regionEntry.textContent = `${newlySeen.length} new placements / ${
+          newlySeenAssets.size} new assets · ${duration.toFixed(1)} ms render · ${
+          frameGap === null ? 'first movement frame' : `${frameGap.toFixed(1)} ms frame gap`}`;
+      }
+    }
+
+    if (!firstRenderRecorded) {
+      firstRenderRecorded = true;
+      const renderFinishedAt = window.performance.now();
+      diagnostics.firstRender.textContent = `${renderFinishedAt.toFixed(1)} ms after navigation (${
+        (renderFinishedAt - scriptStartedAt).toFixed(1)} ms in scene script)`;
+    }
   }
 
   function hasMovement() {
@@ -152,17 +317,19 @@ if (payload && viewportElement && canvas) {
 
   function frame(timestamp) {
     scheduledFrame = null;
+    const frameGap = lastFrameTime === null ? null : timestamp - lastFrameTime;
     if (lastFrameTime === null) lastFrameTime = timestamp;
     const elapsed = Math.min(0.05, (timestamp - lastFrameTime) / 1000);
     lastFrameTime = timestamp;
-    if (hasMovement() && !dialog.open) {
+    const moving = hasMovement() && !dialog.open;
+    if (moving) {
       Object.assign(player, moveForestPlayer(player, movementDirection(), elapsed,
         scene.world, scene.placements));
       followPlayer();
       updateFocus();
     }
-    render();
-    if (hasMovement() && !dialog.open) scheduledFrame = requestAnimationFrame(frame);
+    render({ moving, frameGap });
+    if (moving) scheduledFrame = requestAnimationFrame(frame);
     else lastFrameTime = null;
   }
 

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -22,6 +22,49 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
   ));
 }
 
+export function forestSceneCellId(column, row) {
+  return `${column}:${row}`;
+}
+
+export function forestScenePlacementCellId(placement, cellSize) {
+  return forestSceneCellId(
+    Math.floor(placement.worldX / cellSize),
+    Math.floor(placement.worldY / cellSize)
+  );
+}
+
+export function forestSceneCellIdsForViewport(
+  viewport, world, cellSize, preloadCellCount = 0
+) {
+  const maximumColumn = Math.max(0, Math.ceil(world.width / cellSize) - 1);
+  const maximumRow = Math.max(0, Math.ceil(world.height / cellSize) - 1);
+  const firstColumn = Math.max(0, Math.floor(viewport.x / cellSize) - preloadCellCount);
+  const lastColumn = Math.min(maximumColumn,
+    Math.floor((viewport.x + Math.max(0, viewport.width - 1)) / cellSize)
+      + preloadCellCount);
+  const firstRow = Math.max(0, Math.floor(viewport.y / cellSize) - preloadCellCount);
+  const lastRow = Math.min(maximumRow,
+    Math.floor((viewport.y + Math.max(0, viewport.height - 1)) / cellSize)
+      + preloadCellCount);
+  const ids = [];
+  for (let row = firstRow; row <= lastRow; row += 1) {
+    for (let column = firstColumn; column <= lastColumn; column += 1) {
+      ids.push(forestSceneCellId(column, row));
+    }
+  }
+  return ids;
+}
+
+export function forestSceneAssetKeysForCells(
+  placements, cellIds, cellSize, excludedAssetKeys = []
+) {
+  const requestedCells = new Set(cellIds);
+  const excluded = new Set(excludedAssetKeys);
+  return [...new Set(placements.filter((placement) => requestedCells.has(
+    forestScenePlacementCellId(placement, cellSize)
+  )).map(({ assetKey }) => assetKey).filter((assetKey) => !excluded.has(assetKey)))];
+}
+
 export function normalizedMovement(keys) {
   const x = (keys.right ? 1 : 0) - (keys.left ? 1 : 0);
   const y = (keys.down ? 1 : 0) - (keys.up ? 1 : 0);

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -3,9 +3,26 @@ import express from 'express';
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
 import { getForestLabTree } from '../services/forestLabTreeCache.js';
-import { prepareForestScene } from '../services/forestSceneAssetPool.js';
+import {
+  clearForestSceneAssetPool,
+  prepareForestSceneAssets
+} from '../services/forestSceneAssetPool.js';
 import { generateForestSceneLayout } from '../services/forestSceneLayout.js';
 import { createForestExploration } from '../services/forestSceneExploration.js';
+import {
+  FOREST_PRESSURE_PROFILES,
+  FOREST_SCENE_MAX_ASSET_REQUEST,
+  FOREST_SCENE_CELL_SIZE,
+  FOREST_SCENE_MAX_CELL_REQUEST,
+  FOREST_SCENE_PRELOAD_CELL_COUNT,
+  resolveForestPressureProfile,
+  serializedForestSceneBytes
+} from '../services/forestScenePressure.js';
+import {
+  forestSceneAssetKeysForCells,
+  forestSceneCellIdsForViewport,
+  forestScenePlacementCellId
+} from '../../public/js/forest-scene-math.js';
 import {
   DECIDUOUS_PHENOTYPE,
   LANTERNWOOD_PHENOTYPE
@@ -70,6 +87,42 @@ function forestFixtures() {
   });
 }
 
+function forestSceneForProfile(profile) {
+  return createForestExploration(generateForestSceneLayout(profile.layout));
+}
+
+function placementsInForestCells(scene, cellIds) {
+  const requested = new Set(cellIds);
+  return scene.placements.filter((placement) => requested.has(
+    forestScenePlacementCellId(placement, FOREST_SCENE_CELL_SIZE)
+  ));
+}
+
+function initialForestCellIds(scene) {
+  return forestSceneCellIdsForViewport({
+    x: scene.exploration.spawn.worldX,
+    y: scene.exploration.spawn.worldY,
+    width: 1,
+    height: 1
+  }, scene.world, FOREST_SCENE_CELL_SIZE, FOREST_SCENE_PRELOAD_CELL_COUNT);
+}
+
+function validRequestedForestCellIds(value, world) {
+  const available = new Set(forestSceneCellIdsForViewport({
+    x: 0, y: 0, width: world.width, height: world.height
+  }, world, FOREST_SCENE_CELL_SIZE));
+  return [...new Set(String(value || '').split(',').filter((id) => available.has(id)))]
+    .slice(0, FOREST_SCENE_MAX_CELL_REQUEST);
+}
+
+function validRequestedForestAssetKeys(value, scene, cellIds) {
+  const available = new Set(forestSceneAssetKeysForCells(
+    scene.placements, cellIds, FOREST_SCENE_CELL_SIZE
+  ));
+  return [...new Set(String(value || '').split(',').filter((key) => available.has(key)))]
+    .slice(0, FOREST_SCENE_MAX_ASSET_REQUEST);
+}
+
 router.get(
   '/__dev/views/forest-lab',
   optionalAuth,
@@ -84,15 +137,72 @@ router.get(
 );
 
 router.get(
+  '/__dev/api/activity-forest/assets',
+  (req, res) => {
+    const profile = resolveForestPressureProfile(req.query.pressure);
+    const scene = forestSceneForProfile(profile);
+    const cellIds = validRequestedForestCellIds(req.query.cells, scene.world);
+    if (!cellIds.length) return res.status(400).json({ error: 'Valid forest cells are required.' });
+    const assetKeys = validRequestedForestAssetKeys(req.query.assetKeys, scene, cellIds);
+    if (!assetKeys.length) {
+      return res.status(400).json({ error: 'Valid unloaded forest assets are required.' });
+    }
+    const requestedAssetKeys = new Set(assetKeys);
+    const { assets, diagnostics } = prepareForestSceneAssets(
+      placementsInForestCells(scene, cellIds).filter(
+        ({ assetKey }) => requestedAssetKeys.has(assetKey)
+      )
+    );
+    res.set('Cache-Control', 'no-store');
+    return res.json({
+      cellIds,
+      assets,
+      serverPreparation: {
+        ...diagnostics,
+        serializedAssetBytes: Buffer.byteLength(JSON.stringify(assets), 'utf8')
+      }
+    });
+  }
+);
+
+router.get(
   '/__dev/views/activity-forest',
   optionalAuth,
   (req, res) => {
-    const scene = prepareForestScene(createForestExploration(generateForestSceneLayout()));
+    const profile = resolveForestPressureProfile(req.query.pressure);
+    const coldPreparationRequested = req.query.cold === '1';
+    if (coldPreparationRequested) clearForestSceneAssetPool();
+    const layout = forestSceneForProfile(profile);
+    const initialCellIds = initialForestCellIds(layout);
+    const { assets, diagnostics: preparation } = prepareForestSceneAssets(
+      placementsInForestCells(layout, initialCellIds)
+    );
+    const scene = JSON.parse(JSON.stringify({
+      ...layout,
+      assets,
+      assetLoading: {
+        strategy: 'regional',
+        profileId: profile.id,
+        cellSize: FOREST_SCENE_CELL_SIZE,
+        preloadCellCount: FOREST_SCENE_PRELOAD_CELL_COUNT,
+        initialCellIds,
+        totalAssetCount: new Set(layout.placements.map(({ assetKey }) => assetKey)).size
+      }
+    }));
+    const serverDiagnostics = {
+      ...preparation,
+      serializedPayloadBytes: serializedForestSceneBytes(scene),
+      coldPreparationRequested
+    };
     res.render('dev/activity-forest', {
-      title: 'Activity Forest Scene',
+      title: profile.pressure ? `Activity Forest Pressure Test: ${profile.label}`
+        : 'Activity Forest Scene',
       user: req.user || null,
       uiLang: res.locals.uiLang,
-      scene
+      scene,
+      profile,
+      pressureProfiles: FOREST_PRESSURE_PROFILES,
+      serverDiagnostics
     });
   }
 );

--- a/server/services/forestSceneAssetPool.js
+++ b/server/services/forestSceneAssetPool.js
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks';
+
 import { generateForestTreeAssetV3 } from './forestTreeGeneratorV3.js';
 import {
   DECIDUOUS_PHENOTYPE,
@@ -19,9 +21,11 @@ export function forestSceneAssetPoolSize() {
   return sceneAssetCache.size;
 }
 
-export function prepareForestScene(layout) {
+export function prepareForestSceneAssets(placements) {
+  const startedAt = performance.now();
   const assets = [];
-  const required = new Map(layout.placements.map((placement) => [placement.assetKey, placement]));
+  const required = new Map(placements.map((placement) => [placement.assetKey, placement]));
+  let generatedAssetCount = 0;
 
   for (const [assetKey, placement] of required) {
     if (!sceneAssetCache.has(assetKey)) {
@@ -33,10 +37,35 @@ export function prepareForestScene(layout) {
       );
       if (asset.cacheKey !== assetKey) throw new Error('Prepared tree asset identity mismatch.');
       sceneAssetCache.set(assetKey, asset);
+      generatedAssetCount += 1;
     }
     assets.push(sceneAssetCache.get(assetKey));
   }
 
-  return JSON.parse(JSON.stringify({ ...layout, assets }));
+  return {
+    assets: JSON.parse(JSON.stringify(assets)),
+    diagnostics: {
+      durationMilliseconds: performance.now() - startedAt,
+      generatedAssetCount,
+      reusedAssetCount: required.size - generatedAssetCount,
+      preparedAssetCount: required.size
+    }
+  };
 }
 
+export function prepareForestSceneWithDiagnostics(layout) {
+  const startedAt = performance.now();
+  const { assets, diagnostics } = prepareForestSceneAssets(layout.placements);
+  const scene = JSON.parse(JSON.stringify({ ...layout, assets }));
+  return {
+    scene,
+    diagnostics: {
+      ...diagnostics,
+      durationMilliseconds: performance.now() - startedAt
+    }
+  };
+}
+
+export function prepareForestScene(layout) {
+  return prepareForestSceneWithDiagnostics(layout).scene;
+}

--- a/server/services/forestSceneLayout.js
+++ b/server/services/forestSceneLayout.js
@@ -95,9 +95,15 @@ export function generateForestSceneLayout(options = {}) {
     ));
     if (pathDistance < config.corridorHalfWidth || overlapsTrunk) continue;
 
-    const phenotype = selectPhenotype(config, config.seed, candidateIndex);
-    const specimenIndex = Math.floor(
-      decisionRandom(config.seed, candidateIndex, 'specimen') * config.specimenPoolSize
+    const specimenIndex = config.assetPoolSize
+      ? placements.length % config.assetPoolSize
+      : Math.floor(
+        decisionRandom(config.seed, candidateIndex, 'specimen') * config.specimenPoolSize
+      );
+    const phenotype = selectPhenotype(
+      config,
+      config.seed,
+      config.assetPoolSize ? specimenIndex : candidateIndex
     );
     const { treeSeed, assetKey } = specimenIdentity(
       config, config.seed, phenotype, specimenIndex
@@ -129,4 +135,3 @@ export function generateForestSceneLayout(options = {}) {
     placements
   };
 }
-

--- a/server/services/forestScenePressure.js
+++ b/server/services/forestScenePressure.js
@@ -1,0 +1,50 @@
+export const DEFAULT_FOREST_PRESSURE_PROFILE_ID = 'representative';
+export const FOREST_SCENE_CELL_SIZE = 480;
+export const FOREST_SCENE_PRELOAD_CELL_COUNT = 1;
+export const FOREST_SCENE_MAX_CELL_REQUEST = 64;
+export const FOREST_SCENE_MAX_ASSET_REQUEST = 256;
+
+export const FOREST_PRESSURE_PROFILES = Object.freeze([
+  Object.freeze({
+    id: DEFAULT_FOREST_PRESSURE_PROFILE_ID,
+    label: 'Representative grove',
+    description: 'The calm default: 180 placements sharing up to 16 assets.',
+    pressure: false,
+    layout: Object.freeze({})
+  }),
+  Object.freeze({
+    id: 'asset-variety',
+    label: 'Asset variety',
+    description: '180 placements sharing 60 assets.',
+    pressure: true,
+    layout: Object.freeze({ seed: 'pressure-asset-variety', assetPoolSize: 60 })
+  }),
+  Object.freeze({
+    id: 'unique-assets',
+    label: 'Unique assets',
+    description: '180 placements with one unique asset per tree.',
+    pressure: true,
+    layout: Object.freeze({ seed: 'pressure-unique-assets', assetPoolSize: 180 })
+  }),
+  Object.freeze({
+    id: 'large-world',
+    label: 'Large world',
+    description: '600 placements sharing 60 assets across a 6000 × 3600 world.',
+    pressure: true,
+    layout: Object.freeze({
+      seed: 'pressure-large-world',
+      world: Object.freeze({ width: 6000, height: 3600 }),
+      placementCount: 600,
+      assetPoolSize: 60
+    })
+  })
+]);
+
+export function resolveForestPressureProfile(profileId) {
+  return FOREST_PRESSURE_PROFILES.find(({ id }) => id === profileId)
+    || FOREST_PRESSURE_PROFILES.find(({ id }) => id === DEFAULT_FOREST_PRESSURE_PROFILE_ID);
+}
+
+export function serializedForestSceneBytes(scene) {
+  return Buffer.byteLength(JSON.stringify(scene), 'utf8');
+}

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -6,11 +6,21 @@ import {
 import {
   clearForestSceneAssetPool,
   forestSceneAssetPoolSize,
-  prepareForestScene
+  prepareForestSceneAssets,
+  prepareForestScene,
+  prepareForestSceneWithDiagnostics
 } from '../server/services/forestSceneAssetPool.js';
+import {
+  FOREST_PRESSURE_PROFILES,
+  resolveForestPressureProfile,
+  serializedForestSceneBytes
+} from '../server/services/forestScenePressure.js';
 import {
   cameraFollowingPlayer,
   focusedForestPlacement,
+  forestSceneAssetKeysForCells,
+  forestSceneCellIdsForViewport,
+  forestScenePlacementCellId,
   forestDepthOrder,
   moveForestPlayer,
   normalizedMovement,
@@ -87,6 +97,83 @@ describe('static Activity Forest scene', () => {
       expect(serialized).not.toContain(`"${excluded}"`);
     }
     expect(JSON.parse(serialized)).toEqual(scene);
+  });
+
+  it('defines explicit development pressure profiles without changing the default layout', () => {
+    const representative = resolveForestPressureProfile('representative');
+    const variety = resolveForestPressureProfile('asset-variety');
+    const unique = resolveForestPressureProfile('unique-assets');
+    const large = resolveForestPressureProfile('large-world');
+
+    expect(FOREST_PRESSURE_PROFILES.length).toBe(4);
+    expect(representative.pressure).toBeFalse();
+    expect(representative.layout).toEqual({});
+    expect(resolveForestPressureProfile('unknown')).toBe(representative);
+    expect(generateForestSceneLayout(variety.layout).placements
+      .map(({ assetKey }) => assetKey).filter((key, index, keys) => keys.indexOf(key) === index)
+      .length).toBe(60);
+    expect(new Set(generateForestSceneLayout(unique.layout).placements
+      .map(({ assetKey }) => assetKey)).size).toBe(180);
+    const largeScene = generateForestSceneLayout(large.layout);
+    expect(largeScene.placements.length).toBe(600);
+    expect(largeScene.world).toEqual({ width: 6000, height: 3600 });
+  });
+
+  it('reports cold and warm server preparation work and exact UTF-8 payload bytes', () => {
+    const layout = generateForestSceneLayout({
+      seed: 'pressure-diagnostics', placementCount: 8, assetPoolSize: 4
+    });
+    const cold = prepareForestSceneWithDiagnostics(layout);
+    const warm = prepareForestSceneWithDiagnostics(layout);
+
+    expect(cold.diagnostics.generatedAssetCount).toBe(4);
+    expect(cold.diagnostics.reusedAssetCount).toBe(0);
+    expect(cold.diagnostics.preparedAssetCount).toBe(4);
+    expect(cold.diagnostics.durationMilliseconds).toBeGreaterThanOrEqual(0);
+    expect(warm.diagnostics.generatedAssetCount).toBe(0);
+    expect(warm.diagnostics.reusedAssetCount).toBe(4);
+    expect(serializedForestSceneBytes(cold.scene))
+      .toBe(Buffer.byteLength(JSON.stringify(cold.scene), 'utf8'));
+  });
+
+  it('partitions the world into stable cells with a clamped preload ring', () => {
+    const world = { width: 1200, height: 900 };
+
+    expect(forestScenePlacementCellId({ worldX: 960, worldY: 479 }, 480)).toBe('2:0');
+    expect(forestSceneCellIdsForViewport(
+      { x: 450, y: 450, width: 100, height: 100 }, world, 480, 1
+    )).toEqual([
+      '0:0', '1:0', '2:0',
+      '0:1', '1:1', '2:1'
+    ]);
+    expect(forestSceneCellIdsForViewport(
+      { x: 0, y: 0, width: 100, height: 100 }, world, 480, 1
+    )).toEqual(['0:0', '1:0', '0:1', '1:1']);
+    const placements = [
+      { worldX: 10, worldY: 10, assetKey: 'shared' },
+      { worldX: 20, worldY: 20, assetKey: 'cell-zero' },
+      { worldX: 500, worldY: 20, assetKey: 'shared' },
+      { worldX: 510, worldY: 20, assetKey: 'cell-one' },
+      { worldX: 20, worldY: 500, assetKey: 'outside' }
+    ];
+    expect(forestSceneAssetKeysForCells(
+      placements, ['0:0', '1:0'], 480, ['shared']
+    )).toEqual(['cell-zero', 'cell-one']);
+  });
+
+  it('prepares only assets required by a regional placement subset', () => {
+    const layout = generateForestSceneLayout({
+      seed: 'regional-assets', placementCount: 8, assetPoolSize: 4
+    });
+    const regionalPlacements = layout.placements.slice(0, 2);
+    const cold = prepareForestSceneAssets(regionalPlacements);
+    const warm = prepareForestSceneAssets(regionalPlacements);
+
+    expect(cold.assets.length).toBe(2);
+    expect(cold.diagnostics.generatedAssetCount).toBe(2);
+    expect(warm.diagnostics.generatedAssetCount).toBe(0);
+    expect(warm.diagnostics.reusedAssetCount).toBe(2);
+    expect(forestSceneAssetPoolSize()).toBe(2);
   });
 
   it('culls by scaled visual bounds and orders visible trees stably by ground Y', () => {

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -11,12 +11,27 @@ block content
   main.activity-forest
     header.activity-forest__header
       div
-        p.activity-forest__eyebrow Development preview
+        p.activity-forest__eyebrow= profile.pressure ? 'Development pressure test' : 'Development preview'
         h1 Activity Forest
+          if profile.pressure
+            |  — #{profile.label}
         p.activity-forest__lede
-          | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
-          | The grove remains deterministic and is composed from reusable procedural tree assets.
+          if profile.pressure
+            | #{profile.description} This mode is development-only and does not change the default grove.
+          else
+            | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
+            | The grove remains deterministic and is composed from reusable procedural tree assets.
       button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
+
+    nav.activity-forest__profiles(aria-label='Forest pressure configurations')
+      each availableProfile in pressureProfiles
+        a(
+          href=availableProfile.id === 'representative' ? '/__dev/views/activity-forest' : `/__dev/views/activity-forest?pressure=${availableProfile.id}`
+          aria-current=availableProfile.id === profile.id ? 'page' : null
+        )= availableProfile.label
+      a.activity-forest__cold(
+        href=`/__dev/views/activity-forest?pressure=${profile.id}&cold=1`
+      ) Repeat with cold server asset cache
 
     p#activity-forest-help.activity-forest__help
       | Move with arrow keys or WASD, or touch and drag in the forest. Near a tree, inspect its writing.
@@ -47,7 +62,31 @@ block content
         dd= scene.placements.length
       div
         dt Unique assets
+        dd= scene.assetLoading.totalAssetCount
+      div
+        dt Initial assets
         dd= scene.assets.length
+      div
+        dt Payload
+        dd #{serverDiagnostics.serializedPayloadBytes.toLocaleString()} bytes
+      div
+        dt Server preparation
+        dd #{serverDiagnostics.durationMilliseconds.toFixed(1)} ms
+      div
+        dt Server assets
+        dd #{serverDiagnostics.generatedAssetCount} generated / #{serverDiagnostics.reusedAssetCount} reused initially
+      div
+        dt Browser preparation
+        dd(data-forest-sprite-duration) —
+      div
+        dt Prepared canvases
+        dd(data-forest-prepared) —
+      div
+        dt Regional loading
+        dd(data-forest-region-loading) —
+      div
+        dt First scene render
+        dd(data-forest-first-render) —
       div
         dt Visible
         dd(data-forest-visible) —
@@ -63,6 +102,12 @@ block content
       div
         dt Last render
         dd(data-forest-duration) —
+      div
+        dt Movement renders
+        dd(data-forest-movement-duration) No movement frames yet
+      div
+        dt Unseen-region entry
+        dd(data-forest-region-entry) Walk beyond the initial view
 
     dialog.activity-forest__dialog(data-forest-dialog aria-labelledby='forest-post-title')
       p.activity-forest__dialog-eyebrow A writing remembered here


### PR DESCRIPTION
## Summary

Add a development-only pressure-testing mode and regional asset-loading strategy for the Activity Forest.

The forest now sends its complete placement manifest initially while preparing only assets near the spawn. As the player moves, the browser prefetches assets for the camera viewport and a one-cell surrounding ring.

## Why

Pressure testing showed that eager loading scaled primarily with the number of unique tree assets:

- 180 unique assets produced a roughly 24.8 MB initial payload.
- Cold server preparation took approximately 6 seconds.
- Time to first render approached 7 seconds.

Movement rendering and viewport culling remained fast, indicating that asset generation and delivery—not Canvas rendering—were the primary bottlenecks.

## Changes

- Add development-only pressure profiles for:
  - 180 placements / up to 16 assets
  - 180 placements / 60 assets
  - 180 placements / 180 assets
  - 600 placements / 60 assets
- Add diagnostics for:
  - Serialized payload size
  - Server asset preparation
  - Browser sprite preparation
  - Time to first render
  - Prepared and visible asset counts
  - Movement render durations
  - Previously unseen region entry
  - Regional request size and timing
- Partition scenes into deterministic 480-pixel cells.
- Include only spawn-region assets in the initial response.
- Prefetch cells covering the viewport plus a one-cell ring.
- Prepare regional sprites in small idle-time batches.
- Retain prepared assets for the page lifetime without eviction.
- Skip regional requests when every required asset is already prepared.
- Validate requested cells and asset keys on the development endpoint.
- Preserve the existing controls, collision behavior, culling, and Canvas renderer.
- Document the measurements, architecture, and deferred optimization options.

## Results

Local browser measurements improved substantially:

| Profile | Eager first render | Regional first render | Eager payload | Regional initial payload |
| --- | ---: | ---: | ---: | ---: |
| 180 unique assets | ~7.0 s | ~2.2 s | 24.8 MB | 5.1 MB |
| 600 placements / 60 assets | ~2.4 s | ~0.9 s | 8.4 MB | 2.6 MB |

Movement renders remained approximately 2–4 ms on average, and region-entry frame gaps stayed near a normal 16 ms frame.

These measurements are device-local and intended as architectural guidance rather than universal benchmarks.

## Non-goals

This change does not add:

- Asset eviction
- WebGL
- Texture atlases
- Persistent asset storage
- A generalized loading framework
- Raster-format transport

Compact raster transport remains a possible follow-up optimization.

## Testing

- 49 relevant forest specs passing
- ESLint passing
- Activity Forest Pug template compiles
- Regional endpoint contract and validation checked
- `git diff --check` passing