### PR TITLE
Add the Activity Forest personal overlay contract

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -246,8 +246,8 @@ The first composed development scene is available at `/__dev/views/activity-fore
 the isolated runtime assets into a deterministic 3000 × 1800 world containing 180 placements.
 The scene now includes the first fixture-only exploration loop: a deterministic player can walk
 the corridor, approach a tree, inspect fixture writing, close it, and continue from the same place.
-It also includes the first shared ambient wind slice. It remains a development preview without
-persistence or real post queries.
+It also includes the first shared ambient wind slice and a development-only personal-overlay proof.
+It remains a development preview without production persistence or real post queries.
 
 `forestSceneLayout.js` owns scene layout version 1. A placement contains only a stable placement
 id, world-space ground anchor, integer scale, phenotype id, specimen seed, and versioned asset
@@ -290,6 +290,73 @@ Active movement frames perform movement math, region-set comparison, culling, or
 draws, then cease when input stops. Procedural generation, response decoding, and color-run replay
 remain outside the animation frame. The render-duration diagnostic remains the local measurement
 point, with no universal benchmark claim for this interaction slice.
+
+### Inhabitable-world contract: generated base and personal overlay
+
+The first inhabitable-world milestone deliberately adds only one placed-object vocabulary item: a
+small clearing marker. It proves the state boundary without beginning trails, construction,
+inventory, crafting, or a general entity system.
+
+Every generated layout now includes a `baseIdentity` with exactly four fields:
+`schemaVersion`, `sceneVersion`, `seed`, and `layoutKey`. The bounded `layoutKey` fingerprints the
+world dimensions and other placement-affecting configuration, so development pressure profiles do
+not accidentally share overlays. Regenerating with the same explicit versions, seed, and
+configuration reproduces that identity and the existing tree placement ids, coordinates, specimen
+seeds, and asset keys. The base identity is not an asset identity and does not incorporate camera state,
+personal choices, or transient animation state.
+
+The separately serialized personal overlay has exactly these top-level fields:
+
+```text
+schemaVersion, id, baseIdentity, revision, objects
+```
+
+An overlay is accepted only for the base identity it names. Its object collection is capped at 32
+records even though this development UI authors only one marker. A marker record has exactly:
+
+```text
+schemaVersion, id, type="marker", worldX, worldY
+```
+
+Ids follow bounded, versioned string patterns; coordinates are bounded safe integers; unknown
+fields and unknown object types are rejected. Moving the representative marker replaces its record
+at the same stable id and increments the overlay revision. The record deliberately has no arbitrary
+metadata, behavior, asset payload, post data, or serialized generated-world fields.
+
+Applying an overlay is a pure step after base generation. It verifies schema and base compatibility,
+then validates the marker footprint against world edges, generated tree trunk collision circles,
+the protected player entrance, and any other accepted overlay footprints. Any invalid object rejects
+the applied object set rather than partially applying ambiguous personal state. Base regeneration
+does not mutate, merge into, or derive randomness from the overlay, so applying or resetting a
+marker cannot change a tree's placement or asset identity.
+
+The marker is deliberately non-solid to the player: its footprint prevents invalid placement but
+does not turn this proof into a navigation or construction system. The current corridor is valid,
+flat terrain for a marker and remains walkable. Interaction reach is a fixed contract constant, not
+saved user data, so every accepted marker remains usable without trusting an arbitrary stored radius.
+
+The development page exposes `Place marker here` and `Reset personal overlay`. Its adapter stores
+only the overlay JSON in browser `localStorage`, under a base-specific development key. Loading
+happens once during scene initialization; saving and resetting happen only in those explicit action
+handlers. Invalid JSON, an unsupported schema version, an incompatible base identity, a storage
+exception, or a newly invalid placement produces a visible diagnostic and an empty applied overlay.
+Invalid stored bytes are not silently overwritten, so a developer can inspect them and recover by
+resetting or placing a valid marker. This adapter is evidence for independent round trips, not a
+production storage policy.
+
+Markers use a fixed prepared canvas drawing path: no object asset or procedural work is needed.
+They participate in the same cached viewport culling and stable ground-Y depth order as trees and
+the player. Marker changes explicitly invalidate that cache. The shared proximity query can focus
+either a loaded tree or a marker with deterministic distance, kind, and id tie-breaking, and the
+existing keyboard, touch, prompt, modal, and focus-return behavior is reused. Animation frames do
+not access storage, parse overlay JSON, validate placement, regenerate the base, or prepare assets.
+
+The explicit future boundary is narrow: production account storage, migrations between generated
+base versions, conflict resolution, multiple devices, authorization, object asset loading, editing
+tools, free-form labels, paths, pickups, inventories, currencies, crafting, multiplayer, and a
+general component framework all remain undesigned. Supporting any of them requires a new contract
+decision; the marker schema is not an invitation to smuggle those systems into an unversioned
+payload.
 
 ### Development pressure profiles
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -35,6 +35,14 @@
   margin-bottom: 0.6rem;
 }
 
+.activity-forest__header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
 .activity-forest__help {
   margin: 0.6rem 0;
   color: var(--muted-text-color);
@@ -188,6 +196,7 @@
 @media (max-width: 600px) {
   .activity-forest { padding-top: 1rem; }
   .activity-forest__header { align-items: start; flex-direction: column; }
+  .activity-forest__header-actions { justify-content: flex-start; }
   .activity-forest__viewport { height: 62vh; min-height: 390px; }
   .activity-forest__profiles .activity-forest__cold { margin-left: 0; }
 }

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1,7 +1,7 @@
 import {
   cameraFollowingPlayer,
   createForestVisibilityCache,
-  focusedForestPlacement,
+  focusedForestSceneItem,
   forestAmbientMotionActive,
   forestSceneAssetKeysForCells,
   forestSceneCellIdsForViewport,
@@ -11,6 +11,13 @@ import {
   normalizedMovement,
   touchMovement
 } from './forest-scene-math.js';
+import { createForestDevOverlayPersistence } from './forest-overlay-persistence.js';
+import {
+  applyForestOverlay,
+  createForestMarker,
+  overlayWithForestMarker,
+  validateForestObjectPlacement
+} from './forest-world-overlay.js';
 
 const payload = document.getElementById('activity-forest-scene');
 const viewportElement = document.querySelector('[data-forest-viewport]');
@@ -27,6 +34,11 @@ if (payload && viewportElement && canvas) {
   const spritesByKey = new Map();
   const camera = { x: 0, y: 0, width: 0, height: 0 };
   const player = { ...scene.exploration.spawn };
+  const overlayPersistence = createForestDevOverlayPersistence(window.localStorage);
+  const persistedOverlay = overlayPersistence.load(scene.baseIdentity);
+  let overlay = persistedOverlay.overlay;
+  let overlayApplication = applyForestOverlay(scene, overlay);
+  let placedObjects = overlayApplication.objects;
   const keys = { left: false, right: false, up: false, down: false };
   const touch = { pointerId: null, originX: 0, originY: 0, x: 0, y: 0 };
   const dialog = document.querySelector('[data-forest-dialog]');
@@ -46,7 +58,8 @@ if (payload && viewportElement && canvas) {
     movementDuration: document.querySelector('[data-forest-movement-duration]'),
     ambientDuration: document.querySelector('[data-forest-ambient-duration]'),
     regionEntry: document.querySelector('[data-forest-region-entry]'),
-    regionLoading: document.querySelector('[data-forest-region-loading]')
+    regionLoading: document.querySelector('[data-forest-region-loading]'),
+    overlay: document.querySelector('[data-forest-overlay]')
   };
   const loadedCellIds = new Set(scene.assetLoading.initialCellIds);
   const pendingCellIds = new Set();
@@ -60,9 +73,11 @@ if (payload && viewportElement && canvas) {
   const windByPlacementId = new Map(scene.placements.map((placement) => (
     [placement.id, forestPlacementWindParameters(placement)]
   )));
-  const visibilityCache = createForestVisibilityCache(scene.placements, assetsByKey);
+  const visibilityCache = createForestVisibilityCache(
+    scene.placements, assetsByKey, 24, placedObjects
+  );
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  let focusedPlacement = null;
+  let focusedItem = null;
   let preparedSpriteCount = 0;
   let scheduledFrame = null;
   let lastFrameTime = null;
@@ -75,6 +90,14 @@ if (payload && viewportElement && canvas) {
     documentHidden: document.hidden,
     reducedMotion: reducedMotionQuery.matches
   });
+
+  function updateOverlayDiagnostic(status = persistedOverlay.status, error = persistedOverlay.error
+    || overlayApplication.error) {
+    diagnostics.overlay.textContent = `${overlay.objects.length} marker · revision ${
+      overlay.revision} · ${status}${error ? ` (${error})` : ''}`;
+  }
+
+  updateOverlayDiagnostic();
 
   function rasterLayerSource(layer) {
     const binary = window.atob(layer.data);
@@ -322,7 +345,7 @@ if (payload && viewportElement && canvas) {
     const originX = Math.round(placement.worldX - camera.x - asset.anchor.x * placement.scale);
     const originY = Math.round(placement.worldY - camera.y - asset.anchor.y * placement.scale);
     const wind = windByPlacementId.get(placement.id);
-    if (placement.id === focusedPlacement?.id) {
+    if (focusedItem?.kind === 'tree' && placement.id === focusedItem.id) {
       context.beginPath();
       context.ellipse(Math.round(placement.worldX - camera.x),
         Math.round(placement.worldY - camera.y), placement.collisionRadius + 10, 8, 0, 0,
@@ -349,6 +372,28 @@ if (payload && viewportElement && canvas) {
     }
   }
 
+  function paintMarker(marker) {
+    const x = Math.round(marker.worldX - camera.x);
+    const y = Math.round(marker.worldY - camera.y);
+    if (focusedItem?.kind === 'marker' && marker.id === focusedItem.id) {
+      context.beginPath();
+      context.ellipse(x, y, 19, 8, 0, 0, Math.PI * 2);
+      context.fillStyle = 'rgba(255, 239, 164, 0.42)';
+      context.fill();
+      context.strokeStyle = '#fff0ae';
+      context.lineWidth = 2;
+      context.stroke();
+    }
+    context.fillStyle = 'rgba(22, 35, 31, 0.28)';
+    context.fillRect(x - 10, y - 3, 20, 5);
+    context.fillStyle = '#554638';
+    context.fillRect(x - 2, y - 23, 4, 22);
+    context.fillStyle = '#d8b45c';
+    context.fillRect(x - 8, y - 27, 16, 8);
+    context.fillStyle = '#6f4d32';
+    context.fillRect(x - 5, y - 25, 10, 2);
+  }
+
   function paintPlayer() {
     const x = Math.round(player.worldX - camera.x);
     const y = Math.round(player.worldY - camera.y);
@@ -364,12 +409,15 @@ if (payload && viewportElement && canvas) {
   }
 
   function updateFocus() {
-    focusedPlacement = focusedForestPlacement(player, scene.placements.filter(
+    focusedItem = focusedForestSceneItem(player, scene.placements.filter(
       ({ assetKey }) => assetsByKey.has(assetKey)
-    ),
-      scene.exploration.interactionRadius);
-    prompt.hidden = !focusedPlacement;
-    diagnostics.focus.textContent = focusedPlacement?.id || 'None';
+    ), placedObjects, scene.exploration.interactionRadius);
+    prompt.hidden = !focusedItem;
+    const action = focusedItem?.kind === 'marker' ? 'inspect marker' : 'inspect';
+    prompt.querySelector('[data-forest-prompt-keyboard]').textContent =
+      `Press E or Enter to ${action}`;
+    prompt.querySelector('[data-forest-prompt-touch]').textContent = `Tap to ${action}`;
+    diagnostics.focus.textContent = focusedItem ? `${focusedItem.kind}: ${focusedItem.id}` : 'None';
   }
 
   function render(elapsedSeconds, moving = false, frameGap = null) {
@@ -379,10 +427,12 @@ if (payload && viewportElement && canvas) {
     const visibility = visibilityCache.read(camera, player);
     for (const item of visibility.depthOrder) {
       if (item.kind === 'player') paintPlayer();
+      else if (item.kind === 'marker') paintMarker(item.object);
       else paintTree(item.placement, elapsedSeconds);
     }
-    const { visible } = visibility;
-    diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length}`;
+    const { visible, visibleObjects } = visibility;
+    diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length} trees · ${
+      visibleObjects.length} markers`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
     const duration = window.performance.now() - start;
@@ -509,15 +559,72 @@ if (payload && viewportElement && canvas) {
   }
 
   function openInspection() {
-    if (!focusedPlacement || dialog.open) return;
+    if (!focusedItem || dialog.open) return;
     clearMovement();
-    const fixture = fixturesById.get(focusedPlacement.fixtureId);
+    if (focusedItem.kind === 'marker') {
+      dialog.querySelector('[data-forest-dialog-eyebrow]').textContent = 'A place made personal';
+      dialog.querySelector('[data-forest-post-title]').textContent = 'Your clearing marker';
+      dialog.querySelector('[data-forest-dialog-context]').hidden = true;
+      dialog.querySelector('[data-forest-post-excerpt]').textContent =
+        'This simple marker is stored in the personal overlay, independently of the generated trees.';
+      dialog.showModal();
+      return;
+    }
+    const fixture = fixturesById.get(focusedItem.value.fixtureId);
+    dialog.querySelector('[data-forest-dialog-eyebrow]').textContent = 'A writing remembered here';
+    dialog.querySelector('[data-forest-dialog-context]').hidden = false;
     dialog.querySelector('[data-forest-post-title]').textContent = fixture.title;
     dialog.querySelector('[data-forest-post-room]').textContent = fixture.roomName;
     dialog.querySelector('[data-forest-post-date]').textContent = new Intl.DateTimeFormat(undefined,
       { dateStyle: 'long' }).format(new Date(`${fixture.createdAt}T12:00:00Z`));
     dialog.querySelector('[data-forest-post-excerpt]').textContent = fixture.excerpt;
     dialog.showModal();
+  }
+
+  function setOverlay(nextOverlay, status) {
+    const application = applyForestOverlay(scene, nextOverlay);
+    if (application.error) {
+      updateOverlayDiagnostic('rejected', application.error);
+      return false;
+    }
+    overlay = nextOverlay;
+    overlayApplication = application;
+    placedObjects = application.objects;
+    visibilityCache.setObjects(placedObjects);
+    updateOverlayDiagnostic(status, null);
+    updateFocus();
+    requestRender();
+    return true;
+  }
+
+  function placeMarker() {
+    const marker = createForestMarker(player.worldX, player.worldY);
+    const placement = validateForestObjectPlacement(marker, scene, placedObjects);
+    if (!placement.valid) {
+      updateOverlayDiagnostic('placement rejected', placement.reason);
+      return;
+    }
+    const nextOverlay = overlayWithForestMarker(overlay, marker);
+    try {
+      overlayPersistence.save(nextOverlay);
+    } catch (error) {
+      updateOverlayDiagnostic('save failed', error.message);
+      return;
+    }
+    setOverlay(nextOverlay, 'saved locally');
+    viewportElement.focus();
+  }
+
+  function resetOverlay() {
+    let emptyOverlay;
+    try {
+      emptyOverlay = overlayPersistence.reset(scene.baseIdentity);
+    } catch (error) {
+      updateOverlayDiagnostic('reset failed', error.message);
+      return;
+    }
+    setOverlay(emptyOverlay, 'reset');
+    viewportElement.focus();
   }
 
   function resetPlayer() {
@@ -553,7 +660,7 @@ if (payload && viewportElement && canvas) {
       keys[direction] = true;
       requestRender();
     } else if ((event.key === 'e' || event.key === 'E' || event.key === 'Enter')
-      && focusedPlacement) {
+      && focusedItem) {
       event.preventDefault();
       openInspection();
     }
@@ -599,6 +706,8 @@ if (payload && viewportElement && canvas) {
   dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
   prompt.addEventListener('click', openInspection);
   document.querySelector('[data-forest-reset]').addEventListener('click', resetPlayer);
+  document.querySelector('[data-forest-place-marker]').addEventListener('click', placeMarker);
+  document.querySelector('[data-forest-reset-overlay]').addEventListener('click', resetOverlay);
   window.addEventListener('resize', resize);
   resize();
   resetPlayer();

--- a/public/js/forest-overlay-persistence.js
+++ b/public/js/forest-overlay-persistence.js
@@ -1,0 +1,42 @@
+import {
+  createEmptyForestOverlay,
+  validateForestOverlay
+} from './forest-world-overlay.js';
+
+export const FOREST_DEV_OVERLAY_STORAGE_PREFIX = 'daily-page:activity-forest:overlay:';
+
+function storageKey(baseIdentity) {
+  return `${FOREST_DEV_OVERLAY_STORAGE_PREFIX}${baseIdentity.sceneVersion}:${
+    baseIdentity.layoutKey}:${baseIdentity.seed}`;
+}
+
+export function createForestDevOverlayPersistence(storage) {
+  return {
+    load(baseIdentity) {
+      const empty = createEmptyForestOverlay(baseIdentity);
+      let raw;
+      try {
+        raw = storage.getItem(storageKey(baseIdentity));
+        if (raw === null) return { overlay: empty, status: 'empty', error: null };
+        const overlay = JSON.parse(raw);
+        const validation = validateForestOverlay(overlay, baseIdentity);
+        if (!validation.valid) {
+          return { overlay: empty, status: 'recovered', error: validation.reason };
+        }
+        return { overlay, status: 'loaded', error: null };
+      } catch (error) {
+        return { overlay: empty, status: 'recovered', error: error.message };
+      }
+    },
+    save(overlay) {
+      const validation = validateForestOverlay(overlay, overlay?.baseIdentity);
+      if (!validation.valid) throw new Error(`Cannot save forest overlay: ${validation.reason}.`);
+      storage.setItem(storageKey(overlay.baseIdentity), JSON.stringify(overlay));
+      return JSON.parse(JSON.stringify(overlay));
+    },
+    reset(baseIdentity) {
+      storage.removeItem(storageKey(baseIdentity));
+      return createEmptyForestOverlay(baseIdentity);
+    }
+  };
+}

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -1,3 +1,5 @@
+import { FOREST_MARKER_INTERACTION_RADIUS } from './forest-world-overlay.js';
+
 export function placementVisualRect(placement, asset) {
   const scale = placement.scale;
   return {
@@ -20,6 +22,15 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
   }).sort((left, right) => (
     left.worldY - right.worldY || left.id.localeCompare(right.id)
   ));
+}
+
+export function visibleForestObjects(objects, viewport, margin = 24) {
+  return objects.filter((object) => (
+    object.worldX + 12 >= viewport.x - margin
+      && object.worldX - 12 <= viewport.x + viewport.width + margin
+      && object.worldY + 28 >= viewport.y - margin
+      && object.worldY - 28 <= viewport.y + viewport.height + margin
+  )).sort((left, right) => left.worldY - right.worldY || left.id.localeCompare(right.id));
 }
 
 export const FOREST_AMBIENT_WIND = Object.freeze({
@@ -78,14 +89,20 @@ export function forestAmbientMotionActive({ documentHidden = false, reducedMotio
   return !documentHidden && !reducedMotion;
 }
 
-export function createForestVisibilityCache(placements, assetsByKey, margin = 24) {
+export function createForestVisibilityCache(placements, assetsByKey, margin = 24,
+  initialObjects = []) {
   let cached = null;
   let invalidated = true;
   let revision = 0;
   let snapshot = null;
+  let objects = initialObjects;
 
   return {
     invalidate() {
+      invalidated = true;
+    },
+    setObjects(nextObjects) {
+      objects = nextObjects;
       invalidated = true;
     },
     read(viewport, player) {
@@ -95,8 +112,14 @@ export function createForestVisibilityCache(placements, assetsByKey, margin = 24
         || snapshot.playerWorldY !== player.worldY || snapshot.assetCount !== assetsByKey.size;
       if (changed) {
         const visible = visibleForestPlacements(placements, assetsByKey, viewport, margin);
+        const visibleObjects = visibleForestObjects(objects, viewport, margin);
         revision += 1;
-        cached = { visible, depthOrder: forestDepthOrder(visible, player), revision };
+        cached = {
+          visible,
+          visibleObjects,
+          depthOrder: forestDepthOrder(visible, player, visibleObjects),
+          revision
+        };
         snapshot = {
           x: viewport.x,
           y: viewport.y,
@@ -218,11 +241,33 @@ export function focusedForestPlacement(player, placements, interactionRadius) {
   ))[0]?.placement || null;
 }
 
-export function forestDepthOrder(placements, player) {
+export function focusedForestSceneItem(player, placements, objects, treeInteractionRadius) {
+  const candidates = [
+    ...placements.map((placement) => ({
+      kind: 'tree', id: placement.id, value: placement,
+      distance: Math.hypot(player.worldX - placement.worldX, player.worldY - placement.worldY),
+      reach: treeInteractionRadius + placement.collisionRadius
+    })),
+    ...objects.map((object) => ({
+      kind: 'marker', id: object.id, value: object,
+      distance: Math.hypot(player.worldX - object.worldX, player.worldY - object.worldY),
+      reach: FOREST_MARKER_INTERACTION_RADIUS
+    }))
+  ];
+  return candidates.filter(({ distance, reach }) => distance <= reach)
+    .sort((left, right) => left.distance - right.distance
+      || left.kind.localeCompare(right.kind) || left.id.localeCompare(right.id))[0] || null;
+}
+
+export function forestDepthOrder(placements, player, objects = []) {
   return [
     ...placements.map((placement) => ({ kind: 'tree', id: placement.id,
       worldY: placement.worldY, placement })),
+    ...objects.map((object) => ({ kind: 'marker', id: object.id,
+      worldY: object.worldY, object })),
     { kind: 'player', id: '~player', worldY: player.worldY, player }
   ].sort((left, right) => left.worldY - right.worldY
-    || (left.kind === right.kind ? left.id.localeCompare(right.id) : left.kind === 'player' ? 1 : -1));
+    || (left.kind === right.kind ? left.id.localeCompare(right.id)
+      : left.kind === 'player' ? 1 : right.kind === 'player' ? -1
+        : left.kind.localeCompare(right.kind)));
 }

--- a/public/js/forest-world-overlay.js
+++ b/public/js/forest-world-overlay.js
@@ -1,0 +1,139 @@
+export const FOREST_OVERLAY_SCHEMA_VERSION = 1;
+export const FOREST_PLACED_OBJECT_SCHEMA_VERSION = 1;
+export const FOREST_MARKER_ID = 'forest-marker-v1-personal-clearing';
+export const FOREST_MARKER_TYPE = 'marker';
+export const FOREST_MARKER_COLLISION_RADIUS = 9;
+export const FOREST_MARKER_INTERACTION_RADIUS = 54;
+export const FOREST_OVERLAY_MAX_OBJECTS = 32;
+
+const OVERLAY_ID_PATTERN = /^forest-overlay-v1-[a-z0-9-]{1,48}$/;
+const OBJECT_ID_PATTERN = /^forest-marker-v1-[a-z0-9-]{1,48}$/;
+
+function exactKeys(value, keys) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && Object.keys(value).length === keys.length
+    && keys.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function validCoordinate(value) {
+  return Number.isSafeInteger(value) && value >= 0 && value <= 100000;
+}
+
+export function isForestBaseIdentity(value) {
+  return exactKeys(value, ['schemaVersion', 'sceneVersion', 'seed', 'layoutKey'])
+    && value.schemaVersion === 1
+    && Number.isSafeInteger(value.sceneVersion) && value.sceneVersion > 0
+    && typeof value.seed === 'string' && value.seed.length > 0 && value.seed.length <= 80
+    && typeof value.layoutKey === 'string' && /^[a-f0-9]{8}$/.test(value.layoutKey);
+}
+
+export function sameForestBaseIdentity(left, right) {
+  return isForestBaseIdentity(left) && isForestBaseIdentity(right)
+    && left.schemaVersion === right.schemaVersion
+    && left.sceneVersion === right.sceneVersion
+    && left.seed === right.seed && left.layoutKey === right.layoutKey;
+}
+
+export function isForestPlacedObject(value) {
+  return exactKeys(value, ['schemaVersion', 'id', 'type', 'worldX', 'worldY'])
+    && value.schemaVersion === FOREST_PLACED_OBJECT_SCHEMA_VERSION
+    && typeof value.id === 'string' && OBJECT_ID_PATTERN.test(value.id)
+    && value.type === FOREST_MARKER_TYPE
+    && validCoordinate(value.worldX) && validCoordinate(value.worldY);
+}
+
+export function createForestMarker(worldX, worldY, id = FOREST_MARKER_ID) {
+  return {
+    schemaVersion: FOREST_PLACED_OBJECT_SCHEMA_VERSION,
+    id,
+    type: FOREST_MARKER_TYPE,
+    worldX: Math.round(worldX),
+    worldY: Math.round(worldY)
+  };
+}
+
+export function createEmptyForestOverlay(baseIdentity) {
+  if (!isForestBaseIdentity(baseIdentity)) throw new Error('A valid forest base identity is required.');
+  return {
+    schemaVersion: FOREST_OVERLAY_SCHEMA_VERSION,
+    id: 'forest-overlay-v1-local-personal',
+    baseIdentity: { ...baseIdentity },
+    revision: 0,
+    objects: []
+  };
+}
+
+export function validateForestOverlay(value, expectedBaseIdentity) {
+  if (!exactKeys(value, [
+    'schemaVersion', 'id', 'baseIdentity', 'revision', 'objects'
+  ])) return { valid: false, reason: 'invalid-shape' };
+  if (value.schemaVersion !== FOREST_OVERLAY_SCHEMA_VERSION) {
+    return { valid: false, reason: 'unsupported-version' };
+  }
+  if (typeof value.id !== 'string' || !OVERLAY_ID_PATTERN.test(value.id)) {
+    return { valid: false, reason: 'invalid-id' };
+  }
+  if (!isForestBaseIdentity(value.baseIdentity)) {
+    return { valid: false, reason: 'invalid-base-identity' };
+  }
+  if (expectedBaseIdentity && !sameForestBaseIdentity(value.baseIdentity, expectedBaseIdentity)) {
+    return { valid: false, reason: 'incompatible-base' };
+  }
+  if (!Number.isSafeInteger(value.revision) || value.revision < 0) {
+    return { valid: false, reason: 'invalid-revision' };
+  }
+  if (!Array.isArray(value.objects) || value.objects.length > FOREST_OVERLAY_MAX_OBJECTS
+    || !value.objects.every(isForestPlacedObject)) {
+    return { valid: false, reason: 'invalid-objects' };
+  }
+  if (new Set(value.objects.map(({ id }) => id)).size !== value.objects.length) {
+    return { valid: false, reason: 'duplicate-object-id' };
+  }
+  return { valid: true, reason: null };
+}
+
+export function overlayWithForestMarker(overlay, marker) {
+  const validation = validateForestOverlay(overlay, overlay?.baseIdentity);
+  if (!validation.valid || !isForestPlacedObject(marker)) {
+    throw new Error('A valid overlay and marker are required.');
+  }
+  return {
+    ...overlay,
+    revision: overlay.revision + 1,
+    objects: [{ ...marker }]
+  };
+}
+
+export function validateForestObjectPlacement(object, scene, otherObjects = []) {
+  if (!isForestPlacedObject(object)) return { valid: false, reason: 'invalid-object' };
+  const radius = FOREST_MARKER_COLLISION_RADIUS;
+  if (object.worldX - radius < 0 || object.worldY - radius < 0
+    || object.worldX + radius > scene.world.width
+    || object.worldY + radius > scene.world.height) {
+    return { valid: false, reason: 'world-bounds' };
+  }
+  if (scene.placements.some((placement) => Math.hypot(
+    object.worldX - placement.worldX, object.worldY - placement.worldY
+  ) < radius + placement.collisionRadius)) {
+    return { valid: false, reason: 'tree-collision' };
+  }
+  const spawn = scene.exploration?.spawn;
+  if (spawn && Math.hypot(object.worldX - spawn.worldX, object.worldY - spawn.worldY)
+    < radius + spawn.radius) return { valid: false, reason: 'entrance-collision' };
+  if (otherObjects.some((other) => other.id !== object.id && Math.hypot(
+    object.worldX - other.worldX, object.worldY - other.worldY
+  ) < radius * 2)) return { valid: false, reason: 'object-collision' };
+  return { valid: true, reason: null };
+}
+
+export function applyForestOverlay(scene, overlay) {
+  const validation = validateForestOverlay(overlay, scene.baseIdentity);
+  if (!validation.valid) return { objects: [], error: validation.reason };
+  const objects = [];
+  for (const object of overlay.objects) {
+    const placement = validateForestObjectPlacement(object, scene, objects);
+    if (!placement.valid) return { objects: [], error: placement.reason };
+    objects.push({ ...object });
+  }
+  return { objects, error: null };
+}

--- a/server/services/forestSceneLayout.js
+++ b/server/services/forestSceneLayout.js
@@ -7,6 +7,7 @@ import { createRandom, hashSeed } from './forest/v3/random.js';
 import { treeAssetCacheKey } from './forest/v3/treeAsset.js';
 
 export const FOREST_SCENE_VERSION = 1;
+export const FOREST_BASE_IDENTITY_SCHEMA_VERSION = 1;
 
 export const DEFAULT_FOREST_SCENE_CONFIG = Object.freeze({
   seed: 'first-grove',
@@ -33,6 +34,26 @@ function decisionRandom(sceneSeed, candidateIndex, decision) {
 
 export function forestCorridorCenter(worldY, worldWidth) {
   return (worldWidth / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
+}
+
+export function forestBaseIdentity(config) {
+  const layoutKey = hashSeed(JSON.stringify({
+    world: config.world,
+    placementCount: config.placementCount,
+    minimumSpacing: config.minimumSpacing,
+    edgeMargin: config.edgeMargin,
+    corridorHalfWidth: config.corridorHalfWidth,
+    scale: config.scale,
+    specimenPoolSize: config.specimenPoolSize,
+    assetPoolSize: config.assetPoolSize || null,
+    phenotypeWeights: config.phenotypeWeights
+  })).toString(16).padStart(8, '0');
+  return Object.freeze({
+    schemaVersion: FOREST_BASE_IDENTITY_SCHEMA_VERSION,
+    sceneVersion: FOREST_SCENE_VERSION,
+    seed: config.seed,
+    layoutKey
+  });
 }
 
 function selectPhenotype(config, sceneSeed, candidateIndex) {
@@ -130,6 +151,7 @@ export function generateForestSceneLayout(options = {}) {
   return {
     version: FOREST_SCENE_VERSION,
     seed: config.seed,
+    baseIdentity: forestBaseIdentity(config),
     world: config.world,
     corridor: { halfWidth: config.corridorHalfWidth },
     placements

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -28,6 +28,7 @@ import {
   cameraFollowingPlayer,
   createForestVisibilityCache,
   focusedForestPlacement,
+  focusedForestSceneItem,
   FOREST_AMBIENT_WIND,
   forestAmbientMotionActive,
   forestSceneAssetKeysForCells,
@@ -41,6 +42,7 @@ import {
   playerCollides,
   touchMovement,
   placementVisualRect,
+  visibleForestObjects,
   visibleForestPlacements
 } from '../public/js/forest-scene-math.js';
 import {
@@ -398,9 +400,13 @@ describe('static Activity Forest scene', () => {
 
     const playerDepthChanged = cache.read({ ...viewport, x: 1 }, { ...player, worldY: 75 });
     expect(playerDepthChanged.revision).toBe(assetChanged.revision + 1);
+    cache.setObjects([{ id: 'marker', worldX: 45, worldY: 65 }]);
+    const objectChanged = cache.read({ ...viewport, x: 1 }, { ...player, worldY: 75 });
+    expect(objectChanged.revision).toBe(playerDepthChanged.revision + 1);
+    expect(objectChanged.visibleObjects.map(({ id }) => id)).toEqual(['marker']);
     cache.invalidate();
     expect(cache.read({ ...viewport, x: 1 }, { ...player, worldY: 75 }).revision)
-      .toBe(playerDepthChanged.revision + 1);
+      .toBe(objectChanged.revision + 1);
   });
 
   it('adds a deterministic, safe spawn and bounded fixture metadata', () => {
@@ -484,5 +490,13 @@ describe('static Activity Forest scene', () => {
       .toEqual(['above', 'far', 'tie-a', 'tie-b', '~player', 'below']);
     expect(focusedForestPlacement(player, placements.slice(1, 3), 10).id).toBe('tie-a');
     expect(focusedForestPlacement(player, [placements[4]], 10)).toBeNull();
+    const marker = { id: 'marker-a', worldX: 3, worldY: 50 };
+    expect(focusedForestSceneItem(player, placements, [marker], 10)).toEqual(
+      jasmine.objectContaining({ kind: 'marker', id: 'marker-a' })
+    );
+    expect(forestDepthOrder(placements, player, [marker]).map((item) => item.id))
+      .toEqual(['above', 'marker-a', 'far', 'tie-a', 'tie-b', '~player', 'below']);
+    expect(visibleForestObjects([marker, { id: 'offscreen-marker', worldX: 500, worldY: 500 }],
+      { x: 0, y: 0, width: 100, height: 100 }, 0)).toEqual([marker]);
   });
 });

--- a/spec/forestWorldOverlaySpec.js
+++ b/spec/forestWorldOverlaySpec.js
@@ -1,0 +1,173 @@
+import {
+  applyForestOverlay,
+  createEmptyForestOverlay,
+  createForestMarker,
+  FOREST_MARKER_ID,
+  overlayWithForestMarker,
+  sameForestBaseIdentity,
+  validateForestObjectPlacement,
+  validateForestOverlay
+} from '../public/js/forest-world-overlay.js';
+import { createForestDevOverlayPersistence } from '../public/js/forest-overlay-persistence.js';
+import { createForestExploration } from '../server/services/forestSceneExploration.js';
+import { generateForestSceneLayout } from '../server/services/forestSceneLayout.js';
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.has(key) ? values.get(key) : null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+    values
+  };
+}
+
+function sceneFixture() {
+  return createForestExploration(generateForestSceneLayout({
+    seed: 'overlay-contract', world: { width: 500, height: 500 }, placementCount: 3
+  }));
+}
+
+function safeMarker(scene) {
+  for (let worldY = 30; worldY < scene.world.height; worldY += 20) {
+    for (let worldX = 30; worldX < scene.world.width; worldX += 20) {
+      const marker = createForestMarker(worldX, worldY);
+      if (validateForestObjectPlacement(marker, scene).valid) return marker;
+    }
+  }
+  throw new Error('The fixture did not contain a valid marker position.');
+}
+
+describe('Activity Forest personal overlay contract', () => {
+  it('keeps generated base identity deterministic and independent of tree asset identity', () => {
+    const first = generateForestSceneLayout({ seed: 'identity-proof' });
+    const repeated = generateForestSceneLayout({ seed: 'identity-proof' });
+    const changed = generateForestSceneLayout({ seed: 'identity-proof-2' });
+    const resized = generateForestSceneLayout({
+      seed: 'identity-proof', world: { width: 3600, height: 2000 }
+    });
+
+    expect(repeated.baseIdentity).toEqual(first.baseIdentity);
+    expect(sameForestBaseIdentity(repeated.baseIdentity, first.baseIdentity)).toBeTrue();
+    expect(sameForestBaseIdentity(changed.baseIdentity, first.baseIdentity)).toBeFalse();
+    expect(sameForestBaseIdentity(resized.baseIdentity, first.baseIdentity)).toBeFalse();
+    expect(repeated.placements).toEqual(first.placements);
+    expect(repeated.placements.map(({ id, assetKey, worldX, worldY }) => (
+      { id, assetKey, worldX, worldY }
+    ))).toEqual(first.placements.map(({ id, assetKey, worldX, worldY }) => (
+      { id, assetKey, worldX, worldY }
+    )));
+  });
+
+  it('round trips a bounded overlay without serializing the generated scene', () => {
+    const scene = sceneFixture();
+    const generatedIdentity = scene.placements.map(({ id, assetKey, worldX, worldY }) => (
+      { id, assetKey, worldX, worldY }
+    ));
+    const overlay = overlayWithForestMarker(
+      createEmptyForestOverlay(scene.baseIdentity), safeMarker(scene)
+    );
+    const roundTrip = JSON.parse(JSON.stringify(overlay));
+
+    expect(validateForestOverlay(roundTrip, scene.baseIdentity).valid).toBeTrue();
+    expect(roundTrip).toEqual(overlay);
+    expect(JSON.stringify(roundTrip)).not.toContain('placements');
+    expect(applyForestOverlay(scene, roundTrip)).toEqual({
+      objects: overlay.objects, error: null
+    });
+    expect(scene.placements.map(({ id, assetKey, worldX, worldY }) => (
+      { id, assetKey, worldX, worldY }
+    ))).toEqual(generatedIdentity);
+  });
+
+  it('retains stable object identity when the representative marker moves', () => {
+    const scene = sceneFixture();
+    const initial = overlayWithForestMarker(
+      createEmptyForestOverlay(scene.baseIdentity), safeMarker(scene)
+    );
+    const movedMarker = createForestMarker(250, 250);
+    const moved = overlayWithForestMarker(initial, movedMarker);
+
+    expect(initial.objects[0].id).toBe(FOREST_MARKER_ID);
+    expect(moved.objects[0].id).toBe(initial.objects[0].id);
+    expect(moved.revision).toBe(initial.revision + 1);
+    expect(moved.objects.length).toBe(1);
+  });
+
+  it('validates world bounds, generated tree occupancy, the entrance, and other objects', () => {
+    const scene = sceneFixture();
+    const tree = scene.placements[0];
+    const valid = safeMarker(scene);
+
+    expect(validateForestObjectPlacement(valid, scene)).toEqual({ valid: true, reason: null });
+    expect(validateForestObjectPlacement(createForestMarker(2, 2), scene).reason)
+      .toBe('world-bounds');
+    expect(validateForestObjectPlacement(
+      createForestMarker(tree.worldX, tree.worldY), scene
+    ).reason).toBe('tree-collision');
+    expect(validateForestObjectPlacement(createForestMarker(
+      scene.exploration.spawn.worldX, scene.exploration.spawn.worldY
+    ), scene).reason).toBe('entrance-collision');
+    expect(validateForestObjectPlacement(
+      createForestMarker(valid.worldX + 1, valid.worldY + 1, 'forest-marker-v1-second'),
+      scene,
+      [valid]
+    ).reason).toBe('object-collision');
+  });
+
+  it('rejects unknown fields, malformed objects, duplicate ids, and unsupported versions', () => {
+    const scene = sceneFixture();
+    const valid = overlayWithForestMarker(
+      createEmptyForestOverlay(scene.baseIdentity), safeMarker(scene)
+    );
+
+    expect(validateForestOverlay({ ...valid, extra: true }, scene.baseIdentity).reason)
+      .toBe('invalid-shape');
+    expect(validateForestOverlay({ ...valid, schemaVersion: 2 }, scene.baseIdentity).reason)
+      .toBe('unsupported-version');
+    expect(validateForestOverlay({ ...valid, objects: [{ ...valid.objects[0], label: 'free text' }] },
+      scene.baseIdentity).reason).toBe('invalid-objects');
+    expect(validateForestOverlay({ ...valid, objects: [valid.objects[0], valid.objects[0]] },
+      scene.baseIdentity).reason).toBe('duplicate-object-id');
+  });
+
+  it('saves independently, reloads after base regeneration, and resets explicitly', () => {
+    const storage = memoryStorage();
+    const persistence = createForestDevOverlayPersistence(storage);
+    const scene = sceneFixture();
+    const overlay = overlayWithForestMarker(
+      createEmptyForestOverlay(scene.baseIdentity), safeMarker(scene)
+    );
+
+    persistence.save(overlay);
+    const regenerated = sceneFixture();
+    const loaded = persistence.load(regenerated.baseIdentity);
+
+    expect(loaded.status).toBe('loaded');
+    expect(applyForestOverlay(regenerated, loaded.overlay).objects).toEqual(overlay.objects);
+    expect(regenerated.placements).toEqual(scene.placements);
+    expect(persistence.reset(scene.baseIdentity).objects).toEqual([]);
+    expect(persistence.load(scene.baseIdentity).status).toBe('empty');
+  });
+
+  it('recovers to an empty overlay without overwriting invalid or incompatible data', () => {
+    const scene = sceneFixture();
+    const storage = memoryStorage();
+    const persistence = createForestDevOverlayPersistence(storage);
+    const key = `daily-page:activity-forest:overlay:${scene.baseIdentity.sceneVersion}:${
+      scene.baseIdentity.layoutKey}:${scene.baseIdentity.seed}`;
+
+    storage.setItem(key, '{bad json');
+    const invalid = persistence.load(scene.baseIdentity);
+    expect(invalid.status).toBe('recovered');
+    expect(invalid.overlay.objects).toEqual([]);
+    expect(storage.getItem(key)).toBe('{bad json');
+
+    const incompatible = createEmptyForestOverlay({ ...scene.baseIdentity, seed: 'other-base' });
+    storage.setItem(key, JSON.stringify(incompatible));
+    expect(persistence.load(scene.baseIdentity)).toEqual(jasmine.objectContaining({
+      status: 'recovered', error: 'incompatible-base'
+    }));
+    expect(storage.getItem(key)).toBe(JSON.stringify(incompatible));
+  });
+});

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -21,7 +21,10 @@ block content
           else
             | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
             | The grove remains deterministic and is composed from reusable procedural tree assets.
-      button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
+      .activity-forest__header-actions
+        button.activity-forest__reset(type='button' data-forest-place-marker) Place marker here
+        button.activity-forest__reset(type='button' data-forest-reset-overlay) Reset personal overlay
+        button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
 
     nav.activity-forest__profiles(aria-label='Forest pressure configurations')
       each availableProfile in pressureProfiles
@@ -44,7 +47,8 @@ block content
       ) Lossless raster experiment
 
     p#activity-forest-help.activity-forest__help
-      | Move with arrow keys or WASD, or touch and drag in the forest. Near a tree, inspect its writing.
+      | Move with arrow keys or WASD, or touch and drag in the forest. Inspect nearby trees or your marker.
+      | “Place marker here” saves one development-only personal overlay independently of the grove.
 
     .activity-forest__viewport(
       tabindex='0'
@@ -57,8 +61,8 @@ block content
       .activity-forest__joystick(data-forest-joystick hidden aria-hidden='true')
         .activity-forest__joystick-stick(data-forest-joystick-stick)
       button.activity-forest__prompt(type='button' data-forest-prompt hidden)
-        span.activity-forest__prompt-keyboard Press E or Enter to inspect
-        span.activity-forest__prompt-touch Tap to inspect
+        span.activity-forest__prompt-keyboard(data-forest-prompt-keyboard) Press E or Enter to inspect
+        span.activity-forest__prompt-touch(data-forest-prompt-touch) Tap to inspect
 
     dl.activity-forest__diagnostics(aria-label='Scene diagnostics')
       div
@@ -70,6 +74,12 @@ block content
       div
         dt Placements
         dd= scene.placements.length
+      div
+        dt Generated base
+        dd v#{scene.baseIdentity.sceneVersion} · #{scene.baseIdentity.seed} · #{scene.baseIdentity.layoutKey}
+      div
+        dt Personal overlay
+        dd(data-forest-overlay) —
       div
         dt Unique assets
         dd= scene.assetLoading.totalAssetCount
@@ -138,9 +148,9 @@ block content
         dd(data-forest-region-entry) Walk beyond the initial view
 
     dialog.activity-forest__dialog(data-forest-dialog aria-labelledby='forest-post-title')
-      p.activity-forest__dialog-eyebrow A writing remembered here
+      p.activity-forest__dialog-eyebrow(data-forest-dialog-eyebrow) A writing remembered here
       h2#forest-post-title(data-forest-post-title)
-      p.activity-forest__dialog-context
+      p.activity-forest__dialog-context(data-forest-dialog-context)
         span(data-forest-post-room)
         span(aria-hidden='true')  ·
         time(data-forest-post-date)


### PR DESCRIPTION
## Summary

Establish the first inhabitable-world contract for Activity Forest by separating the deterministic generated base from a versioned personal overlay.

This uses one deliberately simple clearing marker to prove that personal world state can be stored, reapplied, reset, validated, and rendered without changing generated tree placement or asset identity.

## What changed

- Added a deterministic generated-base identity containing:
  - Scene version
  - Scene seed
  - Placement-configuration fingerprint
- Added bounded, JSON-serializable schemas for:
  - Personal overlays
  - Placed marker objects
- Added stable overlay and placed-object identities.
- Added marker placement validation for:
  - World bounds
  - Tree trunk collisions
  - The protected forest entrance
  - Other overlay footprints
- Added a development-only `localStorage` persistence adapter.
- Added safe recovery for:
  - Invalid JSON
  - Unsupported schema versions
  - Incompatible generated bases
  - Invalid saved placements
  - Browser storage failures
- Added explicit marker placement and overlay reset controls.
- Integrated markers with:
  - Viewport culling
  - Stable ground-Y depth ordering
  - Proximity focus
  - Keyboard, pointer, and touch inspection
  - Scene diagnostics
- Kept persistence access, parsing, placement validation, generation, and asset preparation outside animation frames.
- Documented the implemented contract and its future boundaries.

## Persistence boundary

The browser adapter is intentionally development-only and stores only the personal overlay delta.

It is not a production database design. Production storage, authorization, synchronization, migrations, and multi-device conflict handling remain future decisions.

## Testing

- Full test suite: 577 specs, 0 failures
- Focused forest suites: 27 specs, 0 failures
- ESLint passes for the affected JavaScript
- Activity Forest Pug template compiles successfully
- `git diff --check` passes

## Non-goals

This PR does not add:

- Trails or general terrain editing
- Pickups or inventory
- Crafting or currencies
- General building tools
- Multiplayer
- Production persistence
- An entity-component system
- A generalized game framework

## Next step

Milestone 2 can build one persistent, editable trail on top of this overlay boundary, preferably beginning with a deliberately constrained stepping-stone representation.