### PR TITLE
Add lossless raster transport experiment for Activity Forest

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -255,11 +255,12 @@ placement manifest, but only nearby JSON-round-tripped runtime assets. Many plac
 each asset; generation results and branch diagnostics never cross the scene boundary. The cache
 lives only for the server module/process lifetime and is not production persistence.
 
-The browser draws the prepared scene into one visible Canvas. As each runtime asset arrives, it is
-rasterized once into a small offscreen Canvas in its declared layer order. Placements reuse prepared
-bitmaps, reducing ordinary scene draws
-from thousands of color-run operations per tree to one `drawImage` call per visible tree. These
-offscreen surfaces are per asset, never per placement, and are discarded with the page.
+The browser draws the prepared scene into one visible Canvas. As each runtime asset arrives, its
+three ordered layers are prepared once as small offscreen surfaces. Placements reuse those surfaces,
+reducing ordinary scene draws from thousands of color-run operations per tree to three `drawImage`
+calls per visible tree. The distinct rear-foliage, wood, and front-foliage surfaces remain available
+for later layer-level motion. These surfaces are per asset, never per placement, and are discarded
+with the page.
 Browser-independent math derives each scaled visual rectangle from the asset bounds and ground
 anchor, culls it against the camera, and orders visible placements by ground Y with stable id
 tie-breaking. Integer scaling and disabled image smoothing preserve crisp pixels. Keyboard,
@@ -330,6 +331,36 @@ staging alone improves startup and whether the preload ring prevents region-entr
 raster transport may be evaluated separately if JSON color-run payloads remain material. Asset
 eviction, WebGL, atlases, and generalized loading remain out of scope until further evidence and
 explicit approval.
+
+### Development lossless-raster transport experiment
+
+The Activity Forest route offers a development-only transport selector alongside every pressure
+profile. `color-runs` remains the calm representative scene's default. The experimental
+`lossless-raster` option leaves the placement manifest and versioned runtime identity unchanged but
+replaces each asset's run arrays with three transparent, lossless PNG payloads carried as base64 in
+the existing initial and regional JSON responses. Raster assets retain the schema, renderer,
+phenotype, seed, cache key, dimensions, bounds, anchor, architectural identity, and ordered
+`rear-foliage`, `wood`, and `front-foliage` layer ids. They deliberately do not combine those layers
+into a single image.
+
+The scene asset pool still caches run-based runtime assets by the tree asset's existing versioned
+cache key. A separate process-local raster cache stores the encoded projection under that exact same
+key, so renderer, phenotype, schema, or seed changes naturally invalidate both representations.
+The explicit cold-cache link clears both caches. There is no eviction or persistence.
+
+For each initial response and regional request, diagnostics separate procedural generation time
+from transport encoding time and report the exact UTF-8 byte size of the encoded asset array. The
+browser separately reports JSON response decoding, PNG image decoding, layer preparation, fetch
+time, first completed scene render, regional entry behavior, and the existing last/average/maximum
+movement-render measurements. Color runs follow the same three-layer preparation and draw path, so
+the selector compares transport and browser preparation costs without changing layout, culling,
+depth ordering, exploration, or the default scene. These measurements remain local observations;
+compare repeated cold and warm runs for each pressure profile on the intended baseline device.
+
+The experiment intentionally does not add WebGL, atlases, eviction, persistent storage, a production
+route, or flattened animation layers. Its purpose is to determine whether lossless raster transport
+materially improves encoded bytes and browser preparation enough to justify a later production
+design decision.
 
 The restrained world-space ground treatment and corridor exist only to make depth and negative
 space legible. This first camera is deliberately orthographic: terrain and trees share the same

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -16,7 +16,9 @@ const canvas = document.querySelector('[data-forest-canvas]');
 
 if (payload && viewportElement && canvas) {
   const scriptStartedAt = window.performance.now();
+  const initialResponseDecodeStartedAt = window.performance.now();
   const scene = JSON.parse(payload.textContent);
+  const initialResponseDecodeDuration = window.performance.now() - initialResponseDecodeStartedAt;
   const assetsByKey = new Map();
   const fixturesById = new Map(scene.exploration.fixtures.map((fixture) => [fixture.id, fixture]));
   const context = canvas.getContext('2d');
@@ -35,6 +37,7 @@ if (payload && viewportElement && canvas) {
     player: document.querySelector('[data-forest-player]'),
     focus: document.querySelector('[data-forest-focus]'),
     duration: document.querySelector('[data-forest-duration]'),
+    decodeDuration: document.querySelector('[data-forest-decode-duration]'),
     spriteDuration: document.querySelector('[data-forest-sprite-duration]'),
     prepared: document.querySelector('[data-forest-prepared]'),
     firstRender: document.querySelector('[data-forest-first-render]'),
@@ -57,28 +60,59 @@ if (payload && viewportElement && canvas) {
   let regionRetryAfter = 0;
   let regionalRequestActive = false;
 
-  function prepareRuntimeAssets(assets) {
-    let preparedCount = 0;
-    for (const asset of assets) {
-      if (spritesByKey.has(asset.cacheKey)) continue;
-      const sprite = document.createElement('canvas');
-      sprite.width = asset.dimensions.width;
-      sprite.height = asset.dimensions.height;
-      const spriteContext = sprite.getContext('2d');
-      spriteContext.imageSmoothingEnabled = false;
-      for (const layer of asset.layers) {
+  function rasterLayerSource(layer) {
+    const binary = window.atob(layer.data);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return new Blob([bytes], { type: layer.mediaType });
+  }
+
+  async function decodeRasterLayer(layer) {
+    const source = rasterLayerSource(layer);
+    if (window.createImageBitmap) return window.createImageBitmap(source);
+    return new Promise((resolve, reject) => {
+      const image = new Image();
+      const url = URL.createObjectURL(source);
+      image.onload = () => {
+        URL.revokeObjectURL(url);
+        resolve(image);
+      };
+      image.onerror = () => {
+        URL.revokeObjectURL(url);
+        reject(new Error('Lossless forest raster decoding failed.'));
+      };
+      image.src = url;
+    });
+  }
+
+  async function prepareRuntimeAsset(asset) {
+    if (spritesByKey.has(asset.cacheKey)) return { preparedCount: 0, decodeDuration: 0 };
+    let decodeDuration = 0;
+    const layerSprites = [];
+    for (const layer of asset.layers) {
+      let sprite;
+      if (layer.runs) {
+        sprite = document.createElement('canvas');
+        sprite.width = asset.dimensions.width;
+        sprite.height = asset.dimensions.height;
+        const spriteContext = sprite.getContext('2d');
+        spriteContext.imageSmoothingEnabled = false;
         for (const run of layer.runs) {
           spriteContext.fillStyle = run.color;
           spriteContext.fillRect(run.x, run.y, run.width, 1);
         }
+      } else {
+        const decodeStartedAt = window.performance.now();
+        sprite = await decodeRasterLayer(layer);
+        decodeDuration += window.performance.now() - decodeStartedAt;
       }
-      assetsByKey.set(asset.cacheKey, asset);
-      spritesByKey.set(asset.cacheKey, sprite);
-      preparedCount += 1;
+      layerSprites.push({ id: layer.id, sprite });
     }
+    assetsByKey.set(asset.cacheKey, asset);
+    spritesByKey.set(asset.cacheKey, layerSprites);
     diagnostics.prepared.textContent = `${spritesByKey.size} / ${
-      scene.assetLoading.totalAssetCount} asset canvases`;
-    return preparedCount;
+      scene.assetLoading.totalAssetCount} assets · ${spritesByKey.size * 3} layer sprites`;
+    return { preparedCount: 1, decodeDuration };
   }
 
   function waitForAssetPreparationTime() {
@@ -93,26 +127,34 @@ if (payload && viewportElement && canvas) {
 
   async function prepareRegionalRuntimeAssets(assets) {
     let activeDuration = 0;
+    let decodeDuration = 0;
     let batchDuration = 0;
     let preparedCount = 0;
     for (const [index, asset] of assets.entries()) {
       const assetStartedAt = window.performance.now();
-      preparedCount += prepareRuntimeAssets([asset]);
+      const prepared = await prepareRuntimeAsset(asset);
+      preparedCount += prepared.preparedCount;
+      decodeDuration += prepared.decodeDuration;
       const assetDuration = window.performance.now() - assetStartedAt;
-      activeDuration += assetDuration;
-      batchDuration += assetDuration;
+      const preparationDuration = Math.max(0, assetDuration - prepared.decodeDuration);
+      activeDuration += preparationDuration;
+      batchDuration += preparationDuration;
       if (batchDuration >= 6 && index < assets.length - 1) {
         await waitForAssetPreparationTime();
         batchDuration = 0;
       }
     }
-    return { activeDuration, preparedCount };
+    return { activeDuration, decodeDuration, preparedCount };
   }
 
   const spritePreparationStartedAt = window.performance.now();
-  prepareRuntimeAssets(scene.assets);
-  const spritePreparationDuration = window.performance.now() - spritePreparationStartedAt;
-  diagnostics.spriteDuration.textContent = `${spritePreparationDuration.toFixed(1)} ms initial`;
+  const initialPreparation = await prepareRegionalRuntimeAssets(scene.assets);
+  const initialPreparationElapsed = window.performance.now() - spritePreparationStartedAt;
+  const spritePreparationDuration = initialPreparation.activeDuration;
+  diagnostics.decodeDuration.textContent = `${initialResponseDecodeDuration.toFixed(1)} ms JSON + ${
+    initialPreparation.decodeDuration.toFixed(1)} ms ${scene.assetLoading.transport} initial`;
+  diagnostics.spriteDuration.textContent = `${spritePreparationDuration.toFixed(1)} ms active / ${
+    initialPreparationElapsed.toFixed(1)} ms elapsed initial`;
 
   function updateRegionLoading(message = '') {
     diagnostics.regionLoading.textContent = `${loadedCellIds.size} / ${totalCellCount} cells loaded · ${
@@ -151,24 +193,32 @@ if (payload && viewportElement && canvas) {
     try {
       const query = new URLSearchParams({
         pressure: scene.assetLoading.profileId,
+        transport: scene.assetLoading.transport,
         cells: missingCellIds.join(','),
         assetKeys: missingAssetKeys.join(',')
       });
       const response = await window.fetch(`/__dev/api/activity-forest/assets?${query}`);
       if (!response.ok) throw new Error(`Regional asset request failed (${response.status}).`);
+      const responseDecodeStartedAt = window.performance.now();
       const region = await response.json();
+      const responseDecodeDuration = window.performance.now() - responseDecodeStartedAt;
       const responseReceivedAt = window.performance.now();
       const {
         activeDuration: preparationDuration,
+        decodeDuration,
         preparedCount
       } = await prepareRegionalRuntimeAssets(region.assets);
       region.cellIds.forEach((cellId) => loadedCellIds.add(cellId));
       diagnostics.spriteDuration.textContent = `${spritePreparationDuration.toFixed(1)} ms initial / ${
         preparationDuration.toFixed(1)} ms last regional`;
+      diagnostics.decodeDuration.textContent = `${initialResponseDecodeDuration.toFixed(1)} ms JSON + ${
+        initialPreparation.decodeDuration.toFixed(1)} ms image initial / ${
+        responseDecodeDuration.toFixed(1)} ms JSON + ${decodeDuration.toFixed(1)} ms image regional`;
       completionMessage = `${preparedCount} new assets · ${
-        region.serverPreparation.serializedAssetBytes.toLocaleString()} bytes · ${
+        region.serverPreparation.encodedPayloadBytes.toLocaleString()} bytes · ${
         (responseReceivedAt - requestStartedAt).toFixed(1)} ms fetch · ${
-        region.serverPreparation.durationMilliseconds.toFixed(1)} ms server`;
+        region.serverPreparation.generationDurationMilliseconds.toFixed(1)} ms generate · ${
+        region.serverPreparation.encodingDurationMilliseconds.toFixed(1)} ms encode`;
       updateFocus();
       requestRender();
     } catch (error) {
@@ -234,8 +284,10 @@ if (payload && viewportElement && canvas) {
       context.lineWidth = 2;
       context.stroke();
     }
-    context.drawImage(spritesByKey.get(placement.assetKey), originX, originY,
-      asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+    for (const { sprite } of spritesByKey.get(placement.assetKey)) {
+      context.drawImage(sprite, originX, originY,
+        asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+    }
   }
 
   function paintPlayer() {

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -7,6 +7,12 @@ import {
   clearForestSceneAssetPool,
   prepareForestSceneAssets
 } from '../services/forestSceneAssetPool.js';
+import {
+  clearForestSceneRasterAssetCache,
+  encodeForestSceneAssets,
+  FOREST_ASSET_TRANSPORT_RASTER,
+  resolveForestAssetTransport
+} from '../services/forestSceneAssetTransport.js';
 import { generateForestSceneLayout } from '../services/forestSceneLayout.js';
 import { createForestExploration } from '../services/forestSceneExploration.js';
 import {
@@ -138,8 +144,9 @@ router.get(
 
 router.get(
   '/__dev/api/activity-forest/assets',
-  (req, res) => {
+  async (req, res) => {
     const profile = resolveForestPressureProfile(req.query.pressure);
+    const transport = resolveForestAssetTransport(req.query.transport);
     const scene = forestSceneForProfile(profile);
     const cellIds = validRequestedForestCellIds(req.query.cells, scene.world);
     if (!cellIds.length) return res.status(400).json({ error: 'Valid forest cells are required.' });
@@ -148,18 +155,25 @@ router.get(
       return res.status(400).json({ error: 'Valid unloaded forest assets are required.' });
     }
     const requestedAssetKeys = new Set(assetKeys);
-    const { assets, diagnostics } = prepareForestSceneAssets(
+    const { assets: runtimeAssets, diagnostics } = prepareForestSceneAssets(
       placementsInForestCells(scene, cellIds).filter(
         ({ assetKey }) => requestedAssetKeys.has(assetKey)
       )
     );
+    const { assets, diagnostics: encoding } = await encodeForestSceneAssets(
+      runtimeAssets, transport
+    );
     res.set('Cache-Control', 'no-store');
     return res.json({
       cellIds,
+      transport,
       assets,
       serverPreparation: {
         ...diagnostics,
-        serializedAssetBytes: Buffer.byteLength(JSON.stringify(assets), 'utf8')
+        encodingDurationMilliseconds: encoding.durationMilliseconds,
+        encodedAssetCount: encoding.encodedAssetCount,
+        reusedEncodedAssetCount: encoding.reusedEncodedAssetCount,
+        encodedPayloadBytes: encoding.encodedPayloadBytes
       }
     });
   }
@@ -168,20 +182,28 @@ router.get(
 router.get(
   '/__dev/views/activity-forest',
   optionalAuth,
-  (req, res) => {
+  async (req, res) => {
     const profile = resolveForestPressureProfile(req.query.pressure);
+    const transport = resolveForestAssetTransport(req.query.transport);
     const coldPreparationRequested = req.query.cold === '1';
-    if (coldPreparationRequested) clearForestSceneAssetPool();
+    if (coldPreparationRequested) {
+      clearForestSceneAssetPool();
+      clearForestSceneRasterAssetCache();
+    }
     const layout = forestSceneForProfile(profile);
     const initialCellIds = initialForestCellIds(layout);
-    const { assets, diagnostics: preparation } = prepareForestSceneAssets(
+    const { assets: runtimeAssets, diagnostics: preparation } = prepareForestSceneAssets(
       placementsInForestCells(layout, initialCellIds)
+    );
+    const { assets, diagnostics: encoding } = await encodeForestSceneAssets(
+      runtimeAssets, transport
     );
     const scene = JSON.parse(JSON.stringify({
       ...layout,
       assets,
       assetLoading: {
         strategy: 'regional',
+        transport,
         profileId: profile.id,
         cellSize: FOREST_SCENE_CELL_SIZE,
         preloadCellCount: FOREST_SCENE_PRELOAD_CELL_COUNT,
@@ -191,6 +213,10 @@ router.get(
     }));
     const serverDiagnostics = {
       ...preparation,
+      encodingDurationMilliseconds: encoding.durationMilliseconds,
+      encodedAssetCount: encoding.encodedAssetCount,
+      reusedEncodedAssetCount: encoding.reusedEncodedAssetCount,
+      encodedAssetBytes: encoding.encodedPayloadBytes,
       serializedPayloadBytes: serializedForestSceneBytes(scene),
       coldPreparationRequested
     };
@@ -201,6 +227,7 @@ router.get(
       uiLang: res.locals.uiLang,
       scene,
       profile,
+      rasterTransport: FOREST_ASSET_TRANSPORT_RASTER,
       pressureProfiles: FOREST_PRESSURE_PROFILES,
       serverDiagnostics
     });

--- a/server/services/forestSceneAssetPool.js
+++ b/server/services/forestSceneAssetPool.js
@@ -26,9 +26,11 @@ export function prepareForestSceneAssets(placements) {
   const assets = [];
   const required = new Map(placements.map((placement) => [placement.assetKey, placement]));
   let generatedAssetCount = 0;
+  let generationDurationMilliseconds = 0;
 
   for (const [assetKey, placement] of required) {
     if (!sceneAssetCache.has(assetKey)) {
+      const generationStartedAt = performance.now();
       const phenotype = phenotypesById.get(placement.phenotypeId);
       if (!phenotype) throw new Error(`Unknown forest phenotype: ${placement.phenotypeId}`);
       const asset = generateForestTreeAssetV3(
@@ -38,6 +40,7 @@ export function prepareForestSceneAssets(placements) {
       if (asset.cacheKey !== assetKey) throw new Error('Prepared tree asset identity mismatch.');
       sceneAssetCache.set(assetKey, asset);
       generatedAssetCount += 1;
+      generationDurationMilliseconds += performance.now() - generationStartedAt;
     }
     assets.push(sceneAssetCache.get(assetKey));
   }
@@ -46,6 +49,7 @@ export function prepareForestSceneAssets(placements) {
     assets: JSON.parse(JSON.stringify(assets)),
     diagnostics: {
       durationMilliseconds: performance.now() - startedAt,
+      generationDurationMilliseconds,
       generatedAssetCount,
       reusedAssetCount: required.size - generatedAssetCount,
       preparedAssetCount: required.size

--- a/server/services/forestSceneAssetTransport.js
+++ b/server/services/forestSceneAssetTransport.js
@@ -1,0 +1,111 @@
+import { performance } from 'node:perf_hooks';
+
+import sharp from 'sharp';
+
+export const FOREST_ASSET_TRANSPORT_RUNS = 'color-runs';
+export const FOREST_ASSET_TRANSPORT_RASTER = 'lossless-raster';
+
+const rasterAssetCache = new Map();
+
+export function resolveForestAssetTransport(value) {
+  return value === FOREST_ASSET_TRANSPORT_RASTER
+    ? FOREST_ASSET_TRANSPORT_RASTER : FOREST_ASSET_TRANSPORT_RUNS;
+}
+
+export function clearForestSceneRasterAssetCache() {
+  rasterAssetCache.clear();
+}
+
+export function forestSceneRasterAssetCacheSize() {
+  return rasterAssetCache.size;
+}
+
+function colorChannels(color) {
+  const value = color.startsWith('#') ? color.slice(1) : color;
+  if (value.length === 3) {
+    return [...value].map(channel => Number.parseInt(`${channel}${channel}`, 16));
+  }
+  if (value.length === 6) {
+    return [0, 2, 4].map(index => Number.parseInt(value.slice(index, index + 2), 16));
+  }
+  throw new Error(`Unsupported forest raster color: ${color}`);
+}
+
+function layerPixels(layer, dimensions) {
+  const pixels = Buffer.alloc(dimensions.width * dimensions.height * 4);
+  for (const run of layer.runs) {
+    const [red, green, blue] = colorChannels(run.color);
+    for (let x = run.x; x < run.x + run.width; x += 1) {
+      const offset = ((run.y * dimensions.width) + x) * 4;
+      pixels[offset] = red;
+      pixels[offset + 1] = green;
+      pixels[offset + 2] = blue;
+      pixels[offset + 3] = 255;
+    }
+  }
+  return pixels;
+}
+
+async function encodeRasterLayer(layer, dimensions) {
+  const png = await sharp(layerPixels(layer, dimensions), {
+    raw: { ...dimensions, channels: 4 }
+  }).png({ compressionLevel: 9 }).toBuffer();
+  return {
+    id: layer.id,
+    mediaType: 'image/png',
+    encoding: 'base64',
+    data: png.toString('base64')
+  };
+}
+
+async function encodeRasterAsset(asset) {
+  const { layers, ...metadata } = asset;
+  return {
+    ...metadata,
+    transport: FOREST_ASSET_TRANSPORT_RASTER,
+    layers: await Promise.all(layers.map(layer => encodeRasterLayer(layer, asset.dimensions)))
+  };
+}
+
+export async function encodeForestSceneAssets(assets, transport) {
+  const startedAt = performance.now();
+  let encodedAssetCount = 0;
+  let reusedEncodedAssetCount = 0;
+  let transportedAssets = assets;
+
+  if (transport === FOREST_ASSET_TRANSPORT_RASTER) {
+    transportedAssets = [];
+    for (const asset of assets) {
+      if (!rasterAssetCache.has(asset.cacheKey)) {
+        rasterAssetCache.set(asset.cacheKey, encodeRasterAsset(asset));
+        encodedAssetCount += 1;
+      } else {
+        reusedEncodedAssetCount += 1;
+      }
+      const cached = rasterAssetCache.get(asset.cacheKey);
+      try {
+        const rasterAsset = await cached;
+        if (rasterAssetCache.get(asset.cacheKey) === cached) {
+          rasterAssetCache.set(asset.cacheKey, rasterAsset);
+        }
+        transportedAssets.push(rasterAsset);
+      } catch (error) {
+        if (rasterAssetCache.get(asset.cacheKey) === cached) {
+          rasterAssetCache.delete(asset.cacheKey);
+        }
+        throw error;
+      }
+    }
+  }
+
+  const serialized = JSON.stringify(transportedAssets);
+  return {
+    assets: transportedAssets,
+    diagnostics: {
+      durationMilliseconds: performance.now() - startedAt,
+      encodedAssetCount,
+      reusedEncodedAssetCount,
+      encodedPayloadBytes: Buffer.byteLength(serialized, 'utf8')
+    }
+  };
+}

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -11,6 +11,15 @@ import {
   prepareForestSceneWithDiagnostics
 } from '../server/services/forestSceneAssetPool.js';
 import {
+  clearForestSceneRasterAssetCache,
+  encodeForestSceneAssets,
+  FOREST_ASSET_TRANSPORT_RASTER,
+  FOREST_ASSET_TRANSPORT_RUNS,
+  forestSceneRasterAssetCacheSize,
+  resolveForestAssetTransport
+} from '../server/services/forestSceneAssetTransport.js';
+import sharp from 'sharp';
+import {
   FOREST_PRESSURE_PROFILES,
   resolveForestPressureProfile,
   serializedForestSceneBytes
@@ -35,7 +44,10 @@ import {
 } from '../server/services/forestSceneExploration.js';
 
 describe('static Activity Forest scene', () => {
-  beforeEach(() => clearForestSceneAssetPool());
+  beforeEach(() => {
+    clearForestSceneAssetPool();
+    clearForestSceneRasterAssetCache();
+  });
 
   it('generates exactly serializable deterministic placements', () => {
     const first = generateForestSceneLayout();
@@ -127,6 +139,7 @@ describe('static Activity Forest scene', () => {
     const warm = prepareForestSceneWithDiagnostics(layout);
 
     expect(cold.diagnostics.generatedAssetCount).toBe(4);
+    expect(cold.diagnostics.generationDurationMilliseconds).toBeGreaterThanOrEqual(0);
     expect(cold.diagnostics.reusedAssetCount).toBe(0);
     expect(cold.diagnostics.preparedAssetCount).toBe(4);
     expect(cold.diagnostics.durationMilliseconds).toBeGreaterThanOrEqual(0);
@@ -134,6 +147,80 @@ describe('static Activity Forest scene', () => {
     expect(warm.diagnostics.reusedAssetCount).toBe(4);
     expect(serializedForestSceneBytes(cold.scene))
       .toBe(Buffer.byteLength(JSON.stringify(cold.scene), 'utf8'));
+  });
+
+  it('encodes and caches deterministic lossless layer rasters by versioned asset key', async () => {
+    const layout = generateForestSceneLayout({
+      seed: 'raster-transport', placementCount: 1, assetPoolSize: 1
+    });
+    const [runtimeAsset] = prepareForestSceneAssets(layout.placements).assets;
+    const cold = await encodeForestSceneAssets(
+      [runtimeAsset], FOREST_ASSET_TRANSPORT_RASTER
+    );
+    const warm = await encodeForestSceneAssets(
+      [runtimeAsset], FOREST_ASSET_TRANSPORT_RASTER
+    );
+    clearForestSceneRasterAssetCache();
+    const repeated = await encodeForestSceneAssets(
+      [runtimeAsset], FOREST_ASSET_TRANSPORT_RASTER
+    );
+    const [rasterAsset] = cold.assets;
+
+    expect(rasterAsset.cacheKey).toBe(runtimeAsset.cacheKey);
+    expect(rasterAsset.dimensions).toEqual(runtimeAsset.dimensions);
+    expect(rasterAsset.bounds).toEqual(runtimeAsset.bounds);
+    expect(rasterAsset.anchor).toEqual(runtimeAsset.anchor);
+    expect(rasterAsset.identity).toEqual(runtimeAsset.identity);
+    expect(rasterAsset.layers.map(({ id }) => id)).toEqual([
+      'rear-foliage', 'wood', 'front-foliage'
+    ]);
+    expect(rasterAsset.layers.every(layer => (
+      layer.mediaType === 'image/png' && layer.encoding === 'base64' && !layer.runs
+    ))).toBeTrue();
+    expect(cold.diagnostics.encodedAssetCount).toBe(1);
+    expect(cold.diagnostics.reusedEncodedAssetCount).toBe(0);
+    expect(warm.diagnostics.encodedAssetCount).toBe(0);
+    expect(warm.diagnostics.reusedEncodedAssetCount).toBe(1);
+    expect(warm.assets).toEqual(cold.assets);
+    expect(repeated.assets).toEqual(cold.assets);
+    expect(forestSceneRasterAssetCacheSize()).toBe(1);
+    expect(cold.diagnostics.encodedPayloadBytes)
+      .toBe(Buffer.byteLength(JSON.stringify(cold.assets), 'utf8'));
+
+    for (const [index, layer] of rasterAsset.layers.entries()) {
+      const { data, info } = await sharp(Buffer.from(layer.data, 'base64')).raw().toBuffer({
+        resolveWithObject: true
+      });
+      const expected = Buffer.alloc(data.length);
+      for (const run of runtimeAsset.layers[index].runs) {
+        const color = run.color.slice(1);
+        const channels = color.length === 3
+          ? [...color].map(value => Number.parseInt(`${value}${value}`, 16))
+          : [0, 2, 4].map(offset => Number.parseInt(color.slice(offset, offset + 2), 16));
+        for (let x = run.x; x < run.x + run.width; x += 1) {
+          const offset = ((run.y * info.width) + x) * info.channels;
+          expected.set([...channels, 255], offset);
+        }
+      }
+      expect(info.width).toBe(runtimeAsset.dimensions.width);
+      expect(info.height).toBe(runtimeAsset.dimensions.height);
+      expect(data).toEqual(expected);
+    }
+  });
+
+  it('keeps color runs as the default development transport with exact bytes', async () => {
+    const layout = generateForestSceneLayout({
+      seed: 'run-transport', placementCount: 1, assetPoolSize: 1
+    });
+    const assets = prepareForestSceneAssets(layout.placements).assets;
+    const encoded = await encodeForestSceneAssets(assets, FOREST_ASSET_TRANSPORT_RUNS);
+
+    expect(resolveForestAssetTransport('unknown')).toBe(FOREST_ASSET_TRANSPORT_RUNS);
+    expect(resolveForestAssetTransport(FOREST_ASSET_TRANSPORT_RASTER))
+      .toBe(FOREST_ASSET_TRANSPORT_RASTER);
+    expect(encoded.assets).toBe(assets);
+    expect(encoded.diagnostics.encodedPayloadBytes)
+      .toBe(Buffer.byteLength(JSON.stringify(assets), 'utf8'));
   });
 
   it('partitions the world into stable cells with a clamped preload ring', () => {

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -26,12 +26,22 @@ block content
     nav.activity-forest__profiles(aria-label='Forest pressure configurations')
       each availableProfile in pressureProfiles
         a(
-          href=availableProfile.id === 'representative' ? '/__dev/views/activity-forest' : `/__dev/views/activity-forest?pressure=${availableProfile.id}`
+          href=`/__dev/views/activity-forest?pressure=${availableProfile.id}&transport=${scene.assetLoading.transport}`
           aria-current=availableProfile.id === profile.id ? 'page' : null
         )= availableProfile.label
       a.activity-forest__cold(
-        href=`/__dev/views/activity-forest?pressure=${profile.id}&cold=1`
+        href=`/__dev/views/activity-forest?pressure=${profile.id}&transport=${scene.assetLoading.transport}&cold=1`
       ) Repeat with cold server asset cache
+
+    nav.activity-forest__profiles(aria-label='Forest asset transport')
+      a(
+        href=`/__dev/views/activity-forest?pressure=${profile.id}&transport=color-runs`
+        aria-current=scene.assetLoading.transport === 'color-runs' ? 'page' : null
+      ) JSON color runs
+      a(
+        href=`/__dev/views/activity-forest?pressure=${profile.id}&transport=${rasterTransport}`
+        aria-current=scene.assetLoading.transport === rasterTransport ? 'page' : null
+      ) Lossless raster experiment
 
     p#activity-forest-help.activity-forest__help
       | Move with arrow keys or WASD, or touch and drag in the forest. Near a tree, inspect its writing.
@@ -67,14 +77,29 @@ block content
         dt Initial assets
         dd= scene.assets.length
       div
+        dt Transport
+        dd= scene.assetLoading.transport
+      div
         dt Payload
         dd #{serverDiagnostics.serializedPayloadBytes.toLocaleString()} bytes
       div
-        dt Server preparation
-        dd #{serverDiagnostics.durationMilliseconds.toFixed(1)} ms
+        dt Encoded asset bytes
+        dd #{serverDiagnostics.encodedAssetBytes.toLocaleString()} bytes
+      div
+        dt Server generation
+        dd #{serverDiagnostics.generationDurationMilliseconds.toFixed(1)} ms
+      div
+        dt Server encoding
+        dd #{serverDiagnostics.encodingDurationMilliseconds.toFixed(1)} ms
       div
         dt Server assets
         dd #{serverDiagnostics.generatedAssetCount} generated / #{serverDiagnostics.reusedAssetCount} reused initially
+      div
+        dt Server raster encodings
+        dd #{serverDiagnostics.encodedAssetCount} encoded / #{serverDiagnostics.reusedEncodedAssetCount} reused initially
+      div
+        dt Browser decoding
+        dd(data-forest-decode-duration) —
       div
         dt Browser preparation
         dd(data-forest-sprite-duration) —


### PR DESCRIPTION
## Summary

Adds a development-only lossless raster transport experiment for Activity Forest.

The existing JSON color-run transport remains available as the default and comparison control. The new transport encodes each runtime tree asset as three transparent lossless PNG layers:

- Rear foliage
- Wood
- Front foliage

Asset identity, dimensions, bounds, anchors, deterministic generation, regional loading, exploration controls, and the calm default scene remain unchanged.

## Implementation

- Adds a `lossless-raster` transport alongside `color-runs`.
- Uses the existing versioned tree asset key to cache encoded raster results in memory.
- Preserves separate animation-ready rear-foliage, wood, and front-foliage layers.
- Uses the existing initial and regional JSON request flow.
- Adds transport controls to every development pressure profile.
- Keeps color runs as a correctness and performance comparison path.
- Clears both runtime and encoded caches through the existing cold-cache control.

## Diagnostics

The development scene now reports:

- Server generation time
- Server transport-encoding time
- Generated and reused runtime assets
- Encoded and reused raster assets
- Exact encoded asset bytes
- Total scene payload bytes
- Browser JSON and image-decoding time
- Browser layer-preparation time
- Regional fetch and preparation behavior
- First completed scene render
- Last, average, and maximum movement-render duration
- Unseen-region entry behavior

## Results

Local pressure testing showed approximately:

- 95% smaller encoded asset payloads
- 16–20× smaller initial asset transport in the unique-assets profile
- Approximately 20× smaller encoded assets in the large-world profile
- Equivalent visible output and exploration behavior
- Comparable movement-render performance

PNG decoding costs more browser time than replaying color runs, but the transfer reduction makes lossless raster the leading production candidate. Color runs remain available while the raster path receives additional cold and slower-device validation.

## Scope

This change does not add:

- WebGL
- Texture atlases
- Cache eviction
- Persistent asset storage
- Production routes
- Flattened tree layers

## Testing

- Full test suite: 561 specs, 0 failures
- Focused forest transport and asset tests
- Exact PNG pixel equivalence with source color runs
- Deterministic encoding and warm-cache reuse
- Exact UTF-8 payload byte accounting
- ESLint
- Pug template compilation
- `git diff --check`