### PR TITLE
Allow same-origin LAN requests through CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,7 @@ import { titleOnlyMeta } from './server/utils/unfinished.js';
 import * as viewHelper from './server/utils/view.js'; // Utils
 
 import { initMongooseConnection } from './server/db/mongoose.js';
+import { corsOptionsDelegate } from './server/services/corsPolicy.js';
 import {
   getBlocksByRoomWithFallback,
   getTopBlocksWithFallback, getTrendingTagsWithFallback,
@@ -160,17 +161,6 @@ async function getSupportFundingViewModel() {
     });
     google.init();
 
-    const whitelist = ['https://dailypage.org', 'http://localhost:3000'];
-    const corsOptions = {
-      origin: (origin, callback) => {
-        if (whitelist.indexOf(origin) !== -1 || !origin) {
-          callback(null, true);
-        } else {
-          callback(new Error('Not allowed by CORS'));
-        }
-      },
-    };
-
     app.set('trust proxy', true);
 
     if (process.env.NODE_ENV === 'production') {
@@ -189,14 +179,14 @@ async function getSupportFundingViewModel() {
       res.set('Content-Security-Policy', "frame-src 'self' https://www.google.com;");
       next();
     });
-    app.use(cors(corsOptions));
+    app.use(cors(corsOptionsDelegate));
     app.use(uiPrefixAndLangContext);
     app.use(uiLangFallbackNotice);
     app.use(makePrefixRedirectMiddleware({ isLocalizedPath }))
     app.use(addSeoLocals);
     app.use(addHreflangLocals);
     app.use(initI18n(['layout', 'nav', 'modals', 'notifications', 'errors']));
-    app.options('*', cors(corsOptions));
+    app.options('*', cors(corsOptionsDelegate));
 
     app.use(express.static('public'));
     app.use(express.urlencoded({ extended: true }));

--- a/server/services/corsPolicy.js
+++ b/server/services/corsPolicy.js
@@ -1,0 +1,37 @@
+export const CORS_ALLOWED_ORIGINS = Object.freeze([
+  'https://dailypage.org',
+  'http://localhost:3000'
+]);
+
+function normalizedOrigin(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function requestOrigin(req) {
+  const host = req.get('host');
+  return host ? normalizedOrigin(`${req.protocol}://${host}`) : null;
+}
+
+export function corsOriginAllowed(origin, req) {
+  if (!origin) return true;
+  const normalized = normalizedOrigin(origin);
+  if (!normalized) return false;
+  return CORS_ALLOWED_ORIGINS.includes(normalized) || normalized === requestOrigin(req);
+}
+
+export function corsOptionsForRequest(req) {
+  return {
+    origin(origin, callback) {
+      if (corsOriginAllowed(origin, req)) callback(null, true);
+      else callback(new Error('Not allowed by CORS'));
+    }
+  };
+}
+
+export function corsOptionsDelegate(req, callback) {
+  callback(null, corsOptionsForRequest(req));
+}

--- a/spec/corsPolicySpec.js
+++ b/spec/corsPolicySpec.js
@@ -1,0 +1,65 @@
+import {
+  CORS_ALLOWED_ORIGINS,
+  corsOptionsForRequest,
+  corsOriginAllowed,
+  requestOrigin
+} from '../server/services/corsPolicy.js';
+
+function request(protocol, host) {
+  return {
+    protocol,
+    get(header) {
+      return header.toLowerCase() === 'host' ? host : undefined;
+    }
+  };
+}
+
+function evaluateOrigin(origin, req) {
+  return new Promise(resolve => {
+    corsOptionsForRequest(req).origin(origin, (error, allowed) => resolve({ error, allowed }));
+  });
+}
+
+describe('CORS policy', () => {
+  it('allows requests without an Origin header', () => {
+    expect(corsOriginAllowed(undefined, request('http', '192.168.1.20:3000'))).toBeTrue();
+  });
+
+  it('allows an origin matching the request protocol and LAN host', async () => {
+    const req = request('http', '192.168.1.20:3000');
+    const result = await evaluateOrigin('http://192.168.1.20:3000', req);
+
+    expect(requestOrigin(req)).toBe('http://192.168.1.20:3000');
+    expect(result).toEqual({ error: null, allowed: true });
+  });
+
+  it('uses the proxy-aware request protocol when checking the same host', () => {
+    const req = request('https', 'preview.example.test');
+
+    expect(corsOriginAllowed('https://preview.example.test', req)).toBeTrue();
+    expect(corsOriginAllowed('http://preview.example.test', req)).toBeFalse();
+  });
+
+  it('preserves explicitly allowed cross-origin clients', () => {
+    const req = request('https', 'api.example.test');
+
+    for (const origin of CORS_ALLOWED_ORIGINS) {
+      expect(corsOriginAllowed(origin, req)).toBeTrue();
+    }
+  });
+
+  it('rejects malformed origins and different hosts or ports', async () => {
+    const req = request('http', '192.168.1.20:3000');
+
+    for (const origin of [
+      'not an origin',
+      'http://192.168.1.21:3000',
+      'http://192.168.1.20:4000'
+    ]) {
+      const { error, allowed } = await evaluateOrigin(origin, req);
+      expect(error).toEqual(jasmine.any(Error));
+      expect(error.message).toBe('Not allowed by CORS');
+      expect(allowed).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Updates the global CORS policy to allow requests whose `Origin` exactly matches the protocol, host, and port serving the request.

This enables development pages opened through a LAN address—such as an iPhone accessing `http://192.168.x.x:3000`—to fetch their same-origin API resources successfully.

## Implementation

- Moves CORS policy construction into a focused service.
- Resolves CORS options per request.
- Allows exact same-origin requests using the request’s proxy-aware protocol and host.
- Preserves the existing explicit allowlist for approved cross-origin clients.
- Applies the policy to ordinary requests and preflight requests.
- Continues rejecting malformed origins and mismatched hosts, ports, or schemes.

## Security

This does not add a wildcard or broadly allow private-network origins. A LAN origin is accepted only when it exactly matches the server handling that request.

## Testing

- Added focused coverage for:
  - Requests without an `Origin` header
  - Same-origin LAN requests
  - Proxy-aware HTTPS requests
  - Existing explicitly allowed origins
  - Malformed and mismatched origins
- Full suite: 566 specs, 0 failures
- ESLint passed
- `git diff --check` passed

## Manual verification

Confirmed that an iPhone can load the development Activity Forest over the LAN and complete regional asset requests.