### PR TITLE
Add renewable forest discoveries and a persistent satchel

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -411,14 +411,108 @@ either a loaded tree or a marker with deterministic distance, kind, and id tie-b
 existing keyboard, touch, prompt, modal, and focus-return behavior is reused. Animation frames do
 not access storage, parse overlay JSON, validate placement, regenerate the base, or prepare assets.
 
-The explicit future boundary remains narrow: production account or database storage, migrations
-between generated base versions, conflict resolution, multiple devices, authorization, object asset
-loading, free-form labels, path topology, automatic pathfinding, terrain painting, bridges,
-elevation, excavation, pickups, inventories, currencies, resource costs, crafting, generalized
+The explicit future boundary for the overlay remains narrow: production account or database
+storage, migrations between generated base versions, conflict resolution, multiple devices,
+authorization, object asset loading, free-form labels, path topology, automatic pathfinding,
+terrain painting, bridges, elevation, excavation, currencies, resource costs, crafting, generalized
 construction tools, multiplayer, and a general component framework all remain undesigned. The
 stepping-stone contract does not authorize trail networks, navigation graphs, terrain mutation, or a
 complete customization system. Supporting those requires a new versioned contract decision;
 neither placed-object type is an invitation to smuggle new systems into an unversioned payload.
+
+### Milestone 3 discovery and satchel contract
+
+The first discovery vocabulary is exactly **fallen twigs**, **smooth stones**, and **seed pods**.
+They are small things that have fallen naturally or been offered by the forest. Nothing in the
+interaction presents a writing tree as something to cut, mine, or consume. There is no rarity,
+quality, price, weight, durability, tool, spending rule, or arbitrary item metadata.
+
+The state boundary is explicit:
+
+- Generated discovery placement is reconstructed from the forest base identity, discovery
+  generation version 1, offering-cycle integer, fixed vocabulary, and the current bounded overlay
+  footprints. A complete discovery manifest is never saved.
+- Persistent personal state is a separate exact schema containing schema version 1, one fixed
+  state identity, the compatible forest base identity, a non-negative revision, a bounded offering
+  cycle, exactly three bounded inventory counts, and up to nine collected discovery identities.
+- Focus highlighting, prompt text, pickup feedback, and its dismissal timer are transient browser
+  presentation state. Losing them cannot remove inventory or alter collection progress.
+
+Each generated discovery has exactly seven fields: schema version, stable id, fixed `discovery`
+type, material id, cycle, and integer world coordinates. Its id includes the discovery schema
+version, a key of the complete base identity, cycle, and two-digit offering ordinal. A cycle offers nine discoveries,
+exactly three of each material. Representative and large-world profiles use the same nine-item
+bound. The candidate sequence is deterministic, so identical base, cycle, and overlay inputs
+reproduce identical ids, types, and coordinates without changing tree, asset, marker, or stone
+identity.
+
+Placement stays in a legible corridor band between 150 and at most 1,180 pixels ahead of the
+entrance. This encourages a short exploration beyond the nearest tree without distributing
+required items across the whole large-world profile. Fixed validation protects world edges, tree
+trunks and writing-interaction space, the entrance, marker and stepping-stone footprints, and
+discovery-to-discovery spacing. The current world is flat and its generated corridor is walkable,
+so this deliberately does not add pathfinding, navigation graphs, terrain analysis, or a spawn
+scheduler. Overlay edits can deterministically move a conflicting discovery candidate while
+preserving its identity; the generated manifest still remains independent of saved personal data.
+
+Pickup is an explicit nearby action shared with the existing interaction prompt. Keyboard users
+press E or Enter, pointer users activate the prompt, and touch users tap it. Trees, markers, and
+discoveries enter one deterministic proximity query ordered by distance, then kind and stable id;
+discovery pickup reach is a fixed 34 pixels. Trail editing retains its existing input precedence.
+Dialog and Satchel focus suspend movement, and closing either returns predictable focus to the
+forest. Closing the Satchel also returns focus to the viewport so movement and inspection continue
+immediately.
+
+A pickup first builds and validates a complete candidate discovery state. The development adapter
+serializes and stores that candidate before live state, culling, inventory text, or feedback
+changes. A storage exception therefore leaves the offered discovery and live inventory untouched.
+Already-collected ids and inventory counts at the 9,999 bound are rejected, so repeated input cannot
+credit an item twice. On success exactly one discovery id is recorded, exactly one material count is
+incremented, the visible-object cache is invalidated, and a polite non-modal status identifies the
+material and new count.
+
+Renewal is deterministic and has no wall-clock input. Only after all nine identities in the current
+offering have been collected can the user explicitly welcome another offering. Renewal increments
+the bounded cycle and clears only that cycle's collected-id list; it never subtracts or resets
+inventory and never touches marker or trail edits. Reloading, absence, or waiting does not advance,
+expire, or destroy an opportunity. This completion-gated development proof is intentionally not a
+generalized ecology, event calendar, loot table, or recurring reward schedule.
+
+The in-frame **Satchel** is one compact surface with the three material labels and counts, a concise
+renewal explanation, completion-gated renewal, and an explicit development reset. It has a labeled
+44-pixel target, visible native focus, Escape-to-close behavior, polite live feedback, and focus
+return. Reduced-motion users receive the same static feedback with a shorter dwell; discovery
+visuals have no continuous animation. The reset clears this base-specific inventory and discovery
+progress and regenerates cycle zero. It does not reset the separately stored personal overlay.
+
+The discovery adapter uses its own base-specific development `localStorage` key. Marker-only and
+marker-and-trail overlay v1 records therefore load unchanged. Invalid JSON, unsupported versions,
+incompatible bases, malformed or unknown inventory fields, unsafe or negative counts, duplicate
+collected ids, wrong-cycle ids, and storage exceptions recover to an empty in-memory discovery
+state with a visible diagnostic. Offending stored bytes are not overwritten during load. This is a
+development persistence proof, not database policy.
+
+Discoveries use three fixed Canvas primitive treatments and are non-solid. The Satchel renders its
+material icons through that same drawing function, rather than maintaining approximate text symbols
+or a second visual vocabulary. Available discoveries join the existing bounded visible-object
+cache, viewport culling, and stable ground-Y/id depth ordering. Diagnostics report total and
+remaining discoveries, the cycle, offered counts by type,
+inventory, and the last pickup or persistence failure. Generation, schema validation, JSON work,
+storage access, renewal, and inventory mutation occur only at setup or explicit action boundaries.
+Movement frames perform only the already bounded visibility and pure proximity math over at most
+nine discoveries. Regional tree-asset loading remains unchanged because discoveries need no asset
+requests or preparation.
+
+The Activity Forest stylesheet also contains legacy global `button` and `label` layout properties at
+the page boundary. Forest controls therefore do not inherit the site's generic floats, margins,
+font size, or fixed line-height. Satchel controls explicitly own their dimensions, spacing, colors,
+disabled treatment, and focus rings in both site themes.
+
+The next boundary remains explicit: there is no spending, crafting, construction toolbar, large
+inventory, equipment, shops, trading, daily spawn, streak, survival need, destructive harvesting,
+production storage, multiplayer, or generalized entity system. Benches, lanterns, signs, material
+costs, placement refunds, and environmental personalization belong to later milestones and are not
+implied by the Satchel.
 
 ### Development pressure profiles
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -5,6 +5,29 @@
   padding: 2rem 0 4rem;
 }
 
+/* Contain the legacy global label/button layout rules from style.css. */
+.activity-forest button,
+.activity-forest label {
+  float: none;
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: normal;
+}
+.activity-forest label {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  cursor: default;
+}
+html[data-theme='dark'] .activity-forest label {
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+
 .activity-forest__header {
   display: flex;
   align-items: end;
@@ -32,7 +55,11 @@
 
 .activity-forest__reset {
   flex: 0 0 auto;
+  min-height: 40px;
   margin-bottom: 0.6rem;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.78rem;
+  line-height: 1.2;
 }
 
 .activity-forest__header-actions {
@@ -66,6 +93,11 @@
 .activity-forest__trail-tools[hidden] { display: none; }
 .activity-forest__trail-tools [role='status'] { flex: 1 1 280px; }
 .activity-forest__trail-actions { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.activity-forest__trail-actions button,
+.activity-forest__trail-tools > button {
+  min-height: 36px;
+  padding: 0.4rem 0.7rem;
+}
 .activity-forest__trail-actions button[aria-pressed='true'] {
   border-color: #6f5431;
   background: #6f5431;
@@ -118,6 +150,160 @@
   image-rendering: pixelated;
 }
 
+.activity-forest__satchel-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  min-height: 44px;
+  border: 1px solid rgba(255, 240, 174, 0.72);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  background: rgba(18, 39, 32, 0.82);
+  color: #fff4ce;
+  cursor: pointer;
+  font-size: 0.82rem;
+  line-height: 1;
+}
+html[data-theme='dark'] .activity-forest .activity-forest__satchel-button {
+  border-color: rgba(255, 240, 174, 0.72);
+  background: rgba(18, 39, 32, 0.82);
+  color: #fff4ce;
+}
+
+.activity-forest__satchel {
+  position: absolute;
+  z-index: 2;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: min(340px, calc(100% - 1.5rem));
+  box-sizing: border-box;
+  border: 1px solid #8d7b55;
+  border-radius: 14px;
+  padding: 1rem;
+  background: rgba(245, 239, 217, 0.97);
+  color: #25352f;
+  box-shadow: 0 14px 36px rgba(9, 24, 20, 0.38);
+  touch-action: auto;
+}
+
+.activity-forest__satchel[hidden] { display: none; }
+.activity-forest__satchel-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.activity-forest__satchel-heading h2 { margin: 0.1rem 0 0; }
+.activity-forest__satchel-heading button,
+.activity-forest__satchel-actions button {
+  min-height: 44px;
+  box-sizing: border-box;
+  border: 1px solid #786f54;
+  margin: 0;
+  background: #fff8e5;
+  color: #34463d;
+  font-family: inherit;
+  font-size: 0.78rem;
+  line-height: 1.25;
+}
+.activity-forest__satchel-heading button {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+}
+.activity-forest__satchel button:hover:not(:disabled) {
+  border-color: #4f5f52;
+  background: #f2e7c8;
+}
+.activity-forest__satchel button:focus-visible,
+.activity-forest__satchel-button:focus-visible {
+  outline: 3px solid #8b4d38;
+  outline-offset: 2px;
+}
+.activity-forest__satchel button:disabled {
+  border-color: #b9b39f;
+  background: #e8e1cb;
+  color: #716f64;
+  cursor: default;
+}
+.activity-forest__satchel-list {
+  display: grid;
+  gap: 0.4rem;
+  margin: 1rem 0;
+  padding: 0;
+  list-style: none;
+}
+.activity-forest__satchel-list li {
+  display: grid;
+  grid-template-columns: 1.4rem 1fr auto;
+  align-items: center;
+  gap: 0.45rem;
+  border-bottom: 1px solid rgba(86, 82, 61, 0.18);
+  padding: 0.35rem 0;
+}
+.activity-forest__material-icon {
+  display: block;
+  width: 28px;
+  height: 24px;
+  image-rendering: pixelated;
+}
+.activity-forest__satchel-note { color: #56645b; font-size: 0.82rem; line-height: 1.45; }
+.activity-forest__satchel-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+.activity-forest__satchel-actions button {
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  text-align: center;
+}
+.activity-forest__satchel-actions [data-forest-reset-discoveries] {
+  border-color: transparent;
+  background: transparent;
+  color: #765146;
+}
+
+html[data-theme='dark'] .activity-forest__satchel button {
+  border-color: #786f54;
+  background: #fff8e5;
+  color: #34463d;
+}
+html[data-theme='dark'] .activity-forest__satchel button:hover:not(:disabled) {
+  border-color: #4f5f52;
+  background: #f2e7c8;
+}
+html[data-theme='dark'] .activity-forest__satchel button:disabled {
+  border-color: #b9b39f;
+  background: #e8e1cb;
+  color: #716f64;
+}
+html[data-theme='dark'] .activity-forest__satchel [data-forest-reset-discoveries] {
+  border-color: transparent;
+  background: transparent;
+  color: #765146;
+}
+
+.activity-forest__pickup-feedback {
+  position: absolute;
+  left: 50%;
+  top: 0.75rem;
+  max-width: calc(100% - 9rem);
+  transform: translateX(-50%);
+  border: 1px solid rgba(255, 240, 174, 0.74);
+  border-radius: 999px;
+  margin: 0;
+  padding: 0.45rem 0.8rem;
+  background: rgba(18, 39, 32, 0.84);
+  color: #fff4ce;
+  font-size: 0.75rem;
+  text-align: center;
+  pointer-events: none;
+}
+.activity-forest__pickup-feedback[data-failed='true'] {
+  border-color: #e7a294;
+  color: #ffe4dc;
+}
+
 .activity-forest__joystick {
   position: absolute;
   width: 86px;
@@ -155,6 +341,11 @@
   font-size: 0.72rem;
   cursor: pointer;
 }
+html[data-theme='dark'] .activity-forest .activity-forest__prompt {
+  border-color: rgba(255, 240, 174, 0.7);
+  background: rgba(18, 39, 32, 0.72);
+  color: #f2ead1;
+}
 
 .activity-forest__prompt-touch { display: none; }
 
@@ -186,6 +377,12 @@
 }
 .activity-forest__dialog-context { margin: 0.3rem 0 1.2rem; color: #5f6a61; }
 .activity-forest__dialog-excerpt { font-size: 1.08rem; line-height: 1.65; }
+.activity-forest__dialog button {
+  min-height: 44px;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
 
 .activity-forest__diagnostics {
   display: grid;

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -12,6 +12,17 @@ import {
   touchMovement
 } from './forest-scene-math.js';
 import { createForestDevOverlayPersistence } from './forest-overlay-persistence.js';
+import { createForestDevDiscoveryPersistence } from './forest-discovery-persistence.js';
+import {
+  availableForestDiscoveries,
+  FOREST_DISCOVERY_MATERIALS,
+  FOREST_DISCOVERY_OFFERING_COUNT,
+  FOREST_DISCOVERY_TYPE,
+  forestDiscoveryMaterial,
+  forestDiscoveryStateAfterPickup,
+  generateForestDiscoveries,
+  renewForestDiscoveryState
+} from './forest-discoveries.js';
 import {
   applyForestOverlay,
   createForestMarker,
@@ -45,6 +56,13 @@ if (payload && viewportElement && canvas) {
   let overlay = persistedOverlay.overlay;
   let overlayApplication = applyForestOverlay(scene, overlay);
   let placedObjects = overlayApplication.objects;
+  const discoveryPersistence = createForestDevDiscoveryPersistence(window.localStorage);
+  const persistedDiscoveries = discoveryPersistence.load(scene.baseIdentity);
+  let discoveryState = persistedDiscoveries.state;
+  let discoveryOffering = generateForestDiscoveries(
+    scene, discoveryState.cycle, placedObjects
+  );
+  let availableDiscoveries = availableForestDiscoveries(discoveryOffering, discoveryState);
   const keys = { left: false, right: false, up: false, down: false };
   const touch = { pointerId: null, originX: 0, originY: 0, x: 0, y: 0 };
   const dialog = document.querySelector('[data-forest-dialog]');
@@ -56,6 +74,12 @@ if (payload && viewportElement && canvas) {
   const trailStatus = document.querySelector('[data-forest-trail-status]');
   const trailModeLabel = document.querySelector('[data-forest-trail-mode]');
   const trailEditor = { active: false, tool: 'place', preview: null, movingId: null };
+  const satchelButton = document.querySelector('[data-forest-satchel-button]');
+  const satchel = document.querySelector('[data-forest-satchel]');
+  const pickupFeedback = document.querySelector('[data-forest-pickup-feedback]');
+  let pickupFeedbackTimer = null;
+  let lastPickupResult = persistedDiscoveries.error
+    ? `recovered: ${persistedDiscoveries.error}` : 'No pickup yet';
   const diagnostics = {
     visible: document.querySelector('[data-forest-visible]'),
     camera: document.querySelector('[data-forest-camera]'),
@@ -71,7 +95,10 @@ if (payload && viewportElement && canvas) {
     regionEntry: document.querySelector('[data-forest-region-entry]'),
     regionLoading: document.querySelector('[data-forest-region-loading]'),
     overlay: document.querySelector('[data-forest-overlay]'),
-    trail: document.querySelector('[data-forest-trail-diagnostic]')
+    trail: document.querySelector('[data-forest-trail-diagnostic]'),
+    discoveries: document.querySelector('[data-forest-discoveries]'),
+    inventory: document.querySelector('[data-forest-inventory]'),
+    pickup: document.querySelector('[data-forest-last-pickup]')
   };
   const loadedCellIds = new Set(scene.assetLoading.initialCellIds);
   const pendingCellIds = new Set();
@@ -86,7 +113,7 @@ if (payload && viewportElement && canvas) {
     [placement.id, forestPlacementWindParameters(placement)]
   )));
   const visibilityCache = createForestVisibilityCache(
-    scene.placements, assetsByKey, 24, placedObjects
+    scene.placements, assetsByKey, 24, [...placedObjects, ...availableDiscoveries]
   );
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
   let focusedItem = null;
@@ -113,7 +140,86 @@ if (payload && viewportElement && canvas) {
       overlay.revision} · ${status}${error ? ` (${error})` : ''}`;
   }
 
+  function updateDiscoverySurfaces() {
+    const counts = Object.fromEntries(FOREST_DISCOVERY_MATERIALS.map(({ id }) => [
+      id, discoveryOffering.filter(({ material }) => material === id).length
+    ]));
+    diagnostics.discoveries.textContent = `${availableDiscoveries.length} / ${
+      discoveryOffering.length} remaining · cycle ${discoveryState.cycle} · ${
+      FOREST_DISCOVERY_MATERIALS.map(({ id, shortLabel }) => `${shortLabel} ${counts[id]}`)
+        .join(' · ')}`;
+    diagnostics.inventory.textContent = FOREST_DISCOVERY_MATERIALS.map(({ id, shortLabel }) => (
+      `${shortLabel} ${discoveryState.inventory[id]}`
+    )).join(' · ');
+    diagnostics.pickup.textContent = lastPickupResult;
+    satchelButton.setAttribute('aria-label', `Satchel: ${FOREST_DISCOVERY_MATERIALS.map(
+      ({ id, shortLabel }) => `${discoveryState.inventory[id]} ${shortLabel.toLowerCase()}`
+    ).join(', ')}`);
+    for (const { id } of FOREST_DISCOVERY_MATERIALS) {
+      document.querySelector(`[data-forest-material-count="${id}"]`).textContent =
+        discoveryState.inventory[id];
+    }
+    const complete = availableDiscoveries.length === 0;
+    const renewButton = document.querySelector('[data-forest-renew-discoveries]');
+    renewButton.disabled = !complete;
+    renewButton.textContent = complete ? 'Welcome another offering' : `${
+      availableDiscoveries.length} discoveries remain`;
+  }
+
+  function setDiscoveryObjects() {
+    visibilityCache.setObjects([...placedObjects, ...availableDiscoveries]);
+  }
+
+  function regenerateDiscoveryOffering() {
+    discoveryOffering = generateForestDiscoveries(scene, discoveryState.cycle, placedObjects);
+    availableDiscoveries = availableForestDiscoveries(discoveryOffering, discoveryState);
+    setDiscoveryObjects();
+    updateDiscoverySurfaces();
+  }
+
   updateOverlayDiagnostic();
+  updateDiscoverySurfaces();
+
+  function paintDiscoveryGlyph(targetContext, x, y, material) {
+    targetContext.fillStyle = 'rgba(22, 35, 31, 0.24)';
+    targetContext.beginPath();
+    targetContext.ellipse(x, y + 3, 9, 4, 0, 0, Math.PI * 2);
+    targetContext.fill();
+    if (material === 'fallen-twigs') {
+      targetContext.strokeStyle = '#6c4930';
+      targetContext.lineWidth = 3;
+      targetContext.beginPath();
+      targetContext.moveTo(x - 7, y + 2);
+      targetContext.lineTo(x + 6, y - 4);
+      targetContext.moveTo(x - 2, y);
+      targetContext.lineTo(x - 5, y - 5);
+      targetContext.stroke();
+    } else if (material === 'smooth-stones') {
+      targetContext.fillStyle = '#c8c0a5';
+      targetContext.strokeStyle = '#6f756c';
+      targetContext.lineWidth = 1;
+      targetContext.beginPath();
+      targetContext.ellipse(x, y - 1, 7, 5, -0.12, 0, Math.PI * 2);
+      targetContext.fill();
+      targetContext.stroke();
+    } else {
+      targetContext.fillStyle = '#d4ad4f';
+      targetContext.strokeStyle = '#715c2c';
+      targetContext.lineWidth = 1;
+      targetContext.beginPath();
+      targetContext.ellipse(x - 3, y, 3, 5, -0.45, 0, Math.PI * 2);
+      targetContext.ellipse(x + 3, y - 2, 3, 5, 0.45, 0, Math.PI * 2);
+      targetContext.fill();
+      targetContext.stroke();
+    }
+  }
+
+  document.querySelectorAll('[data-forest-material-icon]').forEach((icon) => {
+    const iconContext = icon.getContext('2d');
+    iconContext.imageSmoothingEnabled = false;
+    paintDiscoveryGlyph(iconContext, icon.width / 2, icon.height / 2,
+      icon.dataset.forestMaterialIcon);
+  });
 
   function rasterLayerSource(layer) {
     const binary = window.atob(layer.data);
@@ -447,6 +553,19 @@ if (payload && viewportElement && canvas) {
     }
   }
 
+  function paintDiscovery(discovery) {
+    const x = Math.round(discovery.worldX - camera.x);
+    const y = Math.round(discovery.worldY - camera.y);
+    paintDiscoveryGlyph(context, x, y, discovery.material);
+    if (focusedItem?.kind === FOREST_DISCOVERY_TYPE && focusedItem.id === discovery.id) {
+      context.strokeStyle = '#fff0ae';
+      context.lineWidth = 2;
+      context.beginPath();
+      context.ellipse(x, y, 13, 9, 0, 0, Math.PI * 2);
+      context.stroke();
+    }
+  }
+
   function paintPlayer() {
     const x = Math.round(player.worldX - camera.x);
     const y = Math.round(player.worldY - camera.y);
@@ -464,9 +583,11 @@ if (payload && viewportElement && canvas) {
   function updateFocus() {
     focusedItem = focusedForestSceneItem(player, scene.placements.filter(
       ({ assetKey }) => assetsByKey.has(assetKey)
-    ), placedObjects, scene.exploration.interactionRadius);
-    prompt.hidden = !focusedItem;
-    const action = focusedItem?.kind === 'marker' ? 'inspect marker' : 'inspect';
+    ), placedObjects, scene.exploration.interactionRadius, availableDiscoveries);
+    prompt.hidden = !focusedItem || trailEditor.active;
+    const action = focusedItem?.kind === FOREST_DISCOVERY_TYPE
+      ? `gather ${forestDiscoveryMaterial(focusedItem.value.material).label.toLowerCase()}`
+      : focusedItem?.kind === 'marker' ? 'inspect marker' : 'inspect';
     prompt.querySelector('[data-forest-prompt-keyboard]').textContent =
       `Press E or Enter to ${action}`;
     prompt.querySelector('[data-forest-prompt-touch]').textContent = `Tap to ${action}`;
@@ -483,6 +604,7 @@ if (payload && viewportElement && canvas) {
       if (item.kind === 'player') paintPlayer();
       else if (item.kind === 'marker') paintMarker(item.object);
       else if (item.kind === FOREST_STEPPING_STONE_TYPE) paintSteppingStone(item.object);
+      else if (item.kind === FOREST_DISCOVERY_TYPE) paintDiscovery(item.object);
       else paintTree(item.placement, elapsedSeconds);
     }
     if (trailEditor.active && trailEditor.preview) {
@@ -491,7 +613,8 @@ if (payload && viewportElement && canvas) {
     const { visible, visibleObjects } = visibility;
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length} trees · ${
       visibleObjects.filter(({ type }) => type === 'marker').length} markers · ${
-      visibleObjects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length} stones`;
+      visibleObjects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length} stones · ${
+      visibleObjects.filter(({ type }) => type === FOREST_DISCOVERY_TYPE).length} discoveries`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
     const duration = window.performance.now() - start;
@@ -555,7 +678,7 @@ if (payload && viewportElement && canvas) {
     if (lastFrameTime === null) lastFrameTime = timestamp;
     const elapsed = Math.min(0.05, (timestamp - lastFrameTime) / 1000);
     lastFrameTime = timestamp;
-    const moving = hasMovement() && !dialog.open;
+    const moving = hasMovement() && !dialog.open && satchel.hidden;
     if (moving) {
       Object.assign(player, moveForestPlayer(player, movementDirection(), elapsed,
         scene.world, scene.placements));
@@ -620,6 +743,91 @@ if (payload && viewportElement && canvas) {
     lastFrameTime = null;
   }
 
+  function reportPickup(message, failed = false) {
+    lastPickupResult = message;
+    diagnostics.pickup.textContent = message;
+    pickupFeedback.textContent = message;
+    pickupFeedback.dataset.failed = String(failed);
+    pickupFeedback.hidden = false;
+    if (pickupFeedbackTimer !== null) window.clearTimeout(pickupFeedbackTimer);
+    pickupFeedbackTimer = window.setTimeout(() => {
+      pickupFeedback.hidden = true;
+      pickupFeedbackTimer = null;
+    }, reducedMotionQuery.matches ? 1800 : 2600);
+  }
+
+  function collectDiscovery(discovery) {
+    const result = forestDiscoveryStateAfterPickup(
+      discoveryState, discovery, discoveryOffering
+    );
+    if (!result.valid) {
+      reportPickup(`Pickup rejected: ${result.reason}.`, true);
+      return false;
+    }
+    try {
+      discoveryPersistence.save(result.state);
+    } catch (error) {
+      reportPickup(`Pickup not saved: ${error.message}`, true);
+      return false;
+    }
+    discoveryState = result.state;
+    availableDiscoveries = availableForestDiscoveries(discoveryOffering, discoveryState);
+    setDiscoveryObjects();
+    const material = forestDiscoveryMaterial(discovery.material);
+    reportPickup(`${material.label} gathered · ${discoveryState.inventory[discovery.material]} in satchel`);
+    updateDiscoverySurfaces();
+    updateFocus();
+    requestRender();
+    return true;
+  }
+
+  function openSatchel() {
+    clearMovement();
+    satchel.hidden = false;
+    satchelButton.setAttribute('aria-expanded', 'true');
+    satchel.querySelector('[data-forest-satchel-close]').focus();
+  }
+
+  function closeSatchel() {
+    if (satchel.hidden) return;
+    satchel.hidden = true;
+    satchelButton.setAttribute('aria-expanded', 'false');
+    viewportElement.focus();
+    requestRender();
+  }
+
+  function renewDiscoveries() {
+    const result = renewForestDiscoveryState(discoveryState, discoveryOffering);
+    if (!result.valid) {
+      reportPickup(`Renewal unavailable: ${result.reason}.`, true);
+      return;
+    }
+    try {
+      discoveryPersistence.save(result.state);
+    } catch (error) {
+      reportPickup(`Renewal not saved: ${error.message}`, true);
+      return;
+    }
+    discoveryState = result.state;
+    regenerateDiscoveryOffering();
+    updateFocus();
+    reportPickup(`The forest has offered ${FOREST_DISCOVERY_OFFERING_COUNT} more small finds.`);
+    requestRender();
+  }
+
+  function resetDiscoveries() {
+    try {
+      discoveryState = discoveryPersistence.reset(scene.baseIdentity);
+    } catch (error) {
+      reportPickup(`Satchel reset failed: ${error.message}`, true);
+      return;
+    }
+    regenerateDiscoveryOffering();
+    updateFocus();
+    reportPickup('Satchel and discovery progress reset for this generated forest.');
+    requestRender();
+  }
+
   function openInspection() {
     if (!focusedItem || dialog.open) return;
     clearMovement();
@@ -643,6 +851,11 @@ if (payload && viewportElement && canvas) {
     dialog.showModal();
   }
 
+  function activateFocusedItem() {
+    if (focusedItem?.kind === FOREST_DISCOVERY_TYPE) collectDiscovery(focusedItem.value);
+    else openInspection();
+  }
+
   function setOverlay(nextOverlay, status) {
     const application = applyForestOverlay(scene, nextOverlay);
     if (application.error) {
@@ -652,7 +865,7 @@ if (payload && viewportElement && canvas) {
     overlay = nextOverlay;
     overlayApplication = application;
     placedObjects = application.objects;
-    visibilityCache.setObjects(placedObjects);
+    regenerateDiscoveryOffering();
     updateOverlayDiagnostic(status, null);
     updateFocus();
     requestRender();
@@ -728,6 +941,7 @@ if (payload && viewportElement && canvas) {
     updateTrailControls();
     if (trailEditor.active) setTrailTool('place');
     else reportTrail('Off');
+    updateFocus();
     viewportElement.focus();
     requestRender();
   }
@@ -887,7 +1101,7 @@ if (payload && viewportElement && canvas) {
     } else if ((event.key === 'e' || event.key === 'E' || event.key === 'Enter')
       && focusedItem) {
       event.preventDefault();
-      openInspection();
+      activateFocusedItem();
     }
   });
   viewportElement.addEventListener('keyup', (event) => {
@@ -898,7 +1112,7 @@ if (payload && viewportElement && canvas) {
     }
   });
   viewportElement.addEventListener('pointerdown', (event) => {
-    if (trailEditor.active && !event.target.closest('button') && !dialog.open) {
+    if (trailEditor.active && !event.target.closest('button') && !dialog.open && satchel.hidden) {
       event.preventDefault();
       const viewportRect = viewportElement.getBoundingClientRect();
       commitTrailAt(camera.x + event.clientX - viewportRect.left,
@@ -906,7 +1120,8 @@ if (payload && viewportElement && canvas) {
       viewportElement.focus();
       return;
     }
-    if (event.pointerType === 'mouse' || event.target.closest('button') || dialog.open) return;
+    if (event.pointerType === 'mouse' || event.target.closest('button') || dialog.open
+      || !satchel.hidden) return;
     event.preventDefault();
     touch.pointerId = event.pointerId;
     touch.originX = event.clientX;
@@ -943,7 +1158,23 @@ if (payload && viewportElement && canvas) {
     requestRender();
   });
   dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
-  prompt.addEventListener('click', openInspection);
+  prompt.addEventListener('click', () => {
+    if (!trailEditor.active) activateFocusedItem();
+  });
+  satchelButton.addEventListener('click', openSatchel);
+  satchel.querySelector('[data-forest-satchel-close]').addEventListener('click', closeSatchel);
+  satchel.querySelector('[data-forest-renew-discoveries]').addEventListener(
+    'click', renewDiscoveries
+  );
+  satchel.querySelector('[data-forest-reset-discoveries]').addEventListener(
+    'click', resetDiscoveries
+  );
+  satchel.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeSatchel();
+    }
+  });
   document.querySelector('[data-forest-reset]').addEventListener('click', resetPlayer);
   trailToggle.addEventListener('click', () => toggleTrailEditor());
   document.querySelector('[data-forest-trail-place]').addEventListener('click', () => {

--- a/public/js/forest-discoveries.js
+++ b/public/js/forest-discoveries.js
@@ -1,0 +1,285 @@
+import {
+  FOREST_MARKER_TYPE,
+  FOREST_STEPPING_STONE_TYPE,
+  isForestBaseIdentity,
+  sameForestBaseIdentity
+} from './forest-world-overlay.js';
+
+export const FOREST_DISCOVERY_SCHEMA_VERSION = 1;
+export const FOREST_DISCOVERY_STATE_SCHEMA_VERSION = 1;
+export const FOREST_DISCOVERY_GENERATION_VERSION = 1;
+export const FOREST_DISCOVERY_TYPE = 'discovery';
+export const FOREST_DISCOVERY_PICKUP_RADIUS = 34;
+export const FOREST_DISCOVERY_RENDER_RADIUS = 10;
+export const FOREST_DISCOVERY_MINIMUM_SPACING = 92;
+export const FOREST_DISCOVERY_TREE_CLEARANCE = 26;
+export const FOREST_DISCOVERY_ENTRANCE_CLEARANCE = 96;
+export const FOREST_DISCOVERY_OVERLAY_CLEARANCE = 18;
+export const FOREST_DISCOVERY_OFFERING_COUNT = 9;
+export const FOREST_DISCOVERY_MAX_CYCLE = 9999;
+export const FOREST_DISCOVERY_MAX_INVENTORY_COUNT = 9999;
+
+export const FOREST_DISCOVERY_MATERIALS = Object.freeze([
+  Object.freeze({ id: 'fallen-twigs', label: 'Fallen twigs', shortLabel: 'Twigs' }),
+  Object.freeze({ id: 'smooth-stones', label: 'Smooth stones', shortLabel: 'Stones' }),
+  Object.freeze({ id: 'seed-pods', label: 'Seed pods', shortLabel: 'Seeds' })
+]);
+
+const MATERIAL_IDS = new Set(FOREST_DISCOVERY_MATERIALS.map(({ id }) => id));
+const DISCOVERY_ID_PATTERN = /^forest-discovery-v1-[a-f0-9]{8}-[0-9]{1,4}-[0-9]{2}$/;
+const STATE_ID = 'forest-discovery-state-v1-local-personal';
+
+function exactKeys(value, keys) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && Object.keys(value).length === keys.length
+    && keys.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function validCoordinate(value) {
+  return Number.isSafeInteger(value) && value >= 0 && value <= 100000;
+}
+
+function hash(value) {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    result ^= value.charCodeAt(index);
+    result = Math.imul(result, 16777619);
+  }
+  return result >>> 0;
+}
+
+function unit(seed) {
+  return hash(seed) / 4294967296;
+}
+
+function discoveryBaseKey(baseIdentity) {
+  return hash(JSON.stringify(baseIdentity)).toString(16).padStart(8, '0');
+}
+
+function corridorCenter(scene, worldY) {
+  return (scene.world.width / 2) + (Math.sin((worldY / 330) + 0.7) * 155);
+}
+
+function overlayRadius(object) {
+  return object.type === FOREST_STEPPING_STONE_TYPE ? 14
+    : object.type === FOREST_MARKER_TYPE ? 12 : 12;
+}
+
+export function isForestDiscoveryMaterial(value) {
+  return typeof value === 'string' && MATERIAL_IDS.has(value);
+}
+
+export function isForestDiscovery(value) {
+  return exactKeys(value, [
+    'schemaVersion', 'id', 'type', 'material', 'cycle', 'worldX', 'worldY'
+  ]) && value.schemaVersion === FOREST_DISCOVERY_SCHEMA_VERSION
+    && typeof value.id === 'string' && DISCOVERY_ID_PATTERN.test(value.id)
+    && value.type === FOREST_DISCOVERY_TYPE
+    && isForestDiscoveryMaterial(value.material)
+    && Number.isSafeInteger(value.cycle) && value.cycle >= 0
+    && value.cycle <= FOREST_DISCOVERY_MAX_CYCLE
+    && validCoordinate(value.worldX) && validCoordinate(value.worldY);
+}
+
+export function emptyForestDiscoveryInventory() {
+  return Object.fromEntries(FOREST_DISCOVERY_MATERIALS.map(({ id }) => [id, 0]));
+}
+
+export function createEmptyForestDiscoveryState(baseIdentity) {
+  if (!isForestBaseIdentity(baseIdentity)) throw new Error('A valid forest base identity is required.');
+  return {
+    schemaVersion: FOREST_DISCOVERY_STATE_SCHEMA_VERSION,
+    id: STATE_ID,
+    baseIdentity: { ...baseIdentity },
+    revision: 0,
+    cycle: 0,
+    inventory: emptyForestDiscoveryInventory(),
+    collectedDiscoveryIds: []
+  };
+}
+
+export function validateForestDiscoveryState(value, expectedBaseIdentity) {
+  if (!exactKeys(value, [
+    'schemaVersion', 'id', 'baseIdentity', 'revision', 'cycle', 'inventory',
+    'collectedDiscoveryIds'
+  ])) return { valid: false, reason: 'invalid-shape' };
+  if (value.schemaVersion !== FOREST_DISCOVERY_STATE_SCHEMA_VERSION) {
+    return { valid: false, reason: 'unsupported-version' };
+  }
+  if (value.id !== STATE_ID) return { valid: false, reason: 'invalid-id' };
+  if (!isForestBaseIdentity(value.baseIdentity)) {
+    return { valid: false, reason: 'invalid-base-identity' };
+  }
+  if (expectedBaseIdentity && !sameForestBaseIdentity(value.baseIdentity, expectedBaseIdentity)) {
+    return { valid: false, reason: 'incompatible-base' };
+  }
+  if (!Number.isSafeInteger(value.revision) || value.revision < 0) {
+    return { valid: false, reason: 'invalid-revision' };
+  }
+  if (!Number.isSafeInteger(value.cycle) || value.cycle < 0
+    || value.cycle > FOREST_DISCOVERY_MAX_CYCLE) {
+    return { valid: false, reason: 'invalid-cycle' };
+  }
+  const materialIds = FOREST_DISCOVERY_MATERIALS.map(({ id }) => id);
+  if (!exactKeys(value.inventory, materialIds) || materialIds.some((id) => (
+    !Number.isSafeInteger(value.inventory[id]) || value.inventory[id] < 0
+      || value.inventory[id] > FOREST_DISCOVERY_MAX_INVENTORY_COUNT
+  ))) return { valid: false, reason: 'invalid-inventory' };
+  if (!Array.isArray(value.collectedDiscoveryIds)
+    || value.collectedDiscoveryIds.length > FOREST_DISCOVERY_OFFERING_COUNT
+    || value.collectedDiscoveryIds.some((id) => (
+      typeof id !== 'string' || !DISCOVERY_ID_PATTERN.test(id)
+    ))) return { valid: false, reason: 'invalid-collected-discoveries' };
+  if (new Set(value.collectedDiscoveryIds).size !== value.collectedDiscoveryIds.length) {
+    return { valid: false, reason: 'duplicate-collected-discovery-id' };
+  }
+  const expectedPrefix = `forest-discovery-v1-${discoveryBaseKey(value.baseIdentity)}-${
+    value.cycle}-`;
+  if (value.collectedDiscoveryIds.some((id) => !id.startsWith(expectedPrefix))) {
+    return { valid: false, reason: 'incompatible-collected-discovery' };
+  }
+  if (value.collectedDiscoveryIds.some((id) => {
+    const ordinal = Number(id.slice(expectedPrefix.length));
+    return !Number.isSafeInteger(ordinal) || ordinal < 1
+      || ordinal > FOREST_DISCOVERY_OFFERING_COUNT;
+  })) return { valid: false, reason: 'invalid-collected-discovery-ordinal' };
+  return { valid: true, reason: null };
+}
+
+export function validateForestDiscoveryPlacement(discovery, scene, placed = [], objects = []) {
+  if (!isForestDiscovery(discovery)) return { valid: false, reason: 'invalid-discovery' };
+  const radius = FOREST_DISCOVERY_RENDER_RADIUS;
+  if (discovery.worldX - radius < 0 || discovery.worldY - radius < 0
+    || discovery.worldX + radius > scene.world.width
+    || discovery.worldY + radius > scene.world.height) {
+    return { valid: false, reason: 'world-bounds' };
+  }
+  if (scene.placements.some((tree) => Math.hypot(
+    discovery.worldX - tree.worldX, discovery.worldY - tree.worldY
+  ) < radius + tree.collisionRadius + FOREST_DISCOVERY_TREE_CLEARANCE)) {
+    return { valid: false, reason: 'tree-interaction-space' };
+  }
+  const spawn = scene.exploration?.spawn;
+  if (spawn && Math.hypot(discovery.worldX - spawn.worldX, discovery.worldY - spawn.worldY)
+    < FOREST_DISCOVERY_ENTRANCE_CLEARANCE) {
+    return { valid: false, reason: 'protected-entrance' };
+  }
+  if (objects.some((object) => Math.hypot(
+    discovery.worldX - object.worldX, discovery.worldY - object.worldY
+  ) < radius + overlayRadius(object) + FOREST_DISCOVERY_OVERLAY_CLEARANCE)) {
+    return { valid: false, reason: 'overlay-collision' };
+  }
+  if (placed.some((other) => Math.hypot(
+    discovery.worldX - other.worldX, discovery.worldY - other.worldY
+  ) < FOREST_DISCOVERY_MINIMUM_SPACING)) {
+    return { valid: false, reason: 'discovery-spacing' };
+  }
+  return { valid: true, reason: null };
+}
+
+export function generateForestDiscoveries(scene, cycle = 0, objects = []) {
+  if (!isForestBaseIdentity(scene?.baseIdentity)) throw new Error('A valid forest scene is required.');
+  if (!Number.isSafeInteger(cycle) || cycle < 0 || cycle > FOREST_DISCOVERY_MAX_CYCLE) {
+    throw new Error('A bounded discovery cycle is required.');
+  }
+  const discoveries = [];
+  const verticalReach = Math.min(1180, Math.max(420, scene.world.height - 360));
+  const minimumY = Math.max(80, scene.exploration.spawn.worldY - verticalReach);
+  const maximumY = Math.max(minimumY, scene.exploration.spawn.worldY - 150);
+  const seed = [
+    `forest-discoveries-v${FOREST_DISCOVERY_GENERATION_VERSION}`,
+    scene.baseIdentity.sceneVersion,
+    scene.baseIdentity.seed,
+    scene.baseIdentity.layoutKey,
+    cycle
+  ].join(':');
+
+  for (let ordinal = 0; ordinal < FOREST_DISCOVERY_OFFERING_COUNT; ordinal += 1) {
+    let accepted = null;
+    for (let attempt = 0; attempt < 2000 && !accepted; attempt += 1) {
+      const decision = `${seed}:${ordinal}:${attempt}`;
+      const worldY = Math.round(minimumY + (unit(`${decision}:y`) * (maximumY - minimumY)));
+      const halfWidth = Math.max(70, scene.corridor.halfWidth - 24);
+      const worldX = Math.round(corridorCenter(scene, worldY)
+        + ((unit(`${decision}:x`) * 2 - 1) * halfWidth));
+      const discovery = {
+        schemaVersion: FOREST_DISCOVERY_SCHEMA_VERSION,
+        id: `forest-discovery-v1-${discoveryBaseKey(scene.baseIdentity)}-${cycle}-${String(
+          ordinal + 1
+        ).padStart(2, '0')}`,
+        type: FOREST_DISCOVERY_TYPE,
+        material: FOREST_DISCOVERY_MATERIALS[ordinal % FOREST_DISCOVERY_MATERIALS.length].id,
+        cycle,
+        worldX,
+        worldY
+      };
+      if (validateForestDiscoveryPlacement(discovery, scene, discoveries, objects).valid) {
+        accepted = discovery;
+      }
+    }
+    if (!accepted) throw new Error(`Could not place discovery ${ordinal + 1}.`);
+    discoveries.push(accepted);
+  }
+  return discoveries;
+}
+
+export function availableForestDiscoveries(discoveries, state) {
+  const validation = validateForestDiscoveryState(state, state?.baseIdentity);
+  if (!validation.valid) throw new Error(`Invalid discovery state: ${validation.reason}.`);
+  const collected = new Set(state.collectedDiscoveryIds);
+  return discoveries.filter(({ id }) => !collected.has(id));
+}
+
+export function forestDiscoveryStateAfterPickup(state, discovery, offering) {
+  const validation = validateForestDiscoveryState(state, state?.baseIdentity);
+  if (!validation.valid) return { state, valid: false, reason: validation.reason };
+  if (!isForestDiscovery(discovery) || discovery.cycle !== state.cycle
+    || !offering.some(({ id }) => id === discovery.id)) {
+    return { state, valid: false, reason: 'discovery-not-offered' };
+  }
+  if (state.collectedDiscoveryIds.includes(discovery.id)) {
+    return { state, valid: false, reason: 'already-collected' };
+  }
+  if (state.inventory[discovery.material] >= FOREST_DISCOVERY_MAX_INVENTORY_COUNT) {
+    return { state, valid: false, reason: 'inventory-limit' };
+  }
+  return {
+    state: {
+      ...state,
+      revision: state.revision + 1,
+      inventory: {
+        ...state.inventory,
+        [discovery.material]: state.inventory[discovery.material] + 1
+      },
+      collectedDiscoveryIds: [...state.collectedDiscoveryIds, discovery.id].sort()
+    },
+    valid: true,
+    reason: null
+  };
+}
+
+export function renewForestDiscoveryState(state, offering) {
+  const validation = validateForestDiscoveryState(state, state?.baseIdentity);
+  if (!validation.valid) return { state, valid: false, reason: validation.reason };
+  if (offering.length !== FOREST_DISCOVERY_OFFERING_COUNT
+    || offering.some(({ id }) => !state.collectedDiscoveryIds.includes(id))) {
+    return { state, valid: false, reason: 'offering-incomplete' };
+  }
+  if (state.cycle >= FOREST_DISCOVERY_MAX_CYCLE) {
+    return { state, valid: false, reason: 'cycle-limit' };
+  }
+  return {
+    state: {
+      ...state,
+      revision: state.revision + 1,
+      cycle: state.cycle + 1,
+      collectedDiscoveryIds: []
+    },
+    valid: true,
+    reason: null
+  };
+}
+
+export function forestDiscoveryMaterial(materialId) {
+  return FOREST_DISCOVERY_MATERIALS.find(({ id }) => id === materialId) || null;
+}

--- a/public/js/forest-discovery-persistence.js
+++ b/public/js/forest-discovery-persistence.js
@@ -1,0 +1,41 @@
+import {
+  createEmptyForestDiscoveryState,
+  validateForestDiscoveryState
+} from './forest-discoveries.js';
+
+export const FOREST_DEV_DISCOVERY_STORAGE_PREFIX = 'daily-page:activity-forest:discoveries:';
+
+function storageKey(baseIdentity) {
+  return `${FOREST_DEV_DISCOVERY_STORAGE_PREFIX}${baseIdentity.sceneVersion}:${
+    baseIdentity.layoutKey}:${baseIdentity.seed}`;
+}
+
+export function createForestDevDiscoveryPersistence(storage) {
+  return {
+    load(baseIdentity) {
+      const empty = createEmptyForestDiscoveryState(baseIdentity);
+      try {
+        const raw = storage.getItem(storageKey(baseIdentity));
+        if (raw === null) return { state: empty, status: 'empty', error: null };
+        const state = JSON.parse(raw);
+        const validation = validateForestDiscoveryState(state, baseIdentity);
+        if (!validation.valid) {
+          return { state: empty, status: 'recovered', error: validation.reason };
+        }
+        return { state, status: 'loaded', error: null };
+      } catch (error) {
+        return { state: empty, status: 'recovered', error: error.message };
+      }
+    },
+    save(state) {
+      const validation = validateForestDiscoveryState(state, state?.baseIdentity);
+      if (!validation.valid) throw new Error(`Cannot save forest discoveries: ${validation.reason}.`);
+      storage.setItem(storageKey(state.baseIdentity), JSON.stringify(state));
+      return JSON.parse(JSON.stringify(state));
+    },
+    reset(baseIdentity) {
+      storage.removeItem(storageKey(baseIdentity));
+      return createEmptyForestDiscoveryState(baseIdentity);
+    }
+  };
+}

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -2,6 +2,10 @@ import {
   FOREST_MARKER_INTERACTION_RADIUS,
   FOREST_STEPPING_STONE_TYPE
 } from './forest-world-overlay.js';
+import {
+  FOREST_DISCOVERY_PICKUP_RADIUS,
+  FOREST_DISCOVERY_TYPE
+} from './forest-discoveries.js';
 
 export function placementVisualRect(placement, asset) {
   const scale = placement.scale;
@@ -28,16 +32,24 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
 }
 
 export function visibleForestObjects(objects, viewport, margin = 24) {
-  return objects.filter((object) => (
-    object.worldX + (object.type === FOREST_STEPPING_STONE_TYPE ? 14 : 12)
+  return objects.filter((object) => {
+    const horizontalRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 14
+      : object.type === FOREST_DISCOVERY_TYPE ? 10 : 12;
+    const upperRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 7
+      : object.type === FOREST_DISCOVERY_TYPE ? 10 : 28;
+    const lowerRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 7
+      : object.type === FOREST_DISCOVERY_TYPE ? 8 : 28;
+    return (
+      object.worldX + horizontalRadius
       >= viewport.x - margin
-      && object.worldX - (object.type === FOREST_STEPPING_STONE_TYPE ? 14 : 12)
+      && object.worldX - horizontalRadius
         <= viewport.x + viewport.width + margin
-      && object.worldY + (object.type === FOREST_STEPPING_STONE_TYPE ? 7 : 28)
+      && object.worldY + lowerRadius
         >= viewport.y - margin
-      && object.worldY - (object.type === FOREST_STEPPING_STONE_TYPE ? 7 : 28)
+      && object.worldY - upperRadius
         <= viewport.y + viewport.height + margin
-  )).sort((left, right) => left.worldY - right.worldY || left.id.localeCompare(right.id));
+    );
+  }).sort((left, right) => left.worldY - right.worldY || left.id.localeCompare(right.id));
 }
 
 export const FOREST_AMBIENT_WIND = Object.freeze({
@@ -248,7 +260,9 @@ export function focusedForestPlacement(player, placements, interactionRadius) {
   ))[0]?.placement || null;
 }
 
-export function focusedForestSceneItem(player, placements, objects, treeInteractionRadius) {
+export function focusedForestSceneItem(
+  player, placements, objects, treeInteractionRadius, discoveries = []
+) {
   const candidates = [
     ...placements.map((placement) => ({
       kind: 'tree', id: placement.id, value: placement,
@@ -259,6 +273,11 @@ export function focusedForestSceneItem(player, placements, objects, treeInteract
       kind: object.type || 'marker', id: object.id, value: object,
       distance: Math.hypot(player.worldX - object.worldX, player.worldY - object.worldY),
       reach: FOREST_MARKER_INTERACTION_RADIUS
+    })),
+    ...discoveries.map((discovery) => ({
+      kind: FOREST_DISCOVERY_TYPE, id: discovery.id, value: discovery,
+      distance: Math.hypot(player.worldX - discovery.worldX, player.worldY - discovery.worldY),
+      reach: FOREST_DISCOVERY_PICKUP_RADIUS
     }))
   ];
   return candidates.filter(({ distance, reach }) => distance <= reach)

--- a/spec/forestDiscoverySpec.js
+++ b/spec/forestDiscoverySpec.js
@@ -1,0 +1,383 @@
+import {
+  availableForestDiscoveries,
+  createEmptyForestDiscoveryState,
+  FOREST_DISCOVERY_MATERIALS,
+  FOREST_DISCOVERY_MAX_INVENTORY_COUNT,
+  FOREST_DISCOVERY_OFFERING_COUNT,
+  FOREST_DISCOVERY_PICKUP_RADIUS,
+  FOREST_DISCOVERY_TYPE,
+  forestDiscoveryStateAfterPickup,
+  generateForestDiscoveries,
+  isForestDiscovery,
+  isForestDiscoveryMaterial,
+  renewForestDiscoveryState,
+  validateForestDiscoveryPlacement,
+  validateForestDiscoveryState
+} from '../public/js/forest-discoveries.js';
+import {
+  createForestDevDiscoveryPersistence,
+  FOREST_DEV_DISCOVERY_STORAGE_PREFIX
+} from '../public/js/forest-discovery-persistence.js';
+import {
+  createEmptyForestOverlay,
+  createForestMarker,
+  createForestSteppingStone,
+  overlayWithForestMarker,
+  overlayWithForestSteppingStone
+} from '../public/js/forest-world-overlay.js';
+import { createForestDevOverlayPersistence } from '../public/js/forest-overlay-persistence.js';
+import {
+  focusedForestSceneItem,
+  forestDepthOrder,
+  visibleForestObjects
+} from '../public/js/forest-scene-math.js';
+import { createForestExploration } from '../server/services/forestSceneExploration.js';
+import { generateForestSceneLayout } from '../server/services/forestSceneLayout.js';
+
+function sceneFixture(options = {}) {
+  return createForestExploration(generateForestSceneLayout({
+    seed: 'discovery-contract', ...options
+  }));
+}
+
+function memoryStorage(initial = {}, failure = null) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => {
+      if (failure === 'get') throw new Error('read unavailable');
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem: (key, value) => {
+      if (failure === 'set') throw new Error('write unavailable');
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      if (failure === 'remove') throw new Error('remove unavailable');
+      values.delete(key);
+    },
+    values
+  };
+}
+
+function collectedOffering(state, offering) {
+  return offering.reduce((current, discovery) => (
+    forestDiscoveryStateAfterPickup(current, discovery, offering).state
+  ), state);
+}
+
+describe('Activity Forest discoveries and tiny inventory', () => {
+  it('uses exactly three calm material types and rejects unknown vocabulary', () => {
+    expect(FOREST_DISCOVERY_MATERIALS.map(({ id }) => id)).toEqual([
+      'fallen-twigs', 'smooth-stones', 'seed-pods'
+    ]);
+    FOREST_DISCOVERY_MATERIALS.forEach(({ id }) => {
+      expect(isForestDiscoveryMaterial(id)).toBeTrue();
+    });
+    expect(isForestDiscoveryMaterial('rare-gem')).toBeFalse();
+  });
+
+  it('generates an exact bounded schema with stable identities, types, and positions', () => {
+    const scene = sceneFixture();
+    const first = generateForestDiscoveries(scene);
+    const repeated = generateForestDiscoveries(scene);
+
+    expect(first.length).toBe(FOREST_DISCOVERY_OFFERING_COUNT);
+    expect(repeated).toEqual(first);
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+    expect(new Set(first.map(({ id }) => id)).size).toBe(first.length);
+    first.forEach((discovery) => {
+      expect(isForestDiscovery(discovery)).toBeTrue();
+      expect(Object.keys(discovery).sort()).toEqual([
+        'cycle', 'id', 'material', 'schemaVersion', 'type', 'worldX', 'worldY'
+      ]);
+    });
+    expect(first.filter(({ material }) => material === 'fallen-twigs').length).toBe(3);
+    expect(first.filter(({ material }) => material === 'smooth-stones').length).toBe(3);
+    expect(first.filter(({ material }) => material === 'seed-pods').length).toBe(3);
+  });
+
+  it('makes cycle changes explicit without altering trees or tree asset identity', () => {
+    const scene = sceneFixture();
+    const generatedIdentity = scene.placements.map(({ id, assetKey, worldX, worldY }) => ({
+      id, assetKey, worldX, worldY
+    }));
+    const first = generateForestDiscoveries(scene, 0);
+    const next = generateForestDiscoveries(scene, 1);
+
+    expect(next.map(({ id }) => id)).not.toEqual(first.map(({ id }) => id));
+    expect(next.map(({ worldX, worldY }) => ({ worldX, worldY })))
+      .not.toEqual(first.map(({ worldX, worldY }) => ({ worldX, worldY })));
+    expect(scene.placements.map(({ id, assetKey, worldX, worldY }) => ({
+      id, assetKey, worldX, worldY
+    }))).toEqual(generatedIdentity);
+  });
+
+  it('respects world, tree, entrance, overlay, and discovery spacing constraints', () => {
+    const scene = sceneFixture();
+    const discoveries = generateForestDiscoveries(scene);
+    discoveries.forEach((discovery, index) => {
+      expect(validateForestDiscoveryPlacement(
+        discovery, scene, discoveries.slice(0, index)
+      )).toEqual({ valid: true, reason: null });
+    });
+    const discovery = discoveries[0];
+    const atTree = { ...discovery, worldX: scene.placements[0].worldX,
+      worldY: scene.placements[0].worldY };
+    const atEntrance = { ...discovery, worldX: scene.exploration.spawn.worldX,
+      worldY: scene.exploration.spawn.worldY };
+    const atEdge = { ...discovery, worldX: 1, worldY: 1 };
+    const stone = createForestSteppingStone(
+      discovery.worldX, discovery.worldY, 'forest-stone-v1-01'
+    );
+
+    expect(validateForestDiscoveryPlacement(atTree, scene).reason)
+      .toBe('tree-interaction-space');
+    expect(validateForestDiscoveryPlacement(atEntrance, scene).reason)
+      .toBe('protected-entrance');
+    expect(validateForestDiscoveryPlacement(atEdge, scene).reason).toBe('world-bounds');
+    expect(validateForestDiscoveryPlacement(discovery, scene, [], [stone]).reason)
+      .toBe('overlay-collision');
+    expect(validateForestDiscoveryPlacement(discovery, scene, [discovery]).reason)
+      .toBe('discovery-spacing');
+  });
+
+  it('uses overlay positions as stable generation inputs without changing overlay identities', () => {
+    const scene = sceneFixture();
+    const first = generateForestDiscoveries(scene);
+    const marker = createForestMarker(first[0].worldX, first[0].worldY);
+    const overlay = overlayWithForestMarker(createEmptyForestOverlay(scene.baseIdentity), marker);
+    const movedAroundOverlay = generateForestDiscoveries(scene, 0, overlay.objects);
+
+    expect(movedAroundOverlay[0].id).toBe(first[0].id);
+    expect(movedAroundOverlay[0]).not.toEqual(first[0]);
+    expect(overlay.objects[0].id).toBe(marker.id);
+  });
+
+  it('keeps representative and large-world offerings equally small and reachable near entrance', () => {
+    const representative = sceneFixture();
+    const large = sceneFixture({
+      world: { width: 6000, height: 3600 }, placementCount: 600, assetPoolSize: 60
+    });
+    for (const scene of [representative, large]) {
+      const discoveries = generateForestDiscoveries(scene);
+      expect(discoveries.length).toBe(FOREST_DISCOVERY_OFFERING_COUNT);
+      discoveries.forEach(({ worldY }) => {
+        expect(worldY).toBeLessThan(scene.exploration.spawn.worldY - 100);
+        expect(worldY).toBeGreaterThanOrEqual(scene.exploration.spawn.worldY - 1180);
+      });
+    }
+  });
+
+  it('validates exact inventory state, safe bounds, ids, and JSON round trips', () => {
+    const scene = sceneFixture();
+    const state = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const roundTrip = JSON.parse(JSON.stringify(state));
+
+    expect(roundTrip).toEqual(state);
+    expect(validateForestDiscoveryState(roundTrip, scene.baseIdentity).valid).toBeTrue();
+    expect(validateForestDiscoveryState({ ...state, extra: true }, scene.baseIdentity).reason)
+      .toBe('invalid-shape');
+    expect(validateForestDiscoveryState({ ...state, schemaVersion: 2 }, scene.baseIdentity).reason)
+      .toBe('unsupported-version');
+    expect(validateForestDiscoveryState({ ...state,
+      inventory: { ...state.inventory, 'fallen-twigs': -1 } }, scene.baseIdentity).reason)
+      .toBe('invalid-inventory');
+    expect(validateForestDiscoveryState({ ...state,
+      inventory: { ...state.inventory, mystery: 1 } }, scene.baseIdentity).reason)
+      .toBe('invalid-inventory');
+  });
+
+  it('selects nearby discoveries deterministically by distance then identity', () => {
+    const scene = sceneFixture();
+    const [first, second] = generateForestDiscoveries(scene).map((discovery) => ({
+      ...discovery, worldX: 100, worldY: 100
+    })).sort((left, right) => left.id.localeCompare(right.id));
+    const player = { worldX: 100, worldY: 100 };
+    const focused = focusedForestSceneItem(player, [], [], 70, [second, first]);
+
+    expect(focused.kind).toBe(FOREST_DISCOVERY_TYPE);
+    expect(focused.id).toBe(first.id);
+    expect(focused.distance).toBe(0);
+    expect(FOREST_DISCOVERY_PICKUP_RADIUS).toBe(34);
+  });
+
+  it('picks up exactly once and increments exactly one bounded count', () => {
+    const scene = sceneFixture();
+    const offering = generateForestDiscoveries(scene);
+    const state = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const first = forestDiscoveryStateAfterPickup(state, offering[0], offering);
+    const repeated = forestDiscoveryStateAfterPickup(first.state, offering[0], offering);
+
+    expect(first.valid).toBeTrue();
+    expect(first.state.revision).toBe(1);
+    expect(first.state.inventory[offering[0].material]).toBe(1);
+    expect(first.state.collectedDiscoveryIds).toEqual([offering[0].id]);
+    expect(repeated.valid).toBeFalse();
+    expect(repeated.reason).toBe('already-collected');
+    expect(repeated.state).toBe(first.state);
+
+    const full = { ...state, inventory: {
+      ...state.inventory, [offering[0].material]: FOREST_DISCOVERY_MAX_INVENTORY_COUNT
+    } };
+    expect(forestDiscoveryStateAfterPickup(full, offering[0], offering).reason)
+      .toBe('inventory-limit');
+  });
+
+  it('renews only completed offerings without time and never consumes inventory', () => {
+    const scene = sceneFixture();
+    const offering = generateForestDiscoveries(scene);
+    const empty = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const incomplete = renewForestDiscoveryState(empty, offering);
+    const complete = collectedOffering(empty, offering);
+    const renewed = renewForestDiscoveryState(complete, offering);
+
+    expect(incomplete.reason).toBe('offering-incomplete');
+    expect(renewed.valid).toBeTrue();
+    expect(renewed.state.cycle).toBe(1);
+    expect(renewed.state.collectedDiscoveryIds).toEqual([]);
+    expect(renewed.state.inventory).toEqual(complete.inventory);
+    expect(generateForestDiscoveries(scene, renewed.state.cycle)).not.toEqual(offering);
+  });
+
+  it('persists inventory and progress independently of the generated manifest', () => {
+    const scene = sceneFixture();
+    const offering = generateForestDiscoveries(scene);
+    const state = forestDiscoveryStateAfterPickup(
+      createEmptyForestDiscoveryState(scene.baseIdentity), offering[0], offering
+    ).state;
+    const storage = memoryStorage();
+    const persistence = createForestDevDiscoveryPersistence(storage);
+
+    persistence.save(state);
+    const loaded = persistence.load(scene.baseIdentity);
+    expect(loaded).toEqual({ state, status: 'loaded', error: null });
+    expect(JSON.stringify(loaded.state)).not.toContain('worldX');
+    expect(availableForestDiscoveries(
+      generateForestDiscoveries(scene, loaded.state.cycle), loaded.state
+    ).length).toBe(FOREST_DISCOVERY_OFFERING_COUNT - 1);
+  });
+
+  it('uses a separate key and leaves existing marker-and-trail overlay records unchanged', () => {
+    const scene = sceneFixture();
+    const openScene = {
+      ...scene,
+      placements: [],
+      exploration: { ...scene.exploration,
+        spawn: { ...scene.exploration.spawn, worldX: 30, worldY: 30 } }
+    };
+    const markerOverlay = overlayWithForestMarker(
+      createEmptyForestOverlay(scene.baseIdentity), createForestMarker(400, 400)
+    );
+    const trailOverlay = overlayWithForestSteppingStone(
+      markerOverlay, createForestSteppingStone(150, 150, 'forest-stone-v1-01'), openScene
+    ).overlay;
+    const storage = memoryStorage();
+    const overlayPersistence = createForestDevOverlayPersistence(storage);
+    const discoveryPersistence = createForestDevDiscoveryPersistence(storage);
+    const offering = generateForestDiscoveries(scene);
+    const state = forestDiscoveryStateAfterPickup(
+      createEmptyForestDiscoveryState(scene.baseIdentity), offering[0], offering
+    ).state;
+
+    overlayPersistence.save(trailOverlay);
+    discoveryPersistence.save(state);
+
+    expect(overlayPersistence.load(scene.baseIdentity).overlay).toEqual(trailOverlay);
+    expect(discoveryPersistence.load(scene.baseIdentity).state).toEqual(state);
+    expect(storage.values.size).toBe(2);
+  });
+
+  it('keeps a failed save atomic because the candidate is not live state', () => {
+    const scene = sceneFixture();
+    const offering = generateForestDiscoveries(scene);
+    const live = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const candidate = forestDiscoveryStateAfterPickup(live, offering[0], offering);
+    const persistence = createForestDevDiscoveryPersistence(memoryStorage({}, 'set'));
+
+    expect(() => persistence.save(candidate.state)).toThrowError('write unavailable');
+    expect(live.inventory[offering[0].material]).toBe(0);
+    expect(live.collectedDiscoveryIds).toEqual([]);
+    expect(availableForestDiscoveries(offering, live)).toEqual(offering);
+  });
+
+  it('recovers visibly from invalid JSON and malformed or incompatible state', () => {
+    const scene = sceneFixture();
+    const key = `${FOREST_DEV_DISCOVERY_STORAGE_PREFIX}${scene.baseIdentity.sceneVersion}:${
+      scene.baseIdentity.layoutKey}:${scene.baseIdentity.seed}`;
+    const storage = memoryStorage({ [key]: '{bad json' });
+    const persistence = createForestDevDiscoveryPersistence(storage);
+    expect(persistence.load(scene.baseIdentity).status).toBe('recovered');
+    expect(storage.getItem(key)).toBe('{bad json');
+
+    const state = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const malformed = { ...state, collectedDiscoveryIds: ['forest-discovery-v1-bad'] };
+    storage.setItem(key, JSON.stringify(malformed));
+    expect(persistence.load(scene.baseIdentity).error).toBe('invalid-collected-discoveries');
+
+    const incompatible = createEmptyForestDiscoveryState({
+      ...scene.baseIdentity, seed: 'another-base'
+    });
+    storage.setItem(key, JSON.stringify(incompatible));
+    expect(persistence.load(scene.baseIdentity).error).toBe('incompatible-base');
+
+    storage.setItem(key, JSON.stringify({ ...state, schemaVersion: 2 }));
+    expect(persistence.load(scene.baseIdentity).error).toBe('unsupported-version');
+    storage.setItem(key, JSON.stringify({ ...state,
+      inventory: { ...state.inventory, 'smooth-stones': -3 } }));
+    expect(persistence.load(scene.baseIdentity).error).toBe('invalid-inventory');
+    storage.setItem(key, JSON.stringify({ ...state,
+      inventory: { ...state.inventory, unknown: 1 } }));
+    expect(persistence.load(scene.baseIdentity).error).toBe('invalid-inventory');
+  });
+
+  it('rejects duplicate and wrong-cycle collection identities', () => {
+    const scene = sceneFixture();
+    const offering = generateForestDiscoveries(scene);
+    const state = createEmptyForestDiscoveryState(scene.baseIdentity);
+    const duplicate = { ...state,
+      collectedDiscoveryIds: [offering[0].id, offering[0].id] };
+    const wrongCycle = { ...state, collectedDiscoveryIds: [
+      offering[0].id.replace('-0-01', '-1-01')
+    ] };
+
+    expect(validateForestDiscoveryState(duplicate, scene.baseIdentity).reason)
+      .toBe('duplicate-collected-discovery-id');
+    expect(validateForestDiscoveryState(wrongCycle, scene.baseIdentity).reason)
+      .toBe('incompatible-collected-discovery');
+  });
+
+  it('resets explicitly without touching a marker-and-trail overlay', () => {
+    const scene = sceneFixture();
+    const overlay = {
+      ...createEmptyForestOverlay(scene.baseIdentity),
+      objects: [createForestSteppingStone(50, 50, 'forest-stone-v1-01')]
+    };
+    const storage = memoryStorage();
+    const persistence = createForestDevDiscoveryPersistence(storage);
+    const offering = generateForestDiscoveries(scene);
+    persistence.save(forestDiscoveryStateAfterPickup(
+      createEmptyForestDiscoveryState(scene.baseIdentity), offering[0], offering
+    ).state);
+
+    const reset = persistence.reset(scene.baseIdentity);
+    expect(reset.inventory).toEqual({ 'fallen-twigs': 0, 'smooth-stones': 0, 'seed-pods': 0 });
+    expect(reset.collectedDiscoveryIds).toEqual([]);
+    expect(overlay.objects[0].id).toBe('forest-stone-v1-01');
+  });
+
+  it('culls discoveries by fixed bounds and gives them stable ground-Y depth order', () => {
+    const scene = sceneFixture();
+    const discoveries = generateForestDiscoveries(scene).slice(0, 2).map((discovery) => ({
+      ...discovery, worldX: 50, worldY: 60
+    })).sort((left, right) => left.id.localeCompare(right.id));
+    const visible = visibleForestObjects(
+      [...discoveries].reverse(), { x: 40, y: 50, width: 20, height: 20 }, 0
+    );
+    const ordered = forestDepthOrder([], { worldX: 50, worldY: 60 }, visible);
+
+    expect(visible.map(({ id }) => id)).toEqual(discoveries.map(({ id }) => id));
+    expect(ordered.map(({ id }) => id)).toEqual([
+      discoveries[0].id, discoveries[1].id, '~player'
+    ]);
+  });
+});

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -49,6 +49,7 @@ block content
 
     p#activity-forest-help.activity-forest__help
       | Move with arrow keys or WASD, or touch and drag in the forest. Inspect nearby trees or your marker.
+      | Gather nearby fallen twigs, smooth stones, and seed pods with the same interaction prompt.
       | “Place marker here” saves one development-only personal overlay independently of the grove.
       | Press T or choose “Edit trail” to place, move, or reversibly remove up to 12 stepping stones.
 
@@ -69,11 +70,67 @@ block content
       data-forest-viewport
     )
       canvas.activity-forest__canvas(data-forest-canvas)
+      button.activity-forest__satchel-button(
+        type='button'
+        data-forest-satchel-button
+        aria-expanded='false'
+        aria-controls='activity-forest-satchel'
+      ) Satchel
+      section#activity-forest-satchel.activity-forest__satchel(
+        data-forest-satchel
+        aria-labelledby='activity-forest-satchel-title'
+        hidden
+      )
+        .activity-forest__satchel-heading
+          div
+            p.activity-forest__dialog-eyebrow A few things the forest offered
+            h2#activity-forest-satchel-title Satchel
+          button(type='button' data-forest-satchel-close aria-label='Close satchel') Close
+        ul.activity-forest__satchel-list
+          li
+            canvas.activity-forest__material-icon(
+              width='28'
+              height='24'
+              data-forest-material-icon='fallen-twigs'
+              aria-hidden='true'
+            )
+            span Fallen twigs
+            strong(data-forest-material-count='fallen-twigs') 0
+          li
+            canvas.activity-forest__material-icon(
+              width='28'
+              height='24'
+              data-forest-material-icon='smooth-stones'
+              aria-hidden='true'
+            )
+            span Smooth stones
+            strong(data-forest-material-count='smooth-stones') 0
+          li
+            canvas.activity-forest__material-icon(
+              width='28'
+              height='24'
+              data-forest-material-icon='seed-pods'
+              aria-hidden='true'
+            )
+            span Seed pods
+            strong(data-forest-material-count='seed-pods') 0
+        p.activity-forest__satchel-note
+          | These small finds are renewable. Once an offering is complete, the forest can offer another
+          | without taking anything from your satchel.
+        .activity-forest__satchel-actions
+          button(type='button' data-forest-renew-discoveries disabled) 9 discoveries remain
+          button(type='button' data-forest-reset-discoveries) Reset satchel and finds
       .activity-forest__joystick(data-forest-joystick hidden aria-hidden='true')
         .activity-forest__joystick-stick(data-forest-joystick-stick)
       button.activity-forest__prompt(type='button' data-forest-prompt hidden)
         span.activity-forest__prompt-keyboard(data-forest-prompt-keyboard) Press E or Enter to inspect
         span.activity-forest__prompt-touch(data-forest-prompt-touch) Tap to inspect
+      p.activity-forest__pickup-feedback(
+        data-forest-pickup-feedback
+        role='status'
+        aria-live='polite'
+        hidden
+      )
 
     dl.activity-forest__diagnostics(aria-label='Scene diagnostics')
       div
@@ -94,6 +151,15 @@ block content
       div
         dt Trail editor
         dd(data-forest-trail-diagnostic) Off
+      div
+        dt Discoveries
+        dd(data-forest-discoveries) —
+      div
+        dt Satchel inventory
+        dd(data-forest-inventory) —
+      div
+        dt Last pickup
+        dd(data-forest-last-pickup) —
       div
         dt Unique assets
         dd= scene.assetLoading.totalAssetCount


### PR DESCRIPTION
## Summary

Implements the Activity Forest Milestone 3 proof of concept: gentle renewable discoveries, proximity pickup, persistent item tracking, and a compact in-forest Satchel.

This establishes the infrastructure for future gathering and customization mechanics while keeping the current experience intentionally small and calm.

## What changed

- Add exactly three non-destructive discovery materials:
  - Fallen twigs
  - Smooth stones
  - Seed pods
- Generate a bounded deterministic offering from the forest base identity and offering cycle.
- Validate discovery placement against:
  - World bounds
  - Tree and writing-interaction space
  - The protected entrance
  - Markers and stepping stones
  - Other discoveries
- Add deterministic proximity selection and explicit keyboard, pointer, and touch pickup.
- Persist bounded inventory and collection progress independently of the generated discovery manifest.
- Make pickup atomic so persistence failures cannot partially collect an item.
- Add completion-gated deterministic renewal without timers, daily incentives, or inventory loss.
- Add a compact, accessible Satchel with:
  - Current material counts
  - Shared world/Satchel item graphics
  - Renewal and explicit reset actions
  - Escape handling, focus return, and polite live feedback
- Integrate discoveries with viewport culling, stable depth ordering, visibility caching, and development diagnostics.
- Isolate Activity Forest controls from legacy global button and label layout rules.
- Document the discovery, inventory, renewal, persistence, accessibility, and performance contracts.

## Compatibility

- Existing marker-only overlays continue to load unchanged.
- Existing marker-and-trail overlays continue to load unchanged.
- Discovery state uses a separate base-specific development persistence key.
- Discovery generation does not alter tree placement, tree assets, marker identities, or stepping-stone identities.
- Renewal never consumes inventory or changes personal overlay edits.
- Invalid or unsupported saved discovery state recovers visibly without overwriting the offending stored data.

## Scope

This remains a proof of concept. It intentionally does not add:

- Material spending
- Crafting or recipes
- Construction objects
- Shops, rarity, trading, or currencies
- Daily spawns, streaks, or limited-time rewards
- Survival or maintenance mechanics
- Destructive harvesting
- Production database persistence
- A generalized inventory or entity framework

The goal is to prove the interaction and state boundaries so the discovery vocabulary, visuals, placement, and future uses can become richer later.

## Verification

- 601 specs pass
- 17 focused discovery and inventory specs pass
- ESLint passes
- Activity Forest Pug template compiles
- JavaScript syntax and diff hygiene checks pass