### PR TITLE
Add calm grouped ambient wind to Activity Forest

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -197,15 +197,22 @@ The recommended near-term technical sequence is:
 
 The procedural generation result is an authoring and diagnostic object. It retains the mutable inputs and derived architecture, three-dimensional branch graph, attraction points, termination diagnostics, foliage shoots and leaves, logical masks, shaded pixel grids, and compact color runs. Forest Lab needs this complete result to explain why a specimen has its shape, but a game-facing renderer does not.
 
-The runtime tree asset is a phenotype-independent, JSON-serializable projection built after generation. Schema version 1 contains:
+The runtime tree asset is a phenotype-independent, JSON-serializable projection built after generation. Schema version 2 contains:
 
 - asset schema version; renderer id and version; phenotype id and asset version
 - deterministic seed and the derived visual cache key
 - logical width and height, ground anchor, and occupied visual bounds
-- ordered `rear-foliage`, `wood`, and `front-foliage` horizontal color-run layers
+- ordered `rear-foliage`, `wood`, and `front-foliage` layers; each foliage layer contains up to
+  three branch-associated motion groups with horizontal color runs, an attachment point, and a
+  bounded wind-response description
 - limited architectural identity and maximum branch order for inspection and later composition
 
-It deliberately excludes masks, full pixel grids, nodes, segments, attraction points, diagnostics, leaves, shoots, and coverage cells. JSON stringify/parse is the serialization boundary: consumers render the parsed asset without procedural growth. Separate foliage and wood layers preserve depth order now and provide stable layer-level attachment points for future shared ambient motion or foliage-cluster metadata; no animation data is defined yet.
+It deliberately excludes masks, full pixel grids, nodes, segments, attraction points, diagnostics,
+leaves, shoots, and coverage cells. JSON stringify/parse is the serialization boundary: consumers
+render the parsed asset without procedural growth. The groups preserve only the minimal runtime
+information needed to move related foliage together; procedural branch and leaf data do not cross
+the asset boundary. Their attachment points leave room for a later model to test rotation or
+deformation without committing this experiment to those techniques.
 
 ### Identity, caching, and invalidation
 
@@ -239,7 +246,8 @@ The first composed development scene is available at `/__dev/views/activity-fore
 the isolated runtime assets into a deterministic 3000 × 1800 world containing 180 placements.
 The scene now includes the first fixture-only exploration loop: a deterministic player can walk
 the corridor, approach a tree, inspect fixture writing, close it, and continue from the same place.
-It remains a development preview without persistence, real post queries, or ambient animation.
+It also includes the first shared ambient wind slice. It remains a development preview without
+persistence or real post queries.
 
 `forestSceneLayout.js` owns scene layout version 1. A placement contains only a stable placement
 id, world-space ground anchor, integer scale, phenotype id, specimen seed, and versioned asset
@@ -255,12 +263,11 @@ placement manifest, but only nearby JSON-round-tripped runtime assets. Many plac
 each asset; generation results and branch diagnostics never cross the scene boundary. The cache
 lives only for the server module/process lifetime and is not production persistence.
 
-The browser draws the prepared scene into one visible Canvas. As each runtime asset arrives, its
-three ordered layers are prepared once as small offscreen surfaces. Placements reuse those surfaces,
-reducing ordinary scene draws from thousands of color-run operations per tree to three `drawImage`
-calls per visible tree. The distinct rear-foliage, wood, and front-foliage surfaces remain available
-for later layer-level motion. These surfaces are per asset, never per placement, and are discarded
-with the page.
+The browser draws the prepared scene into one visible Canvas. As each runtime asset arrives, wood
+and each foliage motion group are prepared once as small offscreen surfaces. Placements reuse those
+surfaces, reducing ordinary scene draws from thousands of color-run operations per tree to at most
+seven `drawImage` calls per visible tree: three rear groups, static wood, and three front groups.
+These surfaces are per asset, never per placement, and are discarded with the page.
 Browser-independent math derives each scaled visual rectangle from the asset bounds and ground
 anchor, culls it against the camera, and orders visible placements by ground Y with stable id
 tie-breaking. Integer scaling and disabled image smoothing preserve crisp pixels. Keyboard,
@@ -337,8 +344,8 @@ explicit approval.
 The Activity Forest route offers a development-only transport selector alongside every pressure
 profile. `color-runs` remains the calm representative scene's default. The experimental
 `lossless-raster` option leaves the placement manifest and versioned runtime identity unchanged but
-replaces each asset's run arrays with three transparent, lossless PNG payloads carried as base64 in
-the existing initial and regional JSON responses. Raster assets retain the schema, renderer,
+replaces each static layer or foliage-group run array with a transparent, lossless PNG payload
+carried as base64 in the existing initial and regional JSON responses. Raster assets retain the schema, renderer,
 phenotype, seed, cache key, dimensions, bounds, anchor, architectural identity, and ordered
 `rear-foliage`, `wood`, and `front-foliage` layer ids. They deliberately do not combine those layers
 into a single image.
@@ -352,7 +359,7 @@ For each initial response and regional request, diagnostics separate procedural 
 from transport encoding time and report the exact UTF-8 byte size of the encoded asset array. The
 browser separately reports JSON response decoding, PNG image decoding, layer preparation, fetch
 time, first completed scene render, regional entry behavior, and the existing last/average/maximum
-movement-render measurements. Color runs follow the same three-layer preparation and draw path, so
+movement-render measurements. Color runs follow the same ordered layer/group preparation and draw path, so
 the selector compares transport and browser preparation costs without changing layout, culling,
 depth ordering, exploration, or the default scene. These measurements remain local observations;
 compare repeated cold and warm runs for each pressure profile on the intended baseline device.
@@ -362,10 +369,85 @@ route, or flattened animation layers. Its purpose is to determine whether lossle
 materially improves encoded bytes and browser preparation enough to justify a later production
 design decision.
 
+### First shared ambient wind
+
+The initial ambient experiment applied one restrained shared wind function to each whole foliage
+layer. It performed well, but observation in the composed scene found that a crown changing position
+as one rigid mass read more like a sprite glitch than wind. The first refinement therefore retains
+the top-level layers while dividing each foliage layer into at most three branch-associated motion
+groups. Each placement deterministically derives a phase, speed in the bounded 0.72–1.08 range,
+and amplitude in the bounded 0.45–1 range from its stable placement id and world coordinates. Asset
+identity is deliberately absent from this derivation, so placements that reuse the same runtime
+asset do not move in lockstep. The calmer shared two-frequency signal is sampled with those placement
+parameters plus each group's small phase lag and response amplitude, then converted to an integer
+horizontal displacement of at most two screen pixels. The stagger lets wind appear to pass across
+the crown instead of translating every leaf on the same frame. `wood` remains at the original
+pixel-snapped origin. There is no vertical motion, branch deformation, rotation, or change to
+top-level layer order.
+
+Wind parameters live only in browser scene state and are calculated once when the placement
+manifest is read. During authoring, every shoot already identifies its primary branch lineage. The
+generator orders those lineages by crown position, assigns each complete lineage to one of three
+bounded groups, and distributes each final visible foliage pixel according to its owning leaf.
+Consequently, no leaf or pixel belongs to more than one group, and compositing all groups at zero
+offset exactly reproduces the static foliage layer. Each runtime group retains only its id, index,
+average branch attachment point, wind-response parameters, and pixels. Schema version 2 and its
+cache key explicitly invalidate schema version 1 assets; dimensions, occupied bounds, tree anchor,
+and placement identity remain unchanged.
+
+Both JSON color runs and lossless rasters use the same draw path. Color runs prepare one surface per
+group; raster transport encodes the same group and metadata as one transparent PNG. Preparation
+occurs outside render frames. The renderer supplies placement time parameters at paint time, so the
+raster pixels do not bake a motion sequence and the same asset can still move differently at each
+placement.
+
+Ambient motion requests continuous frames only while the document is visible and the user has not
+requested reduced motion. A hidden document cancels the pending frame and clears movement input.
+Returning to a visible document reevaluates the preference and requests a fresh frame. With reduced
+motion, foliage displacement is zero and rendering returns to the existing event-driven behavior;
+exploration remains available. Regional network requests are scheduled after the active animation
+callback, and response decoding, raster decoding, color-run replay, and sprite preparation remain
+in the asynchronous regional-preparation path rather than the render path.
+
+The browser maintains one narrow visible/depth-order cache. It recomputes after camera or viewport
+changes, player ground-Y changes, or regional asset arrival, and otherwise returns the same visible
+and player/tree depth-ordered arrays. Ambient-only frames consequently do not rescan the complete
+placement manifest, sort it, or rebuild unseen-region sets. Camera movement, resize, and genuine
+asset arrival remain accepted invalidation points; this is intentionally not a generalized spatial
+index.
+
+Diagnostics preserve first-render, movement, and unseen-region measurements. They add a separate
+ambient-only render count and rolling last, average, and maximum render duration. Movement frames
+continue to update only the movement series, allowing the two workloads to be compared without
+combining their samples.
+
+On Node 24.15.0 in a local development run after motion grouping, the representative profile's initial six-cell region
+contained 35 placements, 12 assets, and 12 visible placements in a 1000 × 700 test viewport. The
+large-world profile contained 20 initial placements, 18 assets, and 10 visible placements. Their
+prepared surface counts were 82 and 125 respectively. One hundred thousand unchanged
+visibility-cache reads took 6.9 ms and 6.8 ms; 200 reads that alternated camera X and therefore
+forced recomputation took 10.1 ms and 11.3 ms. Cold generation for those initial regions took
+1155.8 ms and 1361.7 ms outside render frames. Their color-run asset arrays were 1,723,394 and
+2,495,857 UTF-8 bytes, while lossless-raster arrays were 115,270 and 168,874 bytes. These are local
+architecture checks, not browser frame-time claims. The on-page
+ambient, movement, first-render, decoding, preparation, and unseen-region diagnostics remain the
+source for baseline-device evaluation. The regional loader's bounded preparation yields and the
+cached ambient path ensure regional arrival can cause a genuine one-time visibility recomputation,
+not sustained per-frame placement scans or synchronous decoding stalls inside animation callbacks.
+
+This refinement deliberately stops at three translated lineage groups per foliage depth layer.
+Individual leaf motion, additional cluster hierarchy, branch deformation, rotation, storms, user
+wind controls, WebGL, atlases, cache eviction, persistent storage, production routes, and a general
+animation framework remain future boundaries. Group attachment metadata permits a future experiment
+to interpret the same grouping more richly, but does not authorize or implement such a model.
+Further detail should be considered only if representative-scene observation shows this staggered
+motion is still visibly insufficient and the measured Canvas budget supports more work.
+
 The restrained world-space ground treatment and corridor exist only to make depth and negative
 space legible. This first camera is deliberately orthographic: terrain and trees share the same
-translation, with no viewport-fixed horizon or implied perspective projection. The next likely
-step is to test shared ambient wind against this representative workload. Real post integration,
+translation, with no viewport-fixed horizon or implied perspective projection. The next step is to
+judge the grouped ambient motion perceptually against the representative workload before expanding
+the model. Real post integration,
 persistence, complex physics, animation systems, tap-to-pathfind movement, zoom, terrain systems,
 perspective projection, asset eviction, and game-engine abstractions remain non-goals for this slice.
 

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1,13 +1,15 @@
 import {
   cameraFollowingPlayer,
+  createForestVisibilityCache,
   focusedForestPlacement,
+  forestAmbientMotionActive,
   forestSceneAssetKeysForCells,
   forestSceneCellIdsForViewport,
-  forestDepthOrder,
+  forestFoliageMotionGroupDisplacement,
+  forestPlacementWindParameters,
   moveForestPlayer,
   normalizedMovement,
-  touchMovement,
-  visibleForestPlacements
+  touchMovement
 } from './forest-scene-math.js';
 
 const payload = document.getElementById('activity-forest-scene');
@@ -42,6 +44,7 @@ if (payload && viewportElement && canvas) {
     prepared: document.querySelector('[data-forest-prepared]'),
     firstRender: document.querySelector('[data-forest-first-render]'),
     movementDuration: document.querySelector('[data-forest-movement-duration]'),
+    ambientDuration: document.querySelector('[data-forest-ambient-duration]'),
     regionEntry: document.querySelector('[data-forest-region-entry]'),
     regionLoading: document.querySelector('[data-forest-region-loading]')
   };
@@ -53,12 +56,25 @@ if (payload && viewportElement && canvas) {
   const seenPlacementIds = new Set();
   const seenAssetKeys = new Set();
   const movementRenders = { count: 0, total: 0, maximum: 0 };
+  const ambientRenders = { count: 0, total: 0, maximum: 0 };
+  const windByPlacementId = new Map(scene.placements.map((placement) => (
+    [placement.id, forestPlacementWindParameters(placement)]
+  )));
+  const visibilityCache = createForestVisibilityCache(scene.placements, assetsByKey);
+  const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
   let focusedPlacement = null;
+  let preparedSpriteCount = 0;
   let scheduledFrame = null;
   let lastFrameTime = null;
+  let lastSeenVisibilityRevision = 0;
   let firstRenderRecorded = false;
   let regionRetryAfter = 0;
   let regionalRequestActive = false;
+  let regionalRequestScheduled = false;
+  let ambientMotionActive = forestAmbientMotionActive({
+    documentHidden: document.hidden,
+    reducedMotion: reducedMotionQuery.matches
+  });
 
   function rasterLayerSource(layer) {
     const binary = window.atob(layer.data);
@@ -85,33 +101,56 @@ if (payload && viewportElement && canvas) {
     });
   }
 
+  async function prepareRuntimeSprite(source, dimensions) {
+    if (source.runs) {
+      const sprite = document.createElement('canvas');
+      sprite.width = dimensions.width;
+      sprite.height = dimensions.height;
+      const spriteContext = sprite.getContext('2d');
+      spriteContext.imageSmoothingEnabled = false;
+      for (const run of source.runs) {
+        spriteContext.fillStyle = run.color;
+        spriteContext.fillRect(run.x, run.y, run.width, 1);
+      }
+      return { sprite, decodeDuration: 0 };
+    }
+    const decodeStartedAt = window.performance.now();
+    const sprite = await decodeRasterLayer(source);
+    return { sprite, decodeDuration: window.performance.now() - decodeStartedAt };
+  }
+
   async function prepareRuntimeAsset(asset) {
     if (spritesByKey.has(asset.cacheKey)) return { preparedCount: 0, decodeDuration: 0 };
     let decodeDuration = 0;
     const layerSprites = [];
     for (const layer of asset.layers) {
-      let sprite;
-      if (layer.runs) {
-        sprite = document.createElement('canvas');
-        sprite.width = asset.dimensions.width;
-        sprite.height = asset.dimensions.height;
-        const spriteContext = sprite.getContext('2d');
-        spriteContext.imageSmoothingEnabled = false;
-        for (const run of layer.runs) {
-          spriteContext.fillStyle = run.color;
-          spriteContext.fillRect(run.x, run.y, run.width, 1);
+      if (layer.motionGroups) {
+        const motionGroups = [];
+        for (const group of layer.motionGroups) {
+          const prepared = await prepareRuntimeSprite(group, asset.dimensions);
+          decodeDuration += prepared.decodeDuration;
+          preparedSpriteCount += 1;
+          motionGroups.push({
+            id: group.id,
+            index: group.index,
+            attachment: group.attachment,
+            windResponse: group.windResponse,
+            sprite: prepared.sprite
+          });
         }
+        layerSprites.push({ id: layer.id, motionGroups });
       } else {
-        const decodeStartedAt = window.performance.now();
-        sprite = await decodeRasterLayer(layer);
-        decodeDuration += window.performance.now() - decodeStartedAt;
+        const prepared = await prepareRuntimeSprite(layer, asset.dimensions);
+        decodeDuration += prepared.decodeDuration;
+        preparedSpriteCount += 1;
+        layerSprites.push({ id: layer.id, sprite: prepared.sprite });
       }
-      layerSprites.push({ id: layer.id, sprite });
     }
     assetsByKey.set(asset.cacheKey, asset);
     spritesByKey.set(asset.cacheKey, layerSprites);
+    visibilityCache.invalidate();
     diagnostics.prepared.textContent = `${spritesByKey.size} / ${
-      scene.assetLoading.totalAssetCount} assets · ${spritesByKey.size * 3} layer sprites`;
+      scene.assetLoading.totalAssetCount} assets · ${preparedSpriteCount} layer/group sprites`;
     return { preparedCount: 1, decodeDuration };
   }
 
@@ -232,6 +271,15 @@ if (payload && viewportElement && canvas) {
     }
   }
 
+  function scheduleRequiredRegions() {
+    if (regionalRequestScheduled) return;
+    regionalRequestScheduled = true;
+    window.setTimeout(() => {
+      regionalRequestScheduled = false;
+      requestRequiredRegions();
+    }, 0);
+  }
+
   updateRegionLoading();
 
   function corridorCenter(worldY) {
@@ -240,7 +288,7 @@ if (payload && viewportElement && canvas) {
 
   function followPlayer() {
     Object.assign(camera, cameraFollowingPlayer(player, camera, scene.world));
-    requestRequiredRegions();
+    scheduleRequiredRegions();
   }
 
   function paintGround() {
@@ -269,10 +317,11 @@ if (payload && viewportElement && canvas) {
     context.fill();
   }
 
-  function paintTree(placement) {
+  function paintTree(placement, elapsedSeconds) {
     const asset = assetsByKey.get(placement.assetKey);
     const originX = Math.round(placement.worldX - camera.x - asset.anchor.x * placement.scale);
     const originY = Math.round(placement.worldY - camera.y - asset.anchor.y * placement.scale);
+    const wind = windByPlacementId.get(placement.id);
     if (placement.id === focusedPlacement?.id) {
       context.beginPath();
       context.ellipse(Math.round(placement.worldX - camera.x),
@@ -284,9 +333,19 @@ if (payload && viewportElement && canvas) {
       context.lineWidth = 2;
       context.stroke();
     }
-    for (const { sprite } of spritesByKey.get(placement.assetKey)) {
-      context.drawImage(sprite, originX, originY,
-        asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+    for (const layer of spritesByKey.get(placement.assetKey)) {
+      if (layer.motionGroups) {
+        for (const group of layer.motionGroups) {
+          const displacement = forestFoliageMotionGroupDisplacement(
+            wind, group, elapsedSeconds, ambientMotionActive
+          );
+          context.drawImage(group.sprite, originX + displacement, originY,
+            asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+        }
+      } else {
+        context.drawImage(layer.sprite, originX, originY,
+          asset.dimensions.width * placement.scale, asset.dimensions.height * placement.scale);
+      }
     }
   }
 
@@ -313,28 +372,34 @@ if (payload && viewportElement && canvas) {
     diagnostics.focus.textContent = focusedPlacement?.id || 'None';
   }
 
-  function render({ moving = false, frameGap = null } = {}) {
+  function render(elapsedSeconds, moving = false, frameGap = null) {
     const start = window.performance.now();
     context.imageSmoothingEnabled = false;
     paintGround();
-    const visible = visibleForestPlacements(scene.placements, assetsByKey, camera);
-    for (const item of forestDepthOrder(visible, player)) {
+    const visibility = visibilityCache.read(camera, player);
+    for (const item of visibility.depthOrder) {
       if (item.kind === 'player') paintPlayer();
-      else paintTree(item.placement);
+      else paintTree(item.placement, elapsedSeconds);
     }
+    const { visible } = visibility;
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length}`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
     const duration = window.performance.now() - start;
     diagnostics.duration.textContent = `${duration.toFixed(1)} ms`;
 
-    const newlySeen = visible.filter(({ id }) => !seenPlacementIds.has(id));
-    const newlySeenAssets = new Set(newlySeen.map(({ assetKey }) => assetKey)
-      .filter((assetKey) => !seenAssetKeys.has(assetKey)));
-    visible.forEach(({ id, assetKey }) => {
-      seenPlacementIds.add(id);
-      seenAssetKeys.add(assetKey);
-    });
+    let newlySeen = [];
+    let newlySeenAssets = null;
+    if (visibility.revision !== lastSeenVisibilityRevision) {
+      lastSeenVisibilityRevision = visibility.revision;
+      newlySeen = visible.filter(({ id }) => !seenPlacementIds.has(id));
+      newlySeenAssets = new Set(newlySeen.map(({ assetKey }) => assetKey)
+        .filter((assetKey) => !seenAssetKeys.has(assetKey)));
+      visible.forEach(({ id, assetKey }) => {
+        seenPlacementIds.add(id);
+        seenAssetKeys.add(assetKey);
+      });
+    }
 
     if (moving) {
       movementRenders.count += 1;
@@ -348,6 +413,14 @@ if (payload && viewportElement && canvas) {
           newlySeenAssets.size} new assets · ${duration.toFixed(1)} ms render · ${
           frameGap === null ? 'first movement frame' : `${frameGap.toFixed(1)} ms frame gap`}`;
       }
+    } else if (ambientMotionActive) {
+      ambientRenders.count += 1;
+      ambientRenders.total += duration;
+      ambientRenders.maximum = Math.max(ambientRenders.maximum, duration);
+      diagnostics.ambientDuration.textContent = `${ambientRenders.count} renders · ${
+        duration.toFixed(1)} ms last / ${
+        (ambientRenders.total / ambientRenders.count).toFixed(1)} ms avg / ${
+        ambientRenders.maximum.toFixed(1)} ms max`;
     }
 
     if (!firstRenderRecorded) {
@@ -380,8 +453,8 @@ if (payload && viewportElement && canvas) {
       followPlayer();
       updateFocus();
     }
-    render({ moving, frameGap });
-    if (moving) scheduledFrame = requestAnimationFrame(frame);
+    render(timestamp / 1000, moving, frameGap);
+    if (moving || ambientMotionActive) scheduledFrame = requestAnimationFrame(frame);
     else lastFrameTime = null;
   }
 
@@ -397,6 +470,21 @@ if (payload && viewportElement && canvas) {
     joystick.hidden = true;
     joystickStick.style.transform = '';
     lastFrameTime = null;
+  }
+
+  function updateAmbientMotion() {
+    const nextActive = forestAmbientMotionActive({
+      documentHidden: document.hidden,
+      reducedMotion: reducedMotionQuery.matches
+    });
+    if (document.hidden) clearMovement();
+    ambientMotionActive = nextActive;
+    if (document.hidden && scheduledFrame !== null) {
+      cancelAnimationFrame(scheduledFrame);
+      scheduledFrame = null;
+      lastFrameTime = null;
+    }
+    if (!document.hidden) requestRender();
   }
 
   function updateTouchMovement(event) {
@@ -501,6 +589,8 @@ if (payload && viewportElement && canvas) {
   viewportElement.addEventListener('pointercancel', stopTouchMovement);
   viewportElement.addEventListener('lostpointercapture', stopTouchMovement);
   window.addEventListener('blur', clearMovement);
+  document.addEventListener('visibilitychange', updateAmbientMotion);
+  reducedMotionQuery.addEventListener('change', updateAmbientMotion);
   dialog.addEventListener('close', () => {
     clearMovement();
     viewportElement.focus();

--- a/public/js/forest-lab.js
+++ b/public/js/forest-lab.js
@@ -17,7 +17,11 @@
       const layers = canvas.classList.contains('forest-wood-canvas')
         ? asset.layers.filter(function (layer) { return layer.id === 'wood'; })
         : asset.layers;
-      layers.forEach(function (layer) { paintRuns(context, layer.runs); });
+      layers.forEach(function (layer) {
+        if (layer.motionGroups) {
+          layer.motionGroups.forEach(function (group) { paintRuns(context, group.runs); });
+        } else paintRuns(context, layer.runs);
+      });
     });
   }
 

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -22,6 +22,96 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
   ));
 }
 
+export const FOREST_AMBIENT_WIND = Object.freeze({
+  maximumDisplacement: 2,
+  minimumAmplitude: 0.45,
+  maximumAmplitude: 1,
+  minimumSpeed: 0.72,
+  maximumSpeed: 1.08
+});
+
+function placementHash(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function placementUnit(placement, decision) {
+  return placementHash(`${placement.id}:${placement.worldX}:${placement.worldY}:${decision}`)
+    / 4294967296;
+}
+
+export function forestPlacementWindParameters(placement) {
+  const amplitudeRange = FOREST_AMBIENT_WIND.maximumAmplitude
+    - FOREST_AMBIENT_WIND.minimumAmplitude;
+  const speedRange = FOREST_AMBIENT_WIND.maximumSpeed - FOREST_AMBIENT_WIND.minimumSpeed;
+  return Object.freeze({
+    phase: placementUnit(placement, 'phase') * Math.PI * 2,
+    speed: FOREST_AMBIENT_WIND.minimumSpeed + (placementUnit(placement, 'speed') * speedRange),
+    amplitude: FOREST_AMBIENT_WIND.minimumAmplitude
+      + (placementUnit(placement, 'amplitude') * amplitudeRange)
+  });
+}
+
+export function forestAmbientWindSignal(time) {
+  return (Math.sin(time * 0.55) * 0.72) + (Math.sin((time * 0.21) + 1.4) * 0.28);
+}
+
+export function forestFoliageMotionGroupDisplacement(
+  parameters, group, elapsedSeconds, active = true
+) {
+  if (!active) return 0;
+  const phaseOffset = group.windResponse?.phaseOffset || 0;
+  const response = group.windResponse?.amplitude ?? 1;
+  const signal = forestAmbientWindSignal(
+    (elapsedSeconds * parameters.speed) + parameters.phase + phaseOffset
+  );
+  return Math.round(
+    FOREST_AMBIENT_WIND.maximumDisplacement * parameters.amplitude * response * signal
+  );
+}
+
+export function forestAmbientMotionActive({ documentHidden = false, reducedMotion = false } = {}) {
+  return !documentHidden && !reducedMotion;
+}
+
+export function createForestVisibilityCache(placements, assetsByKey, margin = 24) {
+  let cached = null;
+  let invalidated = true;
+  let revision = 0;
+  let snapshot = null;
+
+  return {
+    invalidate() {
+      invalidated = true;
+    },
+    read(viewport, player) {
+      const changed = invalidated || !snapshot
+        || snapshot.x !== viewport.x || snapshot.y !== viewport.y
+        || snapshot.width !== viewport.width || snapshot.height !== viewport.height
+        || snapshot.playerWorldY !== player.worldY || snapshot.assetCount !== assetsByKey.size;
+      if (changed) {
+        const visible = visibleForestPlacements(placements, assetsByKey, viewport, margin);
+        revision += 1;
+        cached = { visible, depthOrder: forestDepthOrder(visible, player), revision };
+        snapshot = {
+          x: viewport.x,
+          y: viewport.y,
+          width: viewport.width,
+          height: viewport.height,
+          playerWorldY: player.worldY,
+          assetCount: assetsByKey.size
+        };
+        invalidated = false;
+      }
+      return cached;
+    }
+  };
+}
+
 export function forestSceneCellId(column, row) {
   return `${column}:${row}`;
 }

--- a/server/services/forest/v3/rasterizeFoliage.js
+++ b/server/services/forest/v3/rasterizeFoliage.js
@@ -2,6 +2,8 @@ import { createRandom } from './random.js';
 
 const EMPTY = null;
 
+export const FOREST_FOLIAGE_MOTION_GROUP_COUNT = 3;
+
 export const FOLIAGE_PALETTE = Object.freeze({
   highlight: '#9fbe59',
   light: '#73a34a',
@@ -339,7 +341,68 @@ function compactRuns(pixels) {
   return runs;
 }
 
-function rasterizeLayer(leaves, layer, phenotype, palette) {
+function assignFoliageMotionGroups(graph, shoots, leaves) {
+  const lineages = new Map();
+  for (const shoot of shoots) {
+    if (!lineages.has(shoot.lineageId)) lineages.set(shoot.lineageId, { x: 0, count: 0 });
+    const lineage = lineages.get(shoot.lineageId);
+    for (const leafId of shoot.leafIds) {
+      lineage.x += leaves[leafId].x;
+      lineage.count += 1;
+    }
+  }
+  const orderedLineageIds = [...lineages.entries()].sort((first, second) => (
+    (first[1].x / first[1].count) - (second[1].x / second[1].count)
+      || first[0] - second[0]
+  )).map(([lineageId]) => lineageId);
+  const groupByLineage = new Map(orderedLineageIds.map((lineageId, index) => [
+    lineageId,
+    Math.min(FOREST_FOLIAGE_MOTION_GROUP_COUNT - 1, Math.floor(
+      (index * FOREST_FOLIAGE_MOTION_GROUP_COUNT) / orderedLineageIds.length
+    ))
+  ]));
+  for (const shoot of shoots) {
+    shoot.motionGroupId = groupByLineage.get(shoot.lineageId);
+    for (const leafId of shoot.leafIds) leaves[leafId].motionGroupId = shoot.motionGroupId;
+  }
+  return Array.from({ length: FOREST_FOLIAGE_MOTION_GROUP_COUNT }, (_, index) => {
+    const groupShoots = shoots.filter(shoot => shoot.motionGroupId === index);
+    const attachment = groupShoots.reduce((sum, shoot) => ({
+      x: sum.x + graph.nodes[shoot.nodeId].x,
+      y: sum.y + graph.nodes[shoot.nodeId].y
+    }), { x: 0, y: 0 });
+    const groupSize = Math.max(1, groupShoots.length);
+    return {
+      id: `crown-${index}`,
+      index,
+      attachment: {
+        x: Number((attachment.x / groupSize).toFixed(2)),
+        y: Number((attachment.y / groupSize).toFixed(2))
+      },
+      windResponse: {
+        phaseOffset: (index - 1) * 0.72,
+        amplitude: [0.82, 1, 0.9][index]
+      }
+    };
+  });
+}
+
+function compactMotionGroups(pixels, owner, motionGroups) {
+  const groupPixels = Array.from({ length: FOREST_FOLIAGE_MOTION_GROUP_COUNT }, () => (
+    makeGrid(pixels[0].length, pixels.length)
+  ));
+  for (let y = 0; y < pixels.length; y += 1) {
+    for (let x = 0; x < pixels[y].length; x += 1) {
+      if (pixels[y][x]) groupPixels[owner[y][x].leaf.motionGroupId][y][x] = pixels[y][x];
+    }
+  }
+  return groupPixels.map((group, index) => ({
+    ...motionGroups[index],
+    runs: compactRuns(group)
+  })).filter(group => group.runs.length);
+}
+
+function rasterizeLayer(leaves, layer, phenotype, palette, motionGroups) {
   const mask = makeGrid(phenotype.width, phenotype.height, false);
   const owner = makeGrid(phenotype.width, phenotype.height);
   const layerLeaves = leaves
@@ -347,15 +410,21 @@ function rasterizeLayer(leaves, layer, phenotype, palette) {
     .sort((first, second) => first.depth - second.depth || first.id - second.id);
   for (const leaf of layerLeaves) paintLeaf(mask, owner, leaf, phenotype);
   const pixels = shadeLeaves(mask, owner, palette);
-  return { mask, pixels, runs: compactRuns(pixels) };
+  return {
+    mask,
+    pixels,
+    runs: compactRuns(pixels),
+    motionGroups: compactMotionGroups(pixels, owner, motionGroups)
+  };
 }
 
 export function rasterizeFoliage(graph, phenotype, seed) {
   const paletteVariant = selectFoliagePalette(phenotype, seed);
   const palette = paletteVariant.colors;
   const { shoots, leaves, coverageCells } = generateLeafBearingShoots(graph, phenotype, seed);
-  const back = rasterizeLayer(leaves, 'back', phenotype, palette);
-  const front = rasterizeLayer(leaves, 'front', phenotype, palette);
+  const motionGroups = assignFoliageMotionGroups(graph, shoots, leaves);
+  const back = rasterizeLayer(leaves, 'back', phenotype, palette, motionGroups);
+  const front = rasterizeLayer(leaves, 'front', phenotype, palette, motionGroups);
   const mask = makeGrid(phenotype.width, phenotype.height, false);
   const pixels = makeGrid(phenotype.width, phenotype.height);
   for (let y = 0; y < phenotype.height; y += 1) {
@@ -372,6 +441,8 @@ export function rasterizeFoliage(graph, phenotype, seed) {
     runs: compactRuns(pixels),
     backRuns: back.runs,
     frontRuns: front.runs,
+    backMotionGroups: back.motionGroups,
+    frontMotionGroups: front.motionGroups,
     shoots,
     leaves,
     coverageCells,

--- a/server/services/forest/v3/treeAsset.js
+++ b/server/services/forest/v3/treeAsset.js
@@ -1,8 +1,10 @@
-export const FOREST_TREE_ASSET_SCHEMA_VERSION = 1;
+export const FOREST_TREE_ASSET_SCHEMA_VERSION = 2;
 export const FOREST_RENDERER_ID = 'daily-page-forest-v3';
 
 function visualBounds(layers, width, height) {
-  const runs = layers.flatMap(layer => layer.runs);
+  const runs = layers.flatMap(layer => (
+    layer.motionGroups?.flatMap(group => group.runs) || layer.runs
+  ));
   if (!runs.length) return { x: 0, y: 0, width: 0, height: 0 };
   const left = Math.min(...runs.map(run => run.x));
   const top = Math.min(...runs.map(run => run.y));
@@ -38,9 +40,9 @@ export function buildForestTreeAsset(generationResult) {
     phenotypeAssetVersion: phenotype.assetVersion
   });
   const layers = [
-    { id: 'rear-foliage', runs: foliage.backRuns },
+    { id: 'rear-foliage', motionGroups: foliage.backMotionGroups },
     { id: 'wood', runs: wood.runs },
-    { id: 'front-foliage', runs: foliage.frontRuns }
+    { id: 'front-foliage', motionGroups: foliage.frontMotionGroups }
   ];
   return {
     schemaVersion: FOREST_TREE_ASSET_SCHEMA_VERSION,

--- a/server/services/forestSceneAssetTransport.js
+++ b/server/services/forestSceneAssetTransport.js
@@ -50,8 +50,10 @@ async function encodeRasterLayer(layer, dimensions) {
   const png = await sharp(layerPixels(layer, dimensions), {
     raw: { ...dimensions, channels: 4 }
   }).png({ compressionLevel: 9 }).toBuffer();
+  const metadata = { ...layer };
+  delete metadata.runs;
   return {
-    id: layer.id,
+    ...metadata,
     mediaType: 'image/png',
     encoding: 'base64',
     data: png.toString('base64')
@@ -63,7 +65,16 @@ async function encodeRasterAsset(asset) {
   return {
     ...metadata,
     transport: FOREST_ASSET_TRANSPORT_RASTER,
-    layers: await Promise.all(layers.map(layer => encodeRasterLayer(layer, asset.dimensions)))
+    layers: await Promise.all(layers.map(async (layer) => (
+      layer.motionGroups
+        ? {
+          id: layer.id,
+          motionGroups: await Promise.all(layer.motionGroups.map(group => (
+            encodeRasterLayer(group, asset.dimensions)
+          )))
+        }
+        : encodeRasterLayer(layer, asset.dimensions)
+    )))
   };
 }
 

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -26,11 +26,16 @@ import {
 } from '../server/services/forestScenePressure.js';
 import {
   cameraFollowingPlayer,
+  createForestVisibilityCache,
   focusedForestPlacement,
+  FOREST_AMBIENT_WIND,
+  forestAmbientMotionActive,
   forestSceneAssetKeysForCells,
   forestSceneCellIdsForViewport,
   forestScenePlacementCellId,
   forestDepthOrder,
+  forestFoliageMotionGroupDisplacement,
+  forestPlacementWindParameters,
   moveForestPlayer,
   normalizedMovement,
   playerCollides,
@@ -174,9 +179,13 @@ describe('static Activity Forest scene', () => {
     expect(rasterAsset.layers.map(({ id }) => id)).toEqual([
       'rear-foliage', 'wood', 'front-foliage'
     ]);
-    expect(rasterAsset.layers.every(layer => (
-      layer.mediaType === 'image/png' && layer.encoding === 'base64' && !layer.runs
-    ))).toBeTrue();
+    expect(rasterAsset.layers.find(layer => layer.id === 'wood').mediaType).toBe('image/png');
+    for (const layer of rasterAsset.layers.filter(layer => layer.motionGroups)) {
+      expect(layer.motionGroups.length).toBeGreaterThan(1);
+      expect(layer.motionGroups.every(group => (
+        group.mediaType === 'image/png' && group.encoding === 'base64' && !group.runs
+      ))).toBeTrue();
+    }
     expect(cold.diagnostics.encodedAssetCount).toBe(1);
     expect(cold.diagnostics.reusedEncodedAssetCount).toBe(0);
     expect(warm.diagnostics.encodedAssetCount).toBe(0);
@@ -187,24 +196,37 @@ describe('static Activity Forest scene', () => {
     expect(cold.diagnostics.encodedPayloadBytes)
       .toBe(Buffer.byteLength(JSON.stringify(cold.assets), 'utf8'));
 
-    for (const [index, layer] of rasterAsset.layers.entries()) {
-      const { data, info } = await sharp(Buffer.from(layer.data, 'base64')).raw().toBuffer({
-        resolveWithObject: true
-      });
-      const expected = Buffer.alloc(data.length);
-      for (const run of runtimeAsset.layers[index].runs) {
-        const color = run.color.slice(1);
-        const channels = color.length === 3
-          ? [...color].map(value => Number.parseInt(`${value}${value}`, 16))
-          : [0, 2, 4].map(offset => Number.parseInt(color.slice(offset, offset + 2), 16));
-        for (let x = run.x; x < run.x + run.width; x += 1) {
-          const offset = ((run.y * info.width) + x) * info.channels;
-          expected.set([...channels, 255], offset);
+    for (const [index, rasterLayer] of rasterAsset.layers.entries()) {
+      const runtimeLayer = runtimeAsset.layers[index];
+      const rasterSources = rasterLayer.motionGroups || [rasterLayer];
+      const runtimeSources = runtimeLayer.motionGroups || [runtimeLayer];
+      expect(rasterSources.map(source => source.id)).toEqual(
+        runtimeSources.map(source => source.id)
+      );
+      for (const [sourceIndex, source] of rasterSources.entries()) {
+        if (runtimeLayer.motionGroups) {
+          expect(source.index).toBe(runtimeSources[sourceIndex].index);
+          expect(source.attachment).toEqual(runtimeSources[sourceIndex].attachment);
+          expect(source.windResponse).toEqual(runtimeSources[sourceIndex].windResponse);
         }
+        const { data, info } = await sharp(Buffer.from(source.data, 'base64')).raw().toBuffer({
+          resolveWithObject: true
+        });
+        const expected = Buffer.alloc(data.length);
+        for (const run of runtimeSources[sourceIndex].runs) {
+          const color = run.color.slice(1);
+          const channels = color.length === 3
+            ? [...color].map(value => Number.parseInt(`${value}${value}`, 16))
+            : [0, 2, 4].map(offset => Number.parseInt(color.slice(offset, offset + 2), 16));
+          for (let x = run.x; x < run.x + run.width; x += 1) {
+            const offset = ((run.y * info.width) + x) * info.channels;
+            expected.set([...channels, 255], offset);
+          }
+        }
+        expect(info.width).toBe(runtimeAsset.dimensions.width);
+        expect(info.height).toBe(runtimeAsset.dimensions.height);
+        expect(data).toEqual(expected);
       }
-      expect(info.width).toBe(runtimeAsset.dimensions.width);
-      expect(info.height).toBe(runtimeAsset.dimensions.height);
-      expect(data).toEqual(expected);
     }
   });
 
@@ -283,6 +305,102 @@ describe('static Activity Forest scene', () => {
     expect(visibleForestPlacements(
       placements, assets, { x: 0, y: 0, width: 140, height: 100 }, 0
     ).map((placement) => placement.id)).toEqual(['partial', 'tie-a', 'tie-b', 'near']);
+  });
+
+  it('derives deterministic wind parameters from placement rather than shared asset identity', () => {
+    const firstPlacement = {
+      id: 'placement-1', assetKey: 'shared-tree', worldX: 120, worldY: 240
+    };
+    const secondPlacement = {
+      id: 'placement-2', assetKey: 'shared-tree', worldX: 220, worldY: 240
+    };
+    const first = forestPlacementWindParameters(firstPlacement);
+    const repeated = forestPlacementWindParameters({ ...firstPlacement });
+    const second = forestPlacementWindParameters(secondPlacement);
+
+    expect(repeated).toEqual(first);
+    expect(second.phase).not.toBe(first.phase);
+    expect(second).not.toEqual(first);
+    expect(first.amplitude).toBeGreaterThanOrEqual(FOREST_AMBIENT_WIND.minimumAmplitude);
+    expect(first.amplitude).toBeLessThanOrEqual(FOREST_AMBIENT_WIND.maximumAmplitude);
+    expect(first.speed).toBeGreaterThanOrEqual(FOREST_AMBIENT_WIND.minimumSpeed);
+    expect(first.speed).toBeLessThanOrEqual(FOREST_AMBIENT_WIND.maximumSpeed);
+  });
+
+  it('keeps foliage wind bounded and pixel-snapped and becomes static when inactive', () => {
+    const parameters = forestPlacementWindParameters({
+      id: 'bounded-wind', worldX: 42, worldY: 84
+    });
+    const group = { index: 1, windResponse: { phaseOffset: 0, amplitude: 1 } };
+    const samples = Array.from({ length: 500 }, (_, index) => (
+      forestFoliageMotionGroupDisplacement(parameters, group, index / 30)
+    ));
+
+    expect(samples.every(Number.isInteger)).toBeTrue();
+    expect(Math.max(...samples)).toBeLessThanOrEqual(
+      FOREST_AMBIENT_WIND.maximumDisplacement
+    );
+    expect(Math.min(...samples)).toBeGreaterThanOrEqual(
+      -FOREST_AMBIENT_WIND.maximumDisplacement
+    );
+    expect(forestFoliageMotionGroupDisplacement(parameters, group, 4.5, false)).toBe(0);
+    expect(forestAmbientMotionActive()).toBeTrue();
+    expect(forestAmbientMotionActive({ documentHidden: true })).toBeFalse();
+    expect(forestAmbientMotionActive({ reducedMotion: true })).toBeFalse();
+  });
+
+  it('staggers deterministic motion groups without exceeding the ambient bound', () => {
+    const parameters = forestPlacementWindParameters({
+      id: 'grouped-wind', worldX: 140, worldY: 280
+    });
+    const groups = [
+      { index: 0, windResponse: { phaseOffset: -0.72, amplitude: 0.82 } },
+      { index: 1, windResponse: { phaseOffset: 0, amplitude: 1 } },
+      { index: 2, windResponse: { phaseOffset: 0.72, amplitude: 0.9 } }
+    ];
+    const samples = groups.map(group => Array.from({ length: 500 }, (_, index) => (
+      forestFoliageMotionGroupDisplacement(parameters, group, index / 30)
+    )));
+
+    expect(new Set(samples.map(sample => sample.join(','))).size).toBe(groups.length);
+    expect(samples.flat().every(value => Number.isInteger(value)
+      && Math.abs(value) <= FOREST_AMBIENT_WIND.maximumDisplacement)).toBeTrue();
+    expect(groups.every(group => (
+      forestFoliageMotionGroupDisplacement(parameters, group, 8, false) === 0
+    ))).toBeTrue();
+  });
+
+  it('reuses visible depth order until a genuine visibility input changes', () => {
+    const asset = {
+      anchor: { x: 5, y: 10 }, bounds: { x: 1, y: 2, width: 8, height: 9 }
+    };
+    const assets = new Map([['tree', asset]]);
+    const placements = [
+      { id: 'visible', assetKey: 'tree', worldX: 50, worldY: 60, scale: 1 },
+      { id: 'unloaded', assetKey: 'late-tree', worldX: 70, worldY: 70, scale: 1 }
+    ];
+    const viewport = { x: 0, y: 0, width: 100, height: 100 };
+    const player = { worldX: 40, worldY: 65 };
+    const cache = createForestVisibilityCache(placements, assets, 0);
+    const initial = cache.read(viewport, player);
+
+    expect(cache.read(viewport, player)).toBe(initial);
+    expect(initial.visible.map(({ id }) => id)).toEqual(['visible']);
+
+    const cameraChanged = cache.read({ ...viewport, x: 1 }, player);
+    expect(cameraChanged.revision).toBe(initial.revision + 1);
+    expect(cache.read({ ...viewport, x: 1 }, player)).toBe(cameraChanged);
+
+    assets.set('late-tree', asset);
+    const assetChanged = cache.read({ ...viewport, x: 1 }, player);
+    expect(assetChanged.revision).toBe(cameraChanged.revision + 1);
+    expect(assetChanged.visible.map(({ id }) => id)).toEqual(['visible', 'unloaded']);
+
+    const playerDepthChanged = cache.read({ ...viewport, x: 1 }, { ...player, worldY: 75 });
+    expect(playerDepthChanged.revision).toBe(assetChanged.revision + 1);
+    cache.invalidate();
+    expect(cache.read({ ...viewport, x: 1 }, { ...player, worldY: 75 }).revision)
+      .toBe(playerDepthChanged.revision + 1);
   });
 
   it('adds a deterministic, safe spawn and bounded fixture metadata', () => {

--- a/spec/forestTreeAssetSpec.js
+++ b/spec/forestTreeAssetSpec.js
@@ -21,6 +21,10 @@ import {
 
 describe('v3 forest runtime tree assets', () => {
   const post = { id: 'tree-asset-post' };
+  const layerRuns = layer => layer.motionGroups?.flatMap(group => group.runs) || layer.runs;
+  const runPixels = runs => new Map(runs.flatMap(run => Array.from(
+    { length: run.width }, (_, offset) => [`${run.x + offset}:${run.y}`, run.color]
+  )));
 
   beforeEach(() => clearForestLabTreeCache());
 
@@ -50,7 +54,19 @@ describe('v3 forest runtime tree assets', () => {
       'leaves', 'shoots', 'coverageCells'
     ]) expect(serialized).not.toContain(`"${excluded}"`);
     expect(asset.identity.architecture.hasSplitTrunk).toBeDefined();
-    expect(asset.layers.every(layer => Array.isArray(layer.runs))).toBeTrue();
+    expect(asset.layers.find(layer => layer.id === 'wood').runs.length).toBeGreaterThan(0);
+    for (const layer of asset.layers.filter(layer => layer.id.includes('foliage'))) {
+      expect(layer.runs).toBeUndefined();
+      expect(layer.motionGroups.length).toBeGreaterThan(1);
+      expect(layer.motionGroups.length).toBeLessThanOrEqual(3);
+      for (const group of layer.motionGroups) {
+        expect(group.runs.length).toBeGreaterThan(0);
+        expect(group.attachment.x).toEqual(jasmine.any(Number));
+        expect(group.attachment.y).toEqual(jasmine.any(Number));
+        expect(group.windResponse.phaseOffset).toEqual(jasmine.any(Number));
+        expect(group.windResponse.amplitude).toBeGreaterThan(0);
+      }
+    }
   });
 
   it('varies cache identity with seed, renderer, phenotype, and schema versions', () => {
@@ -71,8 +87,10 @@ describe('v3 forest runtime tree assets', () => {
 
   it('builds the same visual asset from an existing generation result', () => {
     const generation = generateForestTreeV3(post, { seed: 303 });
-    expect(buildForestTreeAsset(generation))
-      .toEqual(generateForestTreeAssetV3(post, { seed: 303 }));
+    const asset = buildForestTreeAsset(generation);
+    expect(asset).toEqual(generateForestTreeAssetV3(post, { seed: 303 }));
+    expect(runPixels(layerRuns(asset.layers[0]))).toEqual(runPixels(generation.foliage.backRuns));
+    expect(runPixels(layerRuns(asset.layers[2]))).toEqual(runPixels(generation.foliage.frontRuns));
   });
 
   it('emits the same contract for a distinct registered phenotype', () => {
@@ -92,7 +110,7 @@ describe('v3 forest runtime tree assets', () => {
     const lanternColors = new Set(LANTERNWOOD_PHENOTYPE.foliagePalettes
       .flatMap(variant => Object.values(variant.colors)));
     expect(lanternwood.layers.filter(layer => layer.id.includes('foliage'))
-      .flatMap(layer => layer.runs).every(run => lanternColors.has(run.color))).toBeTrue();
+      .flatMap(layerRuns).every(run => lanternColors.has(run.color))).toBeTrue();
   });
 
   it('selects deterministic whole-tree foliage palettes with weighted rarity', () => {

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -2,6 +2,7 @@ import {
   generateForestTreeGraph,
   generateForestTreeV3
 } from '../server/services/forestTreeGeneratorV3.js';
+import { FOREST_FOLIAGE_MOTION_GROUP_COUNT } from '../server/services/forest/v3/rasterizeFoliage.js';
 
 describe('v3 forest branch graph generator', () => {
   const post = { id: 'post-forest-v3-1' };
@@ -446,6 +447,7 @@ describe('v3 forest branch graph generator', () => {
       expect(tree.foliage.leaves.length).toBeGreaterThan(40);
       expect(tree.foliage.backRuns.length).toBeGreaterThan(0);
       expect(tree.foliage.frontRuns.length).toBeGreaterThan(0);
+      const groupByLineage = new Map();
       for (const shoot of tree.foliage.shoots) {
         expect(shoot.branchOrder).toBeGreaterThanOrEqual(tree.phenotype.foliageMinimumOrder);
         if (tree.nodes[shoot.nodeId].generation < tree.phenotype.foliageMinimumOrder) {
@@ -453,11 +455,17 @@ describe('v3 forest branch graph generator', () => {
           expect(shoot.terminal).toBeTrue();
         }
         expect(shoot.leafIds.length).toBeGreaterThan(0);
+        if (groupByLineage.has(shoot.lineageId)) {
+          expect(shoot.motionGroupId).toBe(groupByLineage.get(shoot.lineageId));
+        } else groupByLineage.set(shoot.lineageId, shoot.motionGroupId);
       }
+      expect(new Set(groupByLineage.values()).size)
+        .toBeLessThanOrEqual(FOREST_FOLIAGE_MOTION_GROUP_COUNT);
       for (const leaf of tree.foliage.leaves) {
         const shoot = tree.foliage.shoots[leaf.shootId];
         expect(shoot.leafIds).toContain(leaf.id);
         expect(leaf.supportNodeId).toBe(shoot.nodeId);
+        expect(leaf.motionGroupId).toBe(shoot.motionGroupId);
       }
     }
   });

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -104,7 +104,7 @@ block content
         dt Browser preparation
         dd(data-forest-sprite-duration) —
       div
-        dt Prepared canvases
+        dt Prepared sprites
         dd(data-forest-prepared) —
       div
         dt Regional loading
@@ -130,6 +130,9 @@ block content
       div
         dt Movement renders
         dd(data-forest-movement-duration) No movement frames yet
+      div
+        dt Ambient renders
+        dd(data-forest-ambient-duration) No ambient frames yet
       div
         dt Unseen-region entry
         dd(data-forest-region-entry) Walk beyond the initial view


### PR DESCRIPTION
## Summary

Add the first ambient wind system to the development Activity Forest scene.

The implementation keeps wood static while moving rear and front foliage with a restrained global wind signal. Foliage is divided into up to three deterministic, branch-lineage-associated motion groups, producing calm staggered movement instead of translating each crown as one rigid sprite.

## Implementation

- Derive deterministic wind phase, speed, and amplitude per placement.
- Group foliage by primary branch lineage during rasterization.
- Preserve the top-level `rear-foliage`, `wood`, and `front-foliage` order.
- Keep displacement bounded to two pixel-snapped horizontal pixels.
- Store minimal group attachment and wind-response metadata for possible future motion experiments.
- Support grouped foliage through both JSON color-run and lossless-raster transports.
- Bump the runtime tree-asset schema to version 2.
- Cache visible, depth-ordered placements between genuine scene changes.
- Render continuously only while ambient motion is active.
- Pause when the document is hidden and respect `prefers-reduced-motion`.
- Keep regional requests, decoding, generation, and sprite preparation outside animation callbacks.
- Add separate ambient-frame count and duration diagnostics.

## Performance

The representative and large-world pressure profiles were exercised with both asset transports. Ambient frames reuse cached visibility and depth ordering rather than rescanning the placement manifest.

Updated preparation, payload, and cache measurements are recorded in the procedural tree design document.

## Testing

- Verify deterministic placement and motion-group parameters.
- Verify branch lineages remain within one motion group.
- Verify grouped pixels exactly reproduce static foliage at zero displacement.
- Verify bounded, pixel-snapped, staggered motion.
- Verify inactive and reduced-motion behavior.
- Verify color-run and lossless-raster transport parity.
- Verify visibility-cache reuse and invalidation.

All 570 specs pass.

## Scope boundaries

This remains a deliberately small Canvas-based experiment. It does not add individual leaf animation, branch deformation, storms, wind controls, WebGL, atlases, cache eviction, persistence, production routes, or a general animation framework.