### PR TITLE
Add persistent editable stepping-stone trails to Activity Forest

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -293,9 +293,10 @@ point, with no universal benchmark claim for this interaction slice.
 
 ### Inhabitable-world contract: generated base and personal overlay
 
-The first inhabitable-world milestone deliberately adds only one placed-object vocabulary item: a
-small clearing marker. It proves the state boundary without beginning trails, construction,
-inventory, crafting, or a general entity system.
+The inhabitable-world work began with a small clearing marker. Milestone 2 adds one deliberately
+narrow editable-trail item, a stepping stone. Together they prove that the state boundary supports a
+reversible spatial edit without beginning general construction, inventory, crafting, or an entity
+system.
 
 Every generated layout now includes a `baseIdentity` with exactly four fields:
 `schemaVersion`, `sceneVersion`, `seed`, and `layoutKey`. The bounded `layoutKey` fingerprints the
@@ -312,7 +313,7 @@ schemaVersion, id, baseIdentity, revision, objects
 ```
 
 An overlay is accepted only for the base identity it names. Its object collection is capped at 32
-records even though this development UI authors only one marker. A marker record has exactly:
+records. A marker record has exactly:
 
 ```text
 schemaVersion, id, type="marker", worldX, worldY
@@ -322,6 +323,65 @@ Ids follow bounded, versioned string patterns; coordinates are bounded safe inte
 fields and unknown object types are rejected. Moving the representative marker replaces its record
 at the same stable id and increments the overlay revision. The record deliberately has no arbitrary
 metadata, behavior, asset payload, post data, or serialized generated-world fields.
+
+### Milestone 2 persistent editable-trail contract
+
+A stepping-stone record uses the same placed-object schema version and has exactly:
+
+```text
+schemaVersion, id, type="stepping-stone", worldX, worldY
+```
+
+Stone ids match the bounded `forest-stone-v1-*` pattern. The editor allocates the lowest unused
+two-digit ordinal from `forest-stone-v1-01` through `forest-stone-v1-12`, giving the trail a hard
+limit of 12 stones and deterministic identity allocation. A move replaces coordinates under the
+same id; it never removes and recreates the object. Accepted objects are stored in id order, making
+JSON output and equal-ground ordering stable. Unknown fields, non-integer or out-of-range
+coordinates, duplicate ids, mismatched id/type pairs, and unsupported object or overlay schema
+versions reject the complete overlay.
+
+The development page exposes one `Edit trail` mode and four small controls: place, move nearest,
+remove, and done. `T` toggles editing; `P`, `M`, Delete/Backspace, Enter, and Escape provide the
+corresponding keyboard path while ordinary movement remains available. Pointer and touch positions
+map directly to world coordinates during editing instead of starting the movement joystick. The
+canvas shows a pale valid or red invalid preview, the compact live status announces a specific
+validation reason, and diagnostics name the active tool and validity. Leaving the mode clears only
+transient preview and selection state and returns focus to the viewport. Editing adds no motion, so
+reduced-motion behavior remains the existing ambient-motion contract.
+
+Placement validation is pure and deterministic. The fixed stone radius is 11 world pixels. A stone
+must remain inside the world; avoid generated trunk collision circles; remain outside the entrance's
+52-pixel protected radius; keep 14 pixels of fixed clearance beyond each tree and stone collision
+footprint; and avoid marker or other overlay-object footprints. The tree clearance protects visual
+legibility immediately around a trunk without reserving the tree's full 70-pixel interaction reach.
+Because stones are non-solid, visually open passages between trees remain usable while every nearby
+position from which writing can be inspected stays walkable. Distinct stones must be at
+least 26 pixels apart. After the first stone, a new or moved stone must be within 96 pixels of
+another stone. The complete set must remain connected under that same 96-pixel neighbor rule.
+Moving or removing a bridge stone is rejected instead of partially splitting the trail. These rules
+protect the spawn and the space needed to approach nearby writing.
+
+Stones are non-solid ground decoration. They cannot block player movement, close a corridor, or
+strand the player; validation protects legibility and interaction space without turning the trail
+into navigation geometry. Adjacent visuals use one narrow rule: in stable id order, each stone after
+the first draws one subdued ground join to its nearest earlier stone within 96 pixels, with id
+tie-breaking. This is a visual hint only, not path topology, collision, or pathfinding.
+
+Place, move, and remove operations construct and validate a complete candidate overlay before
+storage or live state changes. A rejected edit returns the original overlay object, so there is no
+partial revision or stranded state. A successful edit increments the overlay revision exactly once,
+saves through the existing development-only adapter, then invalidates the visible-object cache.
+Reset removes the base-specific local value and reapplies an empty overlay. Regenerating the same
+base reproduces the same tree placement and asset identities before independently reapplying saved
+stones. Invalid JSON, incompatible bases, invalid placements, or unsupported versions recover to an
+empty applied overlay while leaving offending saved bytes available for development diagnosis.
+
+Stepping stones use fixed canvas primitives and bounded culling footprints. They enter the existing
+viewport cache and stable ground-Y depth ordering with id tie-breaking. Joins and visible stones are
+drawn from already validated in-memory objects. Storage access, JSON decoding, schema and placement
+validation, base generation, asset preparation, and overlay mutation stay in initialization or
+explicit editing handlers, never animation frames. The 12-stone bound makes the join pass deliberate
+without introducing a spatial index or regional overlay loader.
 
 Applying an overlay is a pure step after base generation. It verifies schema and base compatibility,
 then validates the marker footprint against world edges, generated tree trunk collision circles,
@@ -351,12 +411,14 @@ either a loaded tree or a marker with deterministic distance, kind, and id tie-b
 existing keyboard, touch, prompt, modal, and focus-return behavior is reused. Animation frames do
 not access storage, parse overlay JSON, validate placement, regenerate the base, or prepare assets.
 
-The explicit future boundary is narrow: production account storage, migrations between generated
-base versions, conflict resolution, multiple devices, authorization, object asset loading, editing
-tools, free-form labels, paths, pickups, inventories, currencies, crafting, multiplayer, and a
-general component framework all remain undesigned. Supporting any of them requires a new contract
-decision; the marker schema is not an invitation to smuggle those systems into an unversioned
-payload.
+The explicit future boundary remains narrow: production account or database storage, migrations
+between generated base versions, conflict resolution, multiple devices, authorization, object asset
+loading, free-form labels, path topology, automatic pathfinding, terrain painting, bridges,
+elevation, excavation, pickups, inventories, currencies, resource costs, crafting, generalized
+construction tools, multiplayer, and a general component framework all remain undesigned. The
+stepping-stone contract does not authorize trail networks, navigation graphs, terrain mutation, or a
+complete customization system. Supporting those requires a new versioned contract decision;
+neither placed-object type is an invitation to smuggle new systems into an unversioned payload.
 
 ### Development pressure profiles
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -49,6 +49,29 @@
   font-size: 0.85rem;
 }
 
+.activity-forest__trail-tools {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.8rem;
+  margin: 0.6rem 0;
+  border: 1px solid #8d7b55;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  background: #f3ead0;
+  color: #34463d;
+  font-size: 0.82rem;
+}
+
+.activity-forest__trail-tools[hidden] { display: none; }
+.activity-forest__trail-tools [role='status'] { flex: 1 1 280px; }
+.activity-forest__trail-actions { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.activity-forest__trail-actions button[aria-pressed='true'] {
+  border-color: #6f5431;
+  background: #6f5431;
+  color: #fff8e5;
+}
+
 .activity-forest__profiles {
   display: flex;
   flex-wrap: wrap;

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -15,6 +15,12 @@ import { createForestDevOverlayPersistence } from './forest-overlay-persistence.
 import {
   applyForestOverlay,
   createForestMarker,
+  createForestTrailPlacementPreview,
+  forestSteppingStoneJoins,
+  FOREST_STEPPING_STONE_TYPE,
+  nextForestSteppingStoneId,
+  overlayWithForestSteppingStone,
+  overlayWithoutForestSteppingStone,
   overlayWithForestMarker,
   validateForestObjectPlacement
 } from './forest-world-overlay.js';
@@ -45,6 +51,11 @@ if (payload && viewportElement && canvas) {
   const prompt = document.querySelector('[data-forest-prompt]');
   const joystick = document.querySelector('[data-forest-joystick]');
   const joystickStick = joystick.querySelector('[data-forest-joystick-stick]');
+  const trailTools = document.querySelector('[data-forest-trail-tools]');
+  const trailToggle = document.querySelector('[data-forest-toggle-trail]');
+  const trailStatus = document.querySelector('[data-forest-trail-status]');
+  const trailModeLabel = document.querySelector('[data-forest-trail-mode]');
+  const trailEditor = { active: false, tool: 'place', preview: null, movingId: null };
   const diagnostics = {
     visible: document.querySelector('[data-forest-visible]'),
     camera: document.querySelector('[data-forest-camera]'),
@@ -59,7 +70,8 @@ if (payload && viewportElement && canvas) {
     ambientDuration: document.querySelector('[data-forest-ambient-duration]'),
     regionEntry: document.querySelector('[data-forest-region-entry]'),
     regionLoading: document.querySelector('[data-forest-region-loading]'),
-    overlay: document.querySelector('[data-forest-overlay]')
+    overlay: document.querySelector('[data-forest-overlay]'),
+    trail: document.querySelector('[data-forest-trail-diagnostic]')
   };
   const loadedCellIds = new Set(scene.assetLoading.initialCellIds);
   const pendingCellIds = new Set();
@@ -93,7 +105,11 @@ if (payload && viewportElement && canvas) {
 
   function updateOverlayDiagnostic(status = persistedOverlay.status, error = persistedOverlay.error
     || overlayApplication.error) {
-    diagnostics.overlay.textContent = `${overlay.objects.length} marker · revision ${
+    const stoneCount = overlay.objects.filter(({ type }) => (
+      type === FOREST_STEPPING_STONE_TYPE
+    )).length;
+    const markerCount = overlay.objects.length - stoneCount;
+    diagnostics.overlay.textContent = `${markerCount} marker · ${stoneCount} stones · revision ${
       overlay.revision} · ${status}${error ? ` (${error})` : ''}`;
   }
 
@@ -394,6 +410,43 @@ if (payload && viewportElement && canvas) {
     context.fillRect(x - 5, y - 25, 10, 2);
   }
 
+  function paintTrailJoins() {
+    const byId = new Map(placedObjects.map((object) => [object.id, object]));
+    context.lineWidth = 5;
+    context.lineCap = 'round';
+    context.strokeStyle = 'rgba(112, 94, 66, 0.36)';
+    for (const join of forestSteppingStoneJoins(placedObjects)) {
+      const from = byId.get(join.fromId);
+      const to = byId.get(join.toId);
+      context.beginPath();
+      context.moveTo(Math.round(from.worldX - camera.x), Math.round(from.worldY - camera.y));
+      context.lineTo(Math.round(to.worldX - camera.x), Math.round(to.worldY - camera.y));
+      context.stroke();
+    }
+  }
+
+  function paintSteppingStone(stone, preview = false) {
+    const x = Math.round(stone.worldX - camera.x);
+    const y = Math.round(stone.worldY - camera.y);
+    context.beginPath();
+    context.ellipse(x, y, 13, 6, 0, 0, Math.PI * 2);
+    context.fillStyle = preview
+      ? (trailEditor.preview?.valid ? 'rgba(238, 224, 181, 0.62)' : 'rgba(173, 78, 62, 0.62)')
+      : '#b8aa83';
+    context.fill();
+    context.strokeStyle = preview
+      ? (trailEditor.preview?.valid ? '#fff0ae' : '#842f27') : '#75694f';
+    context.lineWidth = preview ? 2 : 1;
+    context.stroke();
+    if (!preview) {
+      context.beginPath();
+      context.moveTo(x - 5, y - 1);
+      context.lineTo(x + 4, y - 2);
+      context.strokeStyle = 'rgba(244, 235, 202, 0.48)';
+      context.stroke();
+    }
+  }
+
   function paintPlayer() {
     const x = Math.round(player.worldX - camera.x);
     const y = Math.round(player.worldY - camera.y);
@@ -424,15 +477,21 @@ if (payload && viewportElement && canvas) {
     const start = window.performance.now();
     context.imageSmoothingEnabled = false;
     paintGround();
+    paintTrailJoins();
     const visibility = visibilityCache.read(camera, player);
     for (const item of visibility.depthOrder) {
       if (item.kind === 'player') paintPlayer();
       else if (item.kind === 'marker') paintMarker(item.object);
+      else if (item.kind === FOREST_STEPPING_STONE_TYPE) paintSteppingStone(item.object);
       else paintTree(item.placement, elapsedSeconds);
+    }
+    if (trailEditor.active && trailEditor.preview) {
+      paintSteppingStone(trailEditor.preview.stone, true);
     }
     const { visible, visibleObjects } = visibility;
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length} trees · ${
-      visibleObjects.length} markers`;
+      visibleObjects.filter(({ type }) => type === 'marker').length} markers · ${
+      visibleObjects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length} stones`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
     const duration = window.performance.now() - start;
@@ -502,6 +561,9 @@ if (payload && viewportElement && canvas) {
         scene.world, scene.placements));
       followPlayer();
       updateFocus();
+      if (trailEditor.active && trailEditor.tool !== 'remove') {
+        previewTrailAt(player.worldX, player.worldY, false);
+      }
     }
     render(timestamp / 1000, moving, frameGap);
     if (moving || ambientMotionActive) scheduledFrame = requestAnimationFrame(frame);
@@ -597,6 +659,144 @@ if (payload && viewportElement && canvas) {
     return true;
   }
 
+  const trailReasonText = {
+    'world-bounds': 'That stone would cross the edge of the world.',
+    'tree-collision': 'That position overlaps a tree.',
+    'protected-entrance': 'Keep the entrance clearing open.',
+    'entrance-collision': 'Keep the entrance clearing open.',
+    'tree-interaction-space': 'That stone is too close to the tree trunk.',
+    'object-collision': 'That position overlaps another overlay object.',
+    'stone-too-close': 'Stones must be at least 26 px apart.',
+    'trail-gap': 'Keep each new stone within 96 px of the trail.',
+    'stone-limit': 'This focused trail is limited to 12 stones.',
+    'trail-disconnected': 'That edit would split the trail.',
+    'stone-not-found': 'Choose an existing stepping stone.'
+  };
+
+  function trailStones() {
+    return placedObjects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE);
+  }
+
+  function nearestTrailStone(worldX, worldY, maximumDistance = 70) {
+    return trailStones().map((stone) => ({ stone, distance: Math.hypot(
+      worldX - stone.worldX, worldY - stone.worldY
+    ) })).filter(({ distance }) => distance <= maximumDistance)
+      .sort((left, right) => left.distance - right.distance
+        || left.stone.id.localeCompare(right.stone.id))[0]?.stone || null;
+  }
+
+  function reportTrail(message, validity = '') {
+    trailStatus.textContent = message;
+    diagnostics.trail.textContent = `${trailEditor.active ? trailEditor.tool : 'Off'}${
+      validity ? ` · ${validity}` : ''}`;
+  }
+
+  function updateTrailControls() {
+    trailTools.hidden = !trailEditor.active;
+    trailToggle.setAttribute('aria-pressed', String(trailEditor.active));
+    trailToggle.textContent = trailEditor.active ? 'Editing trail' : 'Edit trail';
+    trailModeLabel.textContent = `Trail editing: ${trailEditor.tool}`;
+    for (const tool of ['place', 'move', 'remove']) {
+      document.querySelector(`[data-forest-trail-${tool}]`).setAttribute(
+        'aria-pressed', String(trailEditor.tool === tool)
+      );
+    }
+  }
+
+  function setTrailTool(tool) {
+    trailEditor.tool = tool;
+    trailEditor.movingId = tool === 'move'
+      ? nearestTrailStone(player.worldX, player.worldY)?.id || null : null;
+    trailEditor.preview = null;
+    updateTrailControls();
+    if (tool === 'move' && !trailEditor.movingId) {
+      reportTrail('Stand near a stone, then choose Move nearest.', 'no nearby stone');
+    } else if (tool === 'remove') {
+      reportTrail('Choose a stone to remove. Removal is rejected if it would split the trail.');
+    } else {
+      reportTrail(tool === 'move' ? 'Choose a new clear position for the selected stone.'
+        : 'Choose clear ground; connected stones stay 26–96 px apart.');
+    }
+    requestRender();
+  }
+
+  function toggleTrailEditor(force) {
+    trailEditor.active = typeof force === 'boolean' ? force : !trailEditor.active;
+    trailEditor.preview = null;
+    trailEditor.movingId = null;
+    clearMovement();
+    updateTrailControls();
+    if (trailEditor.active) setTrailTool('place');
+    else reportTrail('Off');
+    viewportElement.focus();
+    requestRender();
+  }
+
+  function previewTrailAt(worldX, worldY, shouldRender = true) {
+    if (!trailEditor.active || trailEditor.tool === 'remove') return;
+    const id = trailEditor.tool === 'move'
+      ? trailEditor.movingId : nextForestSteppingStoneId(overlay);
+    if (!id) {
+      trailEditor.preview = null;
+      reportTrail(trailReasonText['stone-limit'], 'invalid: stone-limit');
+      return;
+    }
+    const otherObjects = placedObjects.filter(({ id: objectId }) => objectId !== id);
+    trailEditor.preview = createForestTrailPlacementPreview(
+      worldX, worldY, id, scene, otherObjects
+    );
+    const validity = trailEditor.preview;
+    reportTrail(validity.valid ? 'Valid position. Click or press Enter to save.'
+      : (trailReasonText[validity.reason] || validity.reason),
+    validity.valid ? 'valid preview' : `invalid: ${validity.reason}`);
+    if (shouldRender) requestRender();
+  }
+
+  function saveTrailResult(result, action) {
+    if (!result.valid) {
+      reportTrail(trailReasonText[result.reason] || result.reason, `rejected: ${result.reason}`);
+      return false;
+    }
+    try {
+      overlayPersistence.save(result.overlay);
+    } catch (error) {
+      reportTrail(`Save failed: ${error.message}`, 'save failed');
+      return false;
+    }
+    setOverlay(result.overlay, `trail ${action} saved locally`);
+    trailEditor.preview = null;
+    if (trailEditor.tool === 'move') trailEditor.movingId = null;
+    reportTrail(`Stone ${action}. The overlay is saved locally.`, action);
+    return true;
+  }
+
+  function commitTrailAt(worldX, worldY) {
+    if (trailEditor.tool === 'remove') {
+      const stone = nearestTrailStone(worldX, worldY);
+      if (!stone) {
+        reportTrail('Choose a nearby stepping stone.', 'invalid: stone-not-found');
+        return;
+      }
+      saveTrailResult(overlayWithoutForestSteppingStone(overlay, stone.id), 'removed');
+      return;
+    }
+    if (trailEditor.tool === 'move' && !trailEditor.movingId) {
+      const stone = nearestTrailStone(worldX, worldY);
+      if (!stone) {
+        reportTrail('Choose a nearby stepping stone to move.', 'invalid: stone-not-found');
+        return;
+      }
+      trailEditor.movingId = stone.id;
+      reportTrail(`Selected ${stone.id}. Choose its new clear position.`, 'stone selected');
+      return;
+    }
+    previewTrailAt(worldX, worldY);
+    if (!trailEditor.preview?.valid) return;
+    saveTrailResult(overlayWithForestSteppingStone(
+      overlay, trailEditor.preview.stone, scene
+    ), trailEditor.tool === 'move' ? 'moved' : 'placed');
+  }
+
   function placeMarker() {
     const marker = createForestMarker(player.worldX, player.worldY);
     const placement = validateForestObjectPlacement(marker, scene, placedObjects);
@@ -624,6 +824,9 @@ if (payload && viewportElement && canvas) {
       return;
     }
     setOverlay(emptyOverlay, 'reset');
+    trailEditor.preview = null;
+    trailEditor.movingId = null;
+    if (trailEditor.active) setTrailTool('place');
     viewportElement.focus();
   }
 
@@ -659,6 +862,28 @@ if (payload && viewportElement && canvas) {
       event.preventDefault();
       keys[direction] = true;
       requestRender();
+    } else if ((event.key === 't' || event.key === 'T')) {
+      event.preventDefault();
+      toggleTrailEditor();
+    } else if (trailEditor.active && (event.key === 'p' || event.key === 'P')) {
+      event.preventDefault();
+      setTrailTool('place');
+        previewTrailAt(player.worldX, player.worldY, false);
+    } else if (trailEditor.active && (event.key === 'm' || event.key === 'M')) {
+      event.preventDefault();
+      setTrailTool('move');
+      previewTrailAt(player.worldX, player.worldY);
+    } else if (trailEditor.active && (event.key === 'Delete' || event.key === 'Backspace')) {
+      event.preventDefault();
+      setTrailTool('remove');
+      commitTrailAt(player.worldX, player.worldY);
+    } else if (trailEditor.active && event.key === 'Escape') {
+      event.preventDefault();
+      toggleTrailEditor(false);
+    } else if (trailEditor.active && event.key === 'Enter') {
+      event.preventDefault();
+      commitTrailAt(trailEditor.preview?.stone.worldX ?? player.worldX,
+        trailEditor.preview?.stone.worldY ?? player.worldY);
     } else if ((event.key === 'e' || event.key === 'E' || event.key === 'Enter')
       && focusedItem) {
       event.preventDefault();
@@ -673,6 +898,14 @@ if (payload && viewportElement && canvas) {
     }
   });
   viewportElement.addEventListener('pointerdown', (event) => {
+    if (trailEditor.active && !event.target.closest('button') && !dialog.open) {
+      event.preventDefault();
+      const viewportRect = viewportElement.getBoundingClientRect();
+      commitTrailAt(camera.x + event.clientX - viewportRect.left,
+        camera.y + event.clientY - viewportRect.top);
+      viewportElement.focus();
+      return;
+    }
     if (event.pointerType === 'mouse' || event.target.closest('button') || dialog.open) return;
     event.preventDefault();
     touch.pointerId = event.pointerId;
@@ -688,6 +921,12 @@ if (payload && viewportElement && canvas) {
     viewportElement.focus();
   });
   viewportElement.addEventListener('pointermove', (event) => {
+    if (trailEditor.active) {
+      const viewportRect = viewportElement.getBoundingClientRect();
+      previewTrailAt(camera.x + event.clientX - viewportRect.left,
+        camera.y + event.clientY - viewportRect.top);
+      return;
+    }
     if (event.pointerId !== touch.pointerId) return;
     event.preventDefault();
     updateTouchMovement(event);
@@ -706,9 +945,26 @@ if (payload && viewportElement && canvas) {
   dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
   prompt.addEventListener('click', openInspection);
   document.querySelector('[data-forest-reset]').addEventListener('click', resetPlayer);
+  trailToggle.addEventListener('click', () => toggleTrailEditor());
+  document.querySelector('[data-forest-trail-place]').addEventListener('click', () => {
+    setTrailTool('place');
+    viewportElement.focus();
+  });
+  document.querySelector('[data-forest-trail-move]').addEventListener('click', () => {
+    setTrailTool('move');
+    viewportElement.focus();
+  });
+  document.querySelector('[data-forest-trail-remove]').addEventListener('click', () => {
+    setTrailTool('remove');
+    viewportElement.focus();
+  });
+  document.querySelector('[data-forest-trail-done]').addEventListener('click', () => (
+    toggleTrailEditor(false)
+  ));
   document.querySelector('[data-forest-place-marker]').addEventListener('click', placeMarker);
   document.querySelector('[data-forest-reset-overlay]').addEventListener('click', resetOverlay);
   window.addEventListener('resize', resize);
   resize();
+  updateTrailControls();
   resetPlayer();
 }

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -1,4 +1,7 @@
-import { FOREST_MARKER_INTERACTION_RADIUS } from './forest-world-overlay.js';
+import {
+  FOREST_MARKER_INTERACTION_RADIUS,
+  FOREST_STEPPING_STONE_TYPE
+} from './forest-world-overlay.js';
 
 export function placementVisualRect(placement, asset) {
   const scale = placement.scale;
@@ -26,10 +29,14 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
 
 export function visibleForestObjects(objects, viewport, margin = 24) {
   return objects.filter((object) => (
-    object.worldX + 12 >= viewport.x - margin
-      && object.worldX - 12 <= viewport.x + viewport.width + margin
-      && object.worldY + 28 >= viewport.y - margin
-      && object.worldY - 28 <= viewport.y + viewport.height + margin
+    object.worldX + (object.type === FOREST_STEPPING_STONE_TYPE ? 14 : 12)
+      >= viewport.x - margin
+      && object.worldX - (object.type === FOREST_STEPPING_STONE_TYPE ? 14 : 12)
+        <= viewport.x + viewport.width + margin
+      && object.worldY + (object.type === FOREST_STEPPING_STONE_TYPE ? 7 : 28)
+        >= viewport.y - margin
+      && object.worldY - (object.type === FOREST_STEPPING_STONE_TYPE ? 7 : 28)
+        <= viewport.y + viewport.height + margin
   )).sort((left, right) => left.worldY - right.worldY || left.id.localeCompare(right.id));
 }
 
@@ -248,8 +255,8 @@ export function focusedForestSceneItem(player, placements, objects, treeInteract
       distance: Math.hypot(player.worldX - placement.worldX, player.worldY - placement.worldY),
       reach: treeInteractionRadius + placement.collisionRadius
     })),
-    ...objects.map((object) => ({
-      kind: 'marker', id: object.id, value: object,
+    ...objects.filter(({ type }) => type !== FOREST_STEPPING_STONE_TYPE).map((object) => ({
+      kind: object.type || 'marker', id: object.id, value: object,
       distance: Math.hypot(player.worldX - object.worldX, player.worldY - object.worldY),
       reach: FOREST_MARKER_INTERACTION_RADIUS
     }))
@@ -263,7 +270,7 @@ export function forestDepthOrder(placements, player, objects = []) {
   return [
     ...placements.map((placement) => ({ kind: 'tree', id: placement.id,
       worldY: placement.worldY, placement })),
-    ...objects.map((object) => ({ kind: 'marker', id: object.id,
+    ...objects.map((object) => ({ kind: object.type || 'marker', id: object.id,
       worldY: object.worldY, object })),
     { kind: 'player', id: '~player', worldY: player.worldY, player }
   ].sort((left, right) => left.worldY - right.worldY

--- a/public/js/forest-world-overlay.js
+++ b/public/js/forest-world-overlay.js
@@ -2,12 +2,20 @@ export const FOREST_OVERLAY_SCHEMA_VERSION = 1;
 export const FOREST_PLACED_OBJECT_SCHEMA_VERSION = 1;
 export const FOREST_MARKER_ID = 'forest-marker-v1-personal-clearing';
 export const FOREST_MARKER_TYPE = 'marker';
+export const FOREST_STEPPING_STONE_TYPE = 'stepping-stone';
 export const FOREST_MARKER_COLLISION_RADIUS = 9;
 export const FOREST_MARKER_INTERACTION_RADIUS = 54;
 export const FOREST_OVERLAY_MAX_OBJECTS = 32;
+export const FOREST_TRAIL_MAX_STONES = 12;
+export const FOREST_STONE_COLLISION_RADIUS = 11;
+export const FOREST_STONE_MINIMUM_SPACING = 26;
+export const FOREST_STONE_MAXIMUM_SPACING = 96;
+export const FOREST_ENTRANCE_PROTECTION_RADIUS = 52;
+export const FOREST_TREE_TRAIL_CLEARANCE = 14;
 
 const OVERLAY_ID_PATTERN = /^forest-overlay-v1-[a-z0-9-]{1,48}$/;
-const OBJECT_ID_PATTERN = /^forest-marker-v1-[a-z0-9-]{1,48}$/;
+const MARKER_ID_PATTERN = /^forest-marker-v1-[a-z0-9-]{1,48}$/;
+const STONE_ID_PATTERN = /^forest-stone-v1-[a-z0-9-]{1,48}$/;
 
 function exactKeys(value, keys) {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -37,8 +45,9 @@ export function sameForestBaseIdentity(left, right) {
 export function isForestPlacedObject(value) {
   return exactKeys(value, ['schemaVersion', 'id', 'type', 'worldX', 'worldY'])
     && value.schemaVersion === FOREST_PLACED_OBJECT_SCHEMA_VERSION
-    && typeof value.id === 'string' && OBJECT_ID_PATTERN.test(value.id)
-    && value.type === FOREST_MARKER_TYPE
+    && typeof value.id === 'string'
+    && ((value.type === FOREST_MARKER_TYPE && MARKER_ID_PATTERN.test(value.id))
+      || (value.type === FOREST_STEPPING_STONE_TYPE && STONE_ID_PATTERN.test(value.id)))
     && validCoordinate(value.worldX) && validCoordinate(value.worldY);
 }
 
@@ -50,6 +59,28 @@ export function createForestMarker(worldX, worldY, id = FOREST_MARKER_ID) {
     worldX: Math.round(worldX),
     worldY: Math.round(worldY)
   };
+}
+
+export function createForestSteppingStone(worldX, worldY, id) {
+  if (typeof id !== 'string' || !STONE_ID_PATTERN.test(id)) {
+    throw new Error('A versioned stepping-stone identity is required.');
+  }
+  return {
+    schemaVersion: FOREST_PLACED_OBJECT_SCHEMA_VERSION,
+    id,
+    type: FOREST_STEPPING_STONE_TYPE,
+    worldX: Math.round(worldX),
+    worldY: Math.round(worldY)
+  };
+}
+
+export function nextForestSteppingStoneId(overlay) {
+  const used = new Set(overlay.objects.map(({ id }) => id));
+  for (let ordinal = 1; ordinal <= FOREST_TRAIL_MAX_STONES; ordinal += 1) {
+    const id = `forest-stone-v1-${String(ordinal).padStart(2, '0')}`;
+    if (!used.has(id)) return id;
+  }
+  return null;
 }
 
 export function createEmptyForestOverlay(baseIdentity) {
@@ -89,6 +120,8 @@ export function validateForestOverlay(value, expectedBaseIdentity) {
   if (new Set(value.objects.map(({ id }) => id)).size !== value.objects.length) {
     return { valid: false, reason: 'duplicate-object-id' };
   }
+  if (value.objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length
+    > FOREST_TRAIL_MAX_STONES) return { valid: false, reason: 'too-many-stones' };
   return { valid: true, reason: null };
 }
 
@@ -100,13 +133,52 @@ export function overlayWithForestMarker(overlay, marker) {
   return {
     ...overlay,
     revision: overlay.revision + 1,
-    objects: [{ ...marker }]
+    objects: [...overlay.objects.filter(({ type }) => type !== FOREST_MARKER_TYPE), { ...marker }]
+      .sort((left, right) => left.id.localeCompare(right.id))
   };
+}
+
+
+function objectRadius(object) {
+  return object.type === FOREST_STEPPING_STONE_TYPE
+    ? FOREST_STONE_COLLISION_RADIUS : FOREST_MARKER_COLLISION_RADIUS;
+}
+
+function stoneTrailConnected(stones) {
+  if (stones.length < 2) return true;
+  const visited = new Set([stones[0].id]);
+  const remaining = [stones[0]];
+  while (remaining.length) {
+    const current = remaining.shift();
+    for (const stone of stones) {
+      const distance = Math.hypot(current.worldX - stone.worldX, current.worldY - stone.worldY);
+      if (!visited.has(stone.id) && distance <= FOREST_STONE_MAXIMUM_SPACING) {
+        visited.add(stone.id);
+        remaining.push(stone);
+      }
+    }
+  }
+  return visited.size === stones.length;
+}
+
+export function forestSteppingStoneJoins(objects) {
+  const stones = objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return stones.slice(1).map((stone, index) => {
+    const candidates = stones.slice(0, index + 1).map((other) => ({
+      from: other,
+      to: stone,
+      distance: Math.hypot(stone.worldX - other.worldX, stone.worldY - other.worldY)
+    })).filter(({ distance }) => distance <= FOREST_STONE_MAXIMUM_SPACING)
+      .sort((left, right) => left.distance - right.distance
+        || left.from.id.localeCompare(right.from.id));
+    return candidates[0] || null;
+  }).filter(Boolean).map(({ from, to }) => ({ fromId: from.id, toId: to.id }));
 }
 
 export function validateForestObjectPlacement(object, scene, otherObjects = []) {
   if (!isForestPlacedObject(object)) return { valid: false, reason: 'invalid-object' };
-  const radius = FOREST_MARKER_COLLISION_RADIUS;
+  const radius = objectRadius(object);
   if (object.worldX - radius < 0 || object.worldY - radius < 0
     || object.worldX + radius > scene.world.width
     || object.worldY + radius > scene.world.height) {
@@ -122,18 +194,89 @@ export function validateForestObjectPlacement(object, scene, otherObjects = []) 
     < radius + spawn.radius) return { valid: false, reason: 'entrance-collision' };
   if (otherObjects.some((other) => other.id !== object.id && Math.hypot(
     object.worldX - other.worldX, object.worldY - other.worldY
-  ) < radius * 2)) return { valid: false, reason: 'object-collision' };
+  ) < radius + objectRadius(other))) return { valid: false, reason: 'object-collision' };
   return { valid: true, reason: null };
+}
+
+export function validateForestTrailPlacement(stone, scene, otherObjects = []) {
+  if (!isForestPlacedObject(stone) || stone.type !== FOREST_STEPPING_STONE_TYPE) {
+    return { valid: false, reason: 'invalid-stone' };
+  }
+  const basic = validateForestObjectPlacement(stone, scene, otherObjects.filter(
+    ({ type }) => type !== FOREST_STEPPING_STONE_TYPE
+  ));
+  if (!basic.valid) return basic;
+  const spawn = scene.exploration?.spawn;
+  if (spawn && Math.hypot(stone.worldX - spawn.worldX, stone.worldY - spawn.worldY)
+    < FOREST_ENTRANCE_PROTECTION_RADIUS) return { valid: false, reason: 'protected-entrance' };
+  if (scene.placements.some((placement) => Math.hypot(
+    stone.worldX - placement.worldX, stone.worldY - placement.worldY
+  ) < FOREST_STONE_COLLISION_RADIUS + placement.collisionRadius
+    + FOREST_TREE_TRAIL_CLEARANCE)) {
+    return { valid: false, reason: 'tree-interaction-space' };
+  }
+  const otherStones = otherObjects.filter(({ id, type }) => (
+    id !== stone.id && type === FOREST_STEPPING_STONE_TYPE
+  ));
+  if (otherStones.some((other) => Math.hypot(
+    stone.worldX - other.worldX, stone.worldY - other.worldY
+  ) < FOREST_STONE_MINIMUM_SPACING)) return { valid: false, reason: 'stone-too-close' };
+  if (otherStones.length && !otherStones.some((other) => Math.hypot(
+    stone.worldX - other.worldX, stone.worldY - other.worldY
+  ) <= FOREST_STONE_MAXIMUM_SPACING)) return { valid: false, reason: 'trail-gap' };
+  return { valid: true, reason: null };
+}
+
+export function createForestTrailPlacementPreview(worldX, worldY, id, scene, otherObjects = []) {
+  const stone = createForestSteppingStone(worldX, worldY, id);
+  return { stone, ...validateForestTrailPlacement(stone, scene, otherObjects) };
+}
+
+export function overlayWithForestSteppingStone(overlay, stone, scene) {
+  const validation = validateForestOverlay(overlay, overlay?.baseIdentity);
+  if (!validation.valid) throw new Error(`Invalid forest overlay: ${validation.reason}.`);
+  const existing = overlay.objects.find(({ id }) => id === stone.id);
+  if (existing && existing.type !== FOREST_STEPPING_STONE_TYPE) {
+    throw new Error('A stepping stone cannot replace another object type.');
+  }
+  if (!existing && overlay.objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length
+    >= FOREST_TRAIL_MAX_STONES) return { overlay, valid: false, reason: 'stone-limit' };
+  const otherObjects = overlay.objects.filter(({ id }) => id !== stone.id);
+  const placement = validateForestTrailPlacement(stone, scene, otherObjects);
+  if (!placement.valid) return { overlay, ...placement };
+  const objects = [...otherObjects, { ...stone }].sort((left, right) =>
+    left.id.localeCompare(right.id));
+  const stones = objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE);
+  if (!stoneTrailConnected(stones)) return { overlay, valid: false, reason: 'trail-disconnected' };
+  return { overlay: { ...overlay, revision: overlay.revision + 1, objects },
+    valid: true, reason: null };
+}
+
+export function overlayWithoutForestSteppingStone(overlay, stoneId) {
+  const existing = overlay.objects.find(({ id, type }) => id === stoneId
+    && type === FOREST_STEPPING_STONE_TYPE);
+  if (!existing) return { overlay, valid: false, reason: 'stone-not-found' };
+  const objects = overlay.objects.filter(({ id }) => id !== stoneId);
+  if (!stoneTrailConnected(objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE))) {
+    return { overlay, valid: false, reason: 'trail-disconnected' };
+  }
+  return { overlay: { ...overlay, revision: overlay.revision + 1, objects },
+    valid: true, reason: null };
 }
 
 export function applyForestOverlay(scene, overlay) {
   const validation = validateForestOverlay(overlay, scene.baseIdentity);
   if (!validation.valid) return { objects: [], error: validation.reason };
-  const objects = [];
-  for (const object of overlay.objects) {
-    const placement = validateForestObjectPlacement(object, scene, objects);
+  const ordered = [...overlay.objects].sort((left, right) => left.id.localeCompare(right.id));
+  for (const object of ordered) {
+    const otherObjects = ordered.filter(({ id }) => id !== object.id);
+    const placement = object.type === FOREST_STEPPING_STONE_TYPE
+      ? validateForestTrailPlacement(object, scene, otherObjects)
+      : validateForestObjectPlacement(object, scene, otherObjects);
     if (!placement.valid) return { objects: [], error: placement.reason };
-    objects.push({ ...object });
   }
-  return { objects, error: null };
+  if (!stoneTrailConnected(ordered.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE))) {
+    return { objects: [], error: 'trail-disconnected' };
+  }
+  return { objects: ordered.map((object) => ({ ...object })), error: null };
 }

--- a/spec/forestWorldOverlaySpec.js
+++ b/spec/forestWorldOverlaySpec.js
@@ -2,12 +2,26 @@ import {
   applyForestOverlay,
   createEmptyForestOverlay,
   createForestMarker,
+  createForestSteppingStone,
+  createForestTrailPlacementPreview,
+  forestSteppingStoneJoins,
   FOREST_MARKER_ID,
+  FOREST_STEPPING_STONE_TYPE,
+  FOREST_TRAIL_MAX_STONES,
+  FOREST_TREE_TRAIL_CLEARANCE,
+  nextForestSteppingStoneId,
+  overlayWithForestSteppingStone,
+  overlayWithoutForestSteppingStone,
   overlayWithForestMarker,
   sameForestBaseIdentity,
   validateForestObjectPlacement,
+  validateForestTrailPlacement,
   validateForestOverlay
 } from '../public/js/forest-world-overlay.js';
+import {
+  forestDepthOrder,
+  visibleForestObjects
+} from '../public/js/forest-scene-math.js';
 import { createForestDevOverlayPersistence } from '../public/js/forest-overlay-persistence.js';
 import { createForestExploration } from '../server/services/forestSceneExploration.js';
 import { generateForestSceneLayout } from '../server/services/forestSceneLayout.js';
@@ -36,6 +50,23 @@ function safeMarker(scene) {
     }
   }
   throw new Error('The fixture did not contain a valid marker position.');
+}
+
+function openTrailScene() {
+  const scene = sceneFixture();
+  return {
+    ...scene,
+    world: { width: 500, height: 500 },
+    placements: [],
+    exploration: { ...scene.exploration,
+      spawn: { ...scene.exploration.spawn, worldX: 30, worldY: 30 } }
+  };
+}
+
+function addStone(overlay, scene, worldX, worldY, id = nextForestSteppingStoneId(overlay)) {
+  return overlayWithForestSteppingStone(
+    overlay, createForestSteppingStone(worldX, worldY, id), scene
+  );
 }
 
 describe('Activity Forest personal overlay contract', () => {
@@ -169,5 +200,168 @@ describe('Activity Forest personal overlay contract', () => {
       status: 'recovered', error: 'incompatible-base'
     }));
     expect(storage.getItem(key)).toBe(JSON.stringify(incompatible));
+  });
+
+  it('round trips an explicit bounded stepping-stone schema and rejects malformed bounds', () => {
+    const scene = openTrailScene();
+    const stone = createForestSteppingStone(150.4, 159.6, 'forest-stone-v1-01');
+    const placed = addStone(createEmptyForestOverlay(scene.baseIdentity), scene, 150, 160);
+    const roundTrip = JSON.parse(JSON.stringify(placed.overlay));
+
+    expect(stone).toEqual({ schemaVersion: 1, id: 'forest-stone-v1-01',
+      type: FOREST_STEPPING_STONE_TYPE, worldX: 150, worldY: 160 });
+    expect(validateForestOverlay(roundTrip, scene.baseIdentity).valid).toBeTrue();
+    expect(roundTrip).toEqual(placed.overlay);
+    expect(() => createForestSteppingStone(1, 1, 'stone')).toThrow();
+    expect(validateForestOverlay({ ...roundTrip,
+      objects: [{ ...stone, worldX: 100001 }] }, scene.baseIdentity).reason)
+      .toBe('invalid-objects');
+
+    let bounded = createEmptyForestOverlay(scene.baseIdentity);
+    for (let index = 0; index < FOREST_TRAIL_MAX_STONES; index += 1) {
+      bounded = addStone(bounded, scene, 120 + (index * 30), 220).overlay;
+    }
+    expect(nextForestSteppingStoneId(bounded)).toBeNull();
+    expect(addStone(bounded, scene, 480, 220, 'forest-stone-v1-extra').reason)
+      .toBe('stone-limit');
+  });
+
+  it('preserves stable identity across deterministic moves and orders objects by identity', () => {
+    const scene = openTrailScene();
+    const empty = createEmptyForestOverlay(scene.baseIdentity);
+    const first = addStone(empty, scene, 150, 150);
+    const second = addStone(first.overlay, scene, 200, 150);
+    const moved = addStone(second.overlay, scene, 145, 160, first.overlay.objects[0].id);
+
+    expect(first.valid).toBeTrue();
+    expect(second.valid).toBeTrue();
+    expect(moved.valid).toBeTrue();
+    expect(moved.overlay.objects.map(({ id }) => id)).toEqual([
+      'forest-stone-v1-01', 'forest-stone-v1-02'
+    ]);
+    expect(moved.overlay.objects[0].id).toBe(first.overlay.objects[0].id);
+    expect(moved.overlay.revision).toBe(second.overlay.revision + 1);
+  });
+
+  it('returns legible deterministic preview reasons for every protected placement space', () => {
+    const scene = sceneFixture();
+    const tree = { ...scene.placements[0], worldX: 250, worldY: 250, collisionRadius: 20 };
+    const isolatedScene = {
+      ...scene,
+      placements: [tree],
+      exploration: { ...scene.exploration,
+        spawn: { ...scene.exploration.spawn, worldX: 30, worldY: 30 } }
+    };
+    const first = createForestSteppingStone(2, 2, 'forest-stone-v1-01');
+    const entrance = createForestSteppingStone(scene.exploration.spawn.worldX,
+      scene.exploration.spawn.worldY, 'forest-stone-v1-01');
+    const treeCenter = createForestSteppingStone(tree.worldX, tree.worldY,
+      'forest-stone-v1-01');
+    const treeApproach = createForestSteppingStone(
+      tree.worldX + tree.collisionRadius + 11 + FOREST_TREE_TRAIL_CLEARANCE - 1,
+      tree.worldY, 'forest-stone-v1-01'
+    );
+    const openPassage = createForestSteppingStone(
+      tree.worldX + tree.collisionRadius + 11 + FOREST_TREE_TRAIL_CLEARANCE,
+      tree.worldY, 'forest-stone-v1-01'
+    );
+
+    expect(validateForestTrailPlacement(first, scene).reason).toBe('world-bounds');
+    expect(validateForestTrailPlacement(entrance, scene).reason).toBe('entrance-collision');
+    expect(validateForestTrailPlacement(treeCenter, isolatedScene).reason).toBe('tree-collision');
+    expect(validateForestTrailPlacement(treeApproach, isolatedScene).reason)
+      .toBe('tree-interaction-space');
+    expect(validateForestTrailPlacement(openPassage, isolatedScene))
+      .toEqual({ valid: true, reason: null });
+    expect(validateForestTrailPlacement(treeApproach, isolatedScene))
+      .toEqual(validateForestTrailPlacement(treeApproach, isolatedScene));
+    expect(createForestTrailPlacementPreview(
+      treeApproach.worldX, treeApproach.worldY, treeApproach.id, isolatedScene
+    )).toEqual({ stone: treeApproach, valid: false, reason: 'tree-interaction-space' });
+  });
+
+  it('validates overlay collisions and the narrow stone spacing and continuity rules', () => {
+    const scene = openTrailScene();
+    const marker = createForestMarker(150, 150, 'forest-marker-v1-near-trail');
+    const first = createForestSteppingStone(150, 150, 'forest-stone-v1-01');
+    const close = createForestSteppingStone(170, 150, 'forest-stone-v1-02');
+    const connected = createForestSteppingStone(190, 150, 'forest-stone-v1-02');
+    const gap = createForestSteppingStone(300, 150, 'forest-stone-v1-02');
+
+    expect(validateForestTrailPlacement(first, scene, [marker]).reason)
+      .toBe('object-collision');
+    expect(validateForestTrailPlacement(close, scene, [first]).reason).toBe('stone-too-close');
+    expect(validateForestTrailPlacement(connected, scene, [first])).toEqual({
+      valid: true, reason: null
+    });
+    expect(validateForestTrailPlacement(gap, scene, [first]).reason).toBe('trail-gap');
+  });
+
+  it('places, moves, removes, resets, and regenerates without partial or generated-state edits', () => {
+    const scene = openTrailScene();
+    const generated = JSON.parse(JSON.stringify(scene.placements));
+    const storage = memoryStorage();
+    const persistence = createForestDevOverlayPersistence(storage);
+    const first = addStone(createEmptyForestOverlay(scene.baseIdentity), scene, 150, 150);
+    const second = addStone(first.overlay, scene, 200, 150);
+    const third = addStone(second.overlay, scene, 250, 150);
+    const rejectedMiddleRemoval = overlayWithoutForestSteppingStone(
+      third.overlay, 'forest-stone-v1-02'
+    );
+    const moved = addStone(third.overlay, scene, 250, 180, 'forest-stone-v1-03');
+    const removed = overlayWithoutForestSteppingStone(moved.overlay, 'forest-stone-v1-03');
+
+    expect(rejectedMiddleRemoval.valid).toBeFalse();
+    expect(rejectedMiddleRemoval.reason).toBe('trail-disconnected');
+    expect(rejectedMiddleRemoval.overlay).toBe(third.overlay);
+    expect(moved.valid).toBeTrue();
+    expect(removed.valid).toBeTrue();
+    persistence.save(removed.overlay);
+    const regenerated = openTrailScene();
+    expect(applyForestOverlay(regenerated,
+      persistence.load(regenerated.baseIdentity).overlay).objects).toEqual(removed.overlay.objects);
+    expect(scene.placements).toEqual(generated);
+    expect(persistence.reset(scene.baseIdentity).objects).toEqual([]);
+  });
+
+  it('recovers unsupported trail data and keeps overlay/base/marker compatibility intact', () => {
+    const scene = openTrailScene();
+    const marker = createForestMarker(400, 400);
+    const withMarker = overlayWithForestMarker(createEmptyForestOverlay(scene.baseIdentity), marker);
+    const withStone = addStone(withMarker, scene, 150, 150).overlay;
+    const storage = memoryStorage();
+    const persistence = createForestDevOverlayPersistence(storage);
+    persistence.save(withStone);
+
+    expect(withStone.objects.find(({ type }) => type === 'marker')).toEqual(marker);
+    expect(applyForestOverlay(scene, withStone).error).toBeNull();
+    const invalid = { ...withStone, objects: withStone.objects.map((object) => (
+      object.type === FOREST_STEPPING_STONE_TYPE ? { ...object, schemaVersion: 2 } : object
+    )) };
+    expect(validateForestOverlay(invalid, scene.baseIdentity).reason).toBe('invalid-objects');
+    const unsupported = { ...withStone, schemaVersion: 2 };
+    expect(validateForestOverlay(unsupported, scene.baseIdentity).reason)
+      .toBe('unsupported-version');
+  });
+
+  it('culls stones by their bounded footprint and uses stable ground-Y depth ordering and joins', () => {
+    const stones = [
+      createForestSteppingStone(50, 60, 'forest-stone-v1-02'),
+      createForestSteppingStone(50, 60, 'forest-stone-v1-01'),
+      createForestSteppingStone(100, 60, 'forest-stone-v1-03')
+    ];
+    const visible = visibleForestObjects(stones, { x: 55, y: 55, width: 40, height: 20 }, 0);
+    const order = forestDepthOrder([], { worldX: 0, worldY: 60 }, visible);
+
+    expect(visible.map(({ id }) => id)).toEqual([
+      'forest-stone-v1-01', 'forest-stone-v1-02', 'forest-stone-v1-03'
+    ]);
+    expect(order.map(({ id }) => id)).toEqual([
+      'forest-stone-v1-01', 'forest-stone-v1-02', 'forest-stone-v1-03', '~player'
+    ]);
+    expect(forestSteppingStoneJoins(stones)).toEqual([
+      { fromId: 'forest-stone-v1-01', toId: 'forest-stone-v1-02' },
+      { fromId: 'forest-stone-v1-01', toId: 'forest-stone-v1-03' }
+    ]);
   });
 });

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -22,6 +22,7 @@ block content
             | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
             | The grove remains deterministic and is composed from reusable procedural tree assets.
       .activity-forest__header-actions
+        button.activity-forest__reset(type='button' data-forest-toggle-trail aria-pressed='false') Edit trail
         button.activity-forest__reset(type='button' data-forest-place-marker) Place marker here
         button.activity-forest__reset(type='button' data-forest-reset-overlay) Reset personal overlay
         button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
@@ -49,6 +50,16 @@ block content
     p#activity-forest-help.activity-forest__help
       | Move with arrow keys or WASD, or touch and drag in the forest. Inspect nearby trees or your marker.
       | “Place marker here” saves one development-only personal overlay independently of the grove.
+      | Press T or choose “Edit trail” to place, move, or reversibly remove up to 12 stepping stones.
+
+    .activity-forest__trail-tools(data-forest-trail-tools hidden aria-label='Trail editing controls')
+      strong(data-forest-trail-mode) Trail editing: place
+      span(data-forest-trail-status role='status' aria-live='polite') Choose clear ground; connected stones stay 26–96 px apart.
+      .activity-forest__trail-actions
+        button(type='button' data-forest-trail-place aria-pressed='true') Place
+        button(type='button' data-forest-trail-move aria-pressed='false') Move nearest
+        button(type='button' data-forest-trail-remove aria-pressed='false') Remove
+        button(type='button' data-forest-trail-done) Done
 
     .activity-forest__viewport(
       tabindex='0'
@@ -80,6 +91,9 @@ block content
       div
         dt Personal overlay
         dd(data-forest-overlay) —
+      div
+        dt Trail editor
+        dd(data-forest-trail-diagnostic) Off
       div
         dt Unique assets
         dd= scene.assetLoading.totalAssetCount


### PR DESCRIPTION
## Summary

Implements Milestone 2 of the Activity Forest sequel roadmap: one narrow, persistent, and reversible spatial edit built on the existing versioned personal overlay.

Players can enter a focused development-only trail-editing mode and preview, place, move, or remove a bounded trail of stepping stones without modifying the deterministic generated forest.

## What changed

- Add an explicit versioned stepping-stone object schema.
- Limit each overlay to 12 stones with deterministic stable identity allocation.
- Preserve stone identities when positions change.
- Store trail changes as personal-overlay records rather than generated-world state.
- Add pure, transactional place, move, and remove operations.
- Reject edits without partially changing the overlay or incrementing its revision.
- Reapply saved trails after regenerating the same base scene.
- Recover safely from invalid JSON, unsupported versions, incompatible bases, and invalid saved placements.

## Placement rules

Stepping-stone placement validates:

- World bounds.
- Generated tree collision footprints.
- A small fixed visual clearance around tree trunks.
- The protected entrance clearing.
- Existing marker and overlay-object footprints.
- A minimum distance of 26 world pixels between stones.
- A maximum continuity distance of 96 world pixels.
- Connectivity after moves and removals.

Stones are non-solid ground decoration, so trails cannot block player movement or strand the player. The tree rule intentionally protects only the trunk and a narrow visual clearance rather than reserving the complete writing interaction radius, allowing trails through visually open gaps.

## Editing interface

The development Activity Forest page now includes a deliberately small trail editor with:

- Place, move-nearest, remove, and done controls.
- Valid and invalid canvas previews.
- Specific validation feedback through an accessible live status region.
- Keyboard controls for toggling and operating the editor.
- Pointer and touch placement using world-space coordinates.
- Focus return to the forest viewport.
- Development diagnostics for the active tool and preview validity.

This interface is development scaffolding for evaluating the overlay contract, not a proposed final player-facing construction interface.

## Rendering and performance

- Render stones using fixed Canvas primitives.
- Include stones in viewport culling and stable ground-Y depth ordering.
- Invalidate the visibility cache only when overlay objects change.
- Join adjacent stones using one deterministic nearest-earlier-neighbor rule.
- Keep persistence access, JSON decoding, schema validation, placement validation, procedural generation, and asset preparation outside animation frames.
- Preserve reduced-motion behavior and the existing regional asset-loading boundary.

## Compatibility

- Preserve existing marker behavior and identity.
- Preserve generated tree placement and tree asset identity.
- Keep generated base state independent from the personal overlay.
- Continue using the development-only local overlay persistence adapter.
- Do not add database or production persistence.

## Tests

Adds focused coverage for:

- Stepping-stone schema bounds and JSON round trips.
- Stable identity across moves.
- Deterministic identity allocation, ordering, and visual joins.
- Placement previews and validation reasons.
- World, tree, entrance, interaction-clearance, and overlay collisions.
- Stone spacing and trail continuity.
- Place, move, remove, reset, persistence, and regeneration round trips.
- Invalid data, incompatible bases, and unsupported versions.
- Marker and generated-scene compatibility.
- Viewport culling and stable depth ordering.
- Rejected edits without partial or stranded state.

Full test suite:

- 584 specs
- 0 failures

## Milestone 2 scope

This completes the persistent editable-trail proof of concept described in the roadmap sequel.

It deliberately does not add:

- Automatic road networks or pathfinding.
- Terrain painting or excavation.
- Bridges or elevation.
- Pickups, inventory, crafting, currencies, or resource costs.
- Production storage.
- Generalized construction tools.
- Multiplayer or a generalized game framework.

Future work may replace the development controls with an in-forest interface or introduce a separately designed constrained terrain/path-editing contract.