### PR TITLE
Expand the Activity Forest gameplay and sustainability vision

### DIFF
--- a/docs/forest/activity-forest-long-term-gameplay-vision.md
+++ b/docs/forest/activity-forest-long-term-gameplay-vision.md
@@ -1,0 +1,515 @@
+# Activity Forest: Long-Term Gameplay and World Vision
+
+## Purpose
+
+This document describes the long-term game design direction for the Activity Forest after the first inhabitable-clearing milestones. It is intentionally broader than the near-term implementation roadmap.
+
+The near-term roadmap should continue to test one small, legible interaction at a time. This document exists so those experiments can point toward a coherent larger world rather than accumulating as unrelated features.
+
+The Activity Forest should become more than generative art or an explorable profile. It should support open-ended construction, curation, discovery, social connection, and emergent play while remaining unmistakably connected to writing.
+
+The north star is:
+
+> **A person's writing becomes a place, and that place becomes a medium they can inhabit, shape, and share.**
+
+## Product identity
+
+The Activity Forest has three simultaneous identities:
+
+1. **A living record of writing**
+   - Posts become stable, inspectable trees.
+   - The landscape preserves traces of projects, interests, collaborations, and periods of life.
+   - Spatial arrangements create new ways to revisit and interpret writing.
+
+2. **A creative world**
+   - The owner can shape terrain, paths, structures, gardens, interiors, signs, and art.
+   - The world can function as a public profile, a personal environment, a collaborative project, or some mixture of the three.
+
+3. **An open-ended game**
+   - Resources, tools, construction systems, ecology, travel, and social interaction should combine in ways that permit outcomes the designer did not script directly.
+   - The game should reward imagination and stewardship rather than optimization, repetitive labor, or spending.
+
+These identities should reinforce one another. The forest should not become a generic crafting game with posts attached as collectibles, nor should the writing connection prevent it from becoming a genuinely playful system.
+
+## Participation depths
+
+Every forest should support several depths of engagement.
+
+### Ambient
+
+Writing grows a complete, attractive landscape. A person who never builds, gathers, or customizes still receives the core magic.
+
+### Curatorial
+
+The owner organizes and interprets the landscape:
+
+- Paths among related trees
+- Named clearings
+- Favorite and commemorative markers
+- Signs, benches, reading nooks, lanterns, gates, and bridges
+- Notes or quotations attached to places
+- Limited relocation or grouping tools
+- Portals and routes among important areas
+
+### Constructive
+
+The owner uses modular systems to build:
+
+- Houses and cabins
+- Exterior and interior rooms
+- Fences, arches, walls, terraces, and stonework
+- Farms, gardens, orchards, and habitat areas
+- Bridges, piers, towers, workshops, and gathering spaces
+- Decorative objects and functional stations
+
+### Expressive
+
+The forest becomes a medium for authored work:
+
+- Paintings made in a simple pixel-art or tile-art editor
+- Sculptures assembled from modular pieces
+- Signs with custom names or messages
+- Display boards for excerpts, quotations, or collections
+- Miniature books, maps, banners, or emblems
+- Music or ambient-sound objects if storage and moderation make them practical
+
+A placed artwork may show a small in-world representation and open a detailed view when approached.
+
+### Social
+
+The forest connects to other people:
+
+- Visitors may enter read-only
+- Trusted invitees may build or decorate within explicit permissions
+- Owners may exchange gifts, seeds, cuttings, plans, or art
+- Collaborators may create shared clearings
+- Portals and paths may recommend other users' forests
+- Community projects may create temporary or permanent shared places
+
+## A world made of worlds
+
+### Edge paths
+
+A public forest should not feel like an isolated diorama. At selected points along its boundary, paths, gates, doorways, ferries, or other transitions may lead into another public forest.
+
+The result is a potentially endless walk through Daily Page:
+
+```text
+one person's forest
+    -> a boundary path
+    -> another person's forest
+    -> another path
+    -> another person's forest
+```
+
+Transitions may be:
+
+- Randomized
+- Weighted toward recently active or thematically related forests
+- Chosen from an owner's recommendations
+- Connected through mutual relationships or collaborations
+- Attached to community quests, rooms, or shared interests
+
+### Safety and consent
+
+Networked traversal must be opt-in and controllable.
+
+Owners should be able to:
+
+- Allow or disallow random visitors
+- Control whether their forest may appear in randomized travel
+- Approve or remove persistent inbound links
+- Block specific users
+- Report abusive or deceptive portals
+- Choose whether visitors arrive at a public entrance or a selected landmark
+
+Public traversal should initially be read-only. Building, item exchange, and chat require explicit permission.
+
+### Portals
+
+Portals are a higher-agency form of travel.
+
+Possible uses:
+
+- Fast travel among distant areas of one forest
+- A deliberate recommendation of another user's public forest
+- Access to a private forest visible only to authorized users
+- Entrance to a shared project or collaborative clearing
+- Return routes to favorite places
+
+Only the owner or authorized builders may create portals. Visitors may use visible portals but cannot alter them.
+
+A portal to another user's forest should behave more like a curated backlink than an unrequested endorsement. The destination owner should be able to opt out of persistent inbound links or limit how they appear.
+
+## The generated world and the authored world
+
+The state model should preserve four layers.
+
+### 1. Generated base
+
+- Terrain seed and version
+- Initial landforms
+- Water and habitat regions
+- Generated post-tree placement
+- Immutable landmarks
+- Deterministic resource and discovery rules
+
+### 2. Writing layer
+
+- Stable post-to-tree identity
+- Post metadata projected into bounded visual traits
+- Relationships among posts
+- Private or public visibility
+- Historical evidence retained across renderer upgrades
+
+Post trees are not ordinary timber. They represent writing and cannot be destroyed for resources.
+
+### 3. Personal overlay
+
+- Trails
+- Structures
+- Placed objects
+- Terrain edits
+- Plantings
+- Art
+- Signs and annotations
+- Portals
+- Permissions
+- Curated tree placement where allowed
+
+### 4. Transient life
+
+- Weather
+- Lighting
+- Wildlife movement
+- Temporary visitors
+- Short-lived discoveries
+- Real-time presence and chat
+
+Generated and authored state should remain independently versioned. A world-generation upgrade must not silently erase or scramble the owner's work.
+
+## World growth and post-tree capacity
+
+Both free and paid users may begin with a compact generated landscape. Writing adds post-linked trees and gradually reveals or generates surrounding terrain.
+
+A proposed free-world bound is an **active grove capacity** rather than deletion or degradation:
+
+- Up to roughly 300 post-linked trees may be spatially active at once.
+- All posts remain available through normal Daily Page archives and forest curation tools.
+- When the active grove reaches capacity, the owner chooses which post trees are currently represented.
+- Removing a tree from the active grove does not delete, demote, or alter its post.
+- Re-adding a removed tree may produce a new generated placement unless the system explicitly preserves a dormant placement record.
+
+Paid forests may continue expanding without the same active-grove bound, allowing the world to generate outward into additional habitats and biomes.
+
+The exact number should be treated as a product and performance hypothesis, not a permanent truth. It should be tested against:
+
+- Typical post counts
+- Browser and server performance
+- How emotionally disruptive curation feels
+- Whether the free world still feels complete
+- Whether expansion is meaningful rather than empty acreage
+
+The interface should never announce that a user's writing has become "too much." It should frame the free bound as a curated active landscape, with the full body of writing still intact and accessible.
+
+## Trees and planting
+
+### Post trees
+
+- Stable identity derived from a post
+- Cannot be cut down or consumed
+- May be inspected to revisit the post
+- Preserve authorship and visibility rules
+- May be decorated, connected, annotated, or curated
+
+All users should have some ability to correct frustrating placement. Paid membership may expand this into full landscape curation, but basic usability should not be sold as a luxury.
+
+A possible boundary:
+
+- Free users receive occasional or bounded transplant actions and can rearrange trees within designated clearing tools.
+- Paid users receive broader, repeatable relocation and landscape-planning controls.
+- Moving a tree never changes its identity or post association.
+
+### Planted trees
+
+- Grown from collected or traded seeds
+- Mature over a modest wall-clock interval, such as several hours
+- May provide fruit, seeds, blossoms, shade, habitat, fallen branches, or other renewable materials
+- May be cut or transplanted if the design supports it
+- Should not require daily care or punish absence
+
+Wall-clock growth should provide anticipation, not obligation. Nothing should die because the player stayed away.
+
+## Building system
+
+Emergent play requires a small set of systems with many combinations, not a giant catalog of single-purpose decorations.
+
+### Modular construction grammar
+
+Prefer reusable parts:
+
+- Floors, walls, roofs, doors, windows, columns, beams, stairs, arches, fences
+- Stone blocks, earth banks, retaining walls, terraces, bridges, and paths
+- Interior surfaces, shelves, tables, chairs, lights, frames, and storage
+- Paint, material, orientation, and trim variants
+
+Parts should snap clearly but permit enough variation to avoid identical buildings.
+
+### Functional affordances
+
+A small number of object behaviors can produce many uses:
+
+- **Container:** stores or displays selected resources or gifts
+- **Surface:** supports objects, art, books, or signs
+- **Seat:** opens a quiet reading or reflection interface
+- **Light:** changes local visibility or atmosphere
+- **Sign:** displays text, a name, or a route
+- **Frame:** displays user-created art or a selected post excerpt
+- **Portal:** links places
+- **Plot:** supports plants or habitat
+- **Workshop:** converts materials according to discovered plans
+- **Gathering point:** defines where visitors arrive or collaborate
+
+The game should favor verbs that compose. "Place," "connect," "display," "grow," "shape," "store," "gift," and "link" are more generative than a hundred isolated collectible objects.
+
+### Earthworks and stoneworks
+
+Longer-term terrain tools may include:
+
+- Raising or lowering bounded terrain patches
+- Smoothing, painting, or replacing ground surfaces
+- Digging ponds or channels within safe constraints
+- Creating terraces, berms, mounds, and sunken gardens
+- Building stone walls, arches, monuments, and entrance structures
+- A customizable ranch-style entrance arch with a name or message
+
+These tools require stronger validation, migration, and collision contracts than ordinary placed objects. They belong after modular building and saved-world upgrades are reliable.
+
+## Crafting and discovery
+
+Crafting should deepen expression and discovery rather than form a mandatory progression ladder.
+
+Good recipe sources include:
+
+- Experimenting with compatible materials
+- Finding plans while exploring
+- Receiving a plan from another user
+- Learning from a community quest
+- Inspecting a structure in another forest
+- Revisiting writing associated with a material or place
+
+Recipes should generally unlock possibilities, not power.
+
+Possible material families:
+
+- Fallen wood and fiber
+- Stone, clay, sand, and pigment
+- Seeds, petals, fruit, and botanical dyes
+- Glass, metal fittings, paper, and fabric obtained through markets or projects
+- Found curiosities with expressive uses
+
+Avoid tool durability, hunger, combat statistics, rarity speculation, and repetitive production chains unless later evidence shows that they genuinely serve the world.
+
+## Economy and market
+
+The market should support exchange and expression, not create a pay-to-advance economy.
+
+Good uses:
+
+- Selling surplus renewable resources
+- Buying ordinary building materials
+- Trading seeds, cuttings, plans, art, and crafted objects
+- Funding shared construction projects
+- Acquiring materials unavailable in one's current biome
+
+Guardrails:
+
+- No real-money purchase of gold
+- No randomized paid rewards
+- No paid mechanical advantage in public competition
+- No essential writing feature tied to resources
+- No market design that rewards spam posting
+- No irreversible loss caused by inactivity
+
+A paid membership should **not** simply remove a gold-earning cap that constrains free users. That would make payment directly purchase economic acceleration.
+
+Safer membership distinctions include:
+
+- Larger market listings
+- Better inventory organization
+- Saved trade searches
+- Private-group exchanges
+- More storage for authored assets
+- Hosted continuity across larger worlds
+- Cosmetic presentation options
+
+If a free daily sale bound is required for abuse prevention, a comparable anti-abuse policy should apply fairly. Membership may raise operational limits only where the difference corresponds to real hosting cost and does not create public dominance.
+
+## Multiplayer and collaboration
+
+Real-time multiplayer is valuable but technically expensive. It should arrive in layers.
+
+### Phase 1: Read-only visiting
+
+- Enter another public forest
+- Inspect public writing
+- Use public portals
+- View art and structures
+- Leave through the entrance or a portal
+
+### Phase 2: Asynchronous collaboration
+
+- Owner grants object-level or area-level permissions
+- Invitees place or edit objects while the owner is absent
+- Changes are versioned and attributable
+- Owners can review, revert, or remove contributions
+
+### Phase 3: Shared presence
+
+- A small number of concurrent visitors
+- Position and avatar presence
+- Simple emotes
+- Optional ephemeral text chat
+- Clear mute, block, kick, and reporting controls
+
+### Phase 4: Cooperative activities
+
+- Shared building
+- Gift exchange
+- Community projects
+- Joint exploration or discovery
+- Collaborative art and writing installations
+
+An ephemeral chat history of one or two minutes may preserve the feeling of spoken conversation, but moderation and safety still require server-side abuse controls, rate limits, reporting evidence, and clear retention policy. The interface may be ephemeral even if narrowly bounded safety records exist behind the scenes.
+
+## Avatars
+
+Every visitor needs a legible avatar, but avatar quality should not become a hierarchy of human worth.
+
+Free users should receive:
+
+- A varied and expressive base creator
+- Multiple body, skin, hair, mobility, and clothing options
+- Enough combinations that the free population does not look uniform
+- Accessibility and identity-respecting choices
+
+Paid membership may add:
+
+- More clothing and accessory sets
+- Additional animation styles
+- Saved outfits
+- Greater color and pattern control
+- Themed cosmetic collections
+
+Paid cosmetics should be expansive rather than corrective. They should not contain the only dignified, culturally broad, or identity-relevant choices.
+
+## Public and private worlds
+
+### Public forest
+
+- Grown from public writing
+- Discoverable according to the owner's settings
+- Traversable by visitors
+- Suitable as a creative public profile
+- Connected to other public forests through edge paths and portals
+- Core ambient, curatorial, and playful mechanics remain meaningful
+
+### Private forest
+
+- Grown from private writing
+- Accessible only to the owner and invited collaborators
+- Not reachable through public random travel
+- May use a private portal visible only to authorized users
+- Supports journaling, drafts, research notes, personal archives, and private projects
+- Receives the same fundamental care as the public world
+
+Private forests are not merely public forests with a lock icon. They are the spatial expression of writing that does not belong in the commons.
+
+## Candidate free and paid boundary
+
+This boundary is provisional and should be tested.
+
+### Free
+
+- Public writing and public post trees
+- A complete ambient forest
+- Core exploration, resource gathering, planting, crafting, and building
+- A bounded but meaningful active grove
+- Basic tree-placement correction
+- Read-only visiting and use of public portals
+- A varied base avatar creator
+- Public art, structures, trails, and profile customization
+- Normal writing, reading, comments, rooms, quests, and discovery
+
+### Paid membership
+
+- Private writing spaces and private forests
+- Continued hosted terrain expansion beyond the free active-grove bound
+- Broader tree and landscape curation
+- More or larger private and collaborative spaces
+- Creation of portals
+- Invited building permissions and small-group collaboration
+- Expanded cosmetic and authored-asset storage
+- Stronger backup, export, history, and organization tools
+- Larger media and art capacity where hosting cost is real
+- Convenience and control features that do not create public mechanical superiority
+
+The principle is:
+
+> **Everyone receives the game. Members receive more space, privacy, continuity, and authorship over the world.**
+
+## Writing and creator tools
+
+The forest revenue model should not ignore the writing product itself.
+
+Strong paid candidates include:
+
+- Private posts, rooms, journals, and notebooks
+- Private quests and long-running projects
+- Full revision history
+- Scheduled or automatic exports
+- Reliable backups and restore points
+- Larger image and media storage
+- Advanced private search, collections, and saved views
+- Shared private rooms with granular permissions
+- Collaborative drafts and review workflows
+- Custom private templates
+- Optional custom domain or portfolio presentation
+- Downloadable world snapshots or archival bundles
+- A private spatial archive that links writing, art, and projects
+
+Core public writing, ordinary editing, accessibility, publishing, reading, comments, and community participation should remain free.
+
+## Design tests for emergent gameplay
+
+Before adding a system, ask:
+
+1. Can players combine it with several existing systems?
+2. Can it produce outcomes the designer did not explicitly script?
+3. Does it create expression, discovery, relationship, or a new route to writing?
+4. Is there more than one reasonable use or arrangement?
+5. Can a player ignore it without suffering loss?
+6. Does it avoid rewarding spam, raw word count, or repetitive activity?
+7. Does it preserve the meaning of post trees?
+8. Does payment expand space or control rather than purchase power?
+9. Can the state be migrated, reversed, and moderated?
+10. Is the interaction still worthwhile without a currency counter?
+
+## Recommended implementation horizon
+
+The existing Part II roadmap should remain the near-term spine through the first clearing loop.
+
+After its current Milestone 3, the next work should still be narrow:
+
+1. Place and personalize two or three clearing objects.
+2. Connect at least one object back to writing.
+3. Evaluate whether the clearing is already pleasant and expressive.
+4. Add a first modular construction proof, such as a small gate, shelter, or arch assembled from reusable parts.
+5. Add one planted-tree lifecycle.
+6. Add one neighboring habitat and bounded world expansion.
+7. Add read-only visits to a deliberately selected fixture forest.
+8. Test one owner-authored outbound portal.
+9. Add asynchronous invited editing before real-time multiplayer.
+10. Evaluate the economy only after building and exchange create genuine material needs.
+
+The long-term vision should guide architecture, but it should not convert the next milestone into the whole game at once.

--- a/docs/product/sustainability-and-open-source.md
+++ b/docs/product/sustainability-and-open-source.md
@@ -2,97 +2,344 @@
 
 ## Purpose
 
-This document records a product strategy direction for making Daily Page financially sustainable without violating the spirit of the site.
+This document records a product strategy for making Daily Page financially sustainable without violating the spirit of the site.
 
-Daily Page should remain a generous public writing commons. Revenue should come from paid private space and hosted continuity, not from selling visibility, public status, moderation power, or access to the basic dignity of writing here.
+Daily Page should remain a generous public writing commons and a complete public game. Revenue should come primarily from private space, larger hosted worlds, continuity, collaboration, organization, and creative control, not from selling visibility, public status, moderation power, or mechanical superiority.
 
 The short version is:
 
-> **The public forest should prove the spirit of Daily Page. The private forest should sustain it.**
+> **The public forest should prove the spirit of Daily Page. Membership should give people more room to make that spirit their own.**
 
-## Revenue model
+## Product and revenue thesis
 
-The cleanest long-term paid boundary is private hosted writing:
+Daily Page may ultimately combine three products:
+
+1. A public writing and knowledge commons
+2. A private writing and thinking space
+3. A persistent creative sandbox shaped by writing
+
+The paid value is stronger when these are treated as one relationship rather than a bag of separately priced features.
+
+A member is not merely paying to hide posts. They are paying for:
+
+- A private body of writing
+- A private world grown from that writing
+- Greater hosted continuity and capacity
+- Deeper curation and collaboration
+- Reliable organization, export, backup, and stewardship
+
+The guiding distinction is not:
+
+```text
+Free: generative art
+Paid: the real game
+```
+
+It is closer to:
 
 ```text
 Free:
-public writing in the Daily Page commons
-public posts represented in a meaningful Activity Forest
-core reading, writing, discovery, and community participation
+a complete public writing experience
+a meaningful public Activity Forest
+core exploration, gathering, building, crafting, and visiting
+a bounded but expressive hosted public world
 
 Paid:
-private writing spaces
-private Activity Forests grown from private writing
-hosted continuity, privacy expectations, backups, and personal organization
+private writing and private worlds
+larger or continuing hosted terrain
+deeper curation and collaborative control
+more storage, history, organization, and continuity
 ```
 
-This boundary works because it is not a tax on public participation. It does not make free users' writing less expressive, less beautiful, or less legitimate. It gives paying users a deeper inward version of the same product idea: the ability to bring more personal writing into Daily Page and let it grow into a private place.
+Everyone should be able to experience the essential game loop. Payment should expand space, privacy, authorship, and hosted convenience.
 
-Daily Page should avoid revenue models that undermine the commons:
+## Candidate membership promise
 
-- Selling public visibility or ranking.
-- Giving paid users superior public status.
-- Charging for core public writing, commenting, or reading functions.
-- Making the free Activity Forest feel intentionally dull or incomplete.
-- Turning resources, streaks, or activity volume into public power.
-- Depending on ads that distort the writing environment.
+A possible public-facing promise is:
 
-The paid promise should be private terrain, not paid dignity. Everyone gets the core magic. Paid users get hosted private space for writing that does not belong in the public square.
+> **Build a private writing world that grows with your life.**
 
-## Product principles
+A membership might eventually include:
 
-Payment should attach to real hosted value:
+- Private posts, rooms, journals, notebooks, and quests
+- A private Activity Forest grown from private writing
+- Continued terrain expansion beyond the free active-grove capacity
+- Broader tree and landscape curation
+- Invited collaborators and controlled building permissions
+- Portal creation
+- Larger storage for images, art, and world assets
+- Revision history, backups, restore points, and exports
+- Advanced private search, collections, and project organization
+- Saved outfits and expanded cosmetic customization
+- Optional custom-domain or portfolio tools
 
-- Privacy and access control.
-- Storage and infrastructure.
-- Backups and long-term continuity.
-- Personal organization and private rooms.
-- Reliable deployment, updates, and security maintenance.
-- A private Activity Forest that reflects private writing history.
+The first paid release does not need all of these. Private writing plus a private persistent world may be the initial kernel. The rest can accumulate into the membership without fragmenting the experience into microtransactions.
 
-Payment should not attach to public leverage:
+## One membership before many tiers
 
-- More powerful trees or resources.
-- Preferential moderation outcomes.
-- Higher visibility in public spaces.
-- Exclusive public expression mechanics.
-- Essential writing, reading, or community tools.
+Daily Page should begin with one understandable membership rather than a shop full of tollbooths.
 
-A useful shorthand is:
+A single subscription has several advantages:
 
-> **Paid privacy, not paid dignity.**
+- The value proposition remains legible.
+- New features strengthen the membership automatically.
+- Users do not have to evaluate a price at every creative decision.
+- The forest does not become a storefront disguised as a landscape.
+- Product experiments can be added or removed without inventing a new transaction each time.
+
+A higher tier may eventually make sense for materially different use cases, such as teams, classrooms, unusually large storage, or custom hosting. It should appear only after real usage reveals a separate customer group.
+
+## Free public world
+
+The free experience should be capable of producing stories, not merely attractive screenshots.
+
+Free users should receive:
+
+- Public writing and post trees
+- A complete ambient forest
+- Meaningful exploration and discovery
+- Basic gathering, planting, crafting, and building
+- Trails, signs, art, structures, and profile customization
+- Read-only travel among opted-in public forests
+- Use of public portals
+- A varied and dignified avatar creator
+- Core rooms, quests, comments, reading, and publishing
+- Basic correction of frustrating generated placement
+
+A possible capacity boundary is a curated **active grove** of approximately 300 post-linked trees. Reaching the bound must not delete, demote, or devalue writing. All posts remain available through ordinary archives and a tree-selection interface.
+
+The number is provisional. It should be tested for performance, emotional effect, typical user behavior, and whether the free landscape still feels generous.
+
+## Paid hosted worlds
+
+Membership may expand:
+
+- Private forests
+- Continued terrain generation beyond the active-grove bound
+- Additional biomes as the world grows
+- Larger private or collaborative spaces
+- Broader tree relocation and landscape planning
+- Portal creation
+- Controlled building permissions for invited users
+- Expanded authored-art and media capacity
+- Stronger backup, history, and recovery
+- Convenience features for large inventories, projects, and worlds
+
+These are valuable because they involve real hosted cost, private responsibility, persistent state, or deeper control.
+
+## Assessment of proposed premium mechanics
+
+### Unlimited or continuing map growth
+
+**Promising.**
+
+A bounded free world and continuously expanding member world can be a coherent capacity boundary. It maps payment to storage, world state, asset delivery, backups, and long-term continuity.
+
+The free world must still feel complete. The interface should describe it as a curated active landscape rather than a punishment for prolific writing.
+
+### Moving post-linked trees
+
+**Promising with adjustment.**
+
+Full landscape planning can be a paid control feature, but all users need some remedy for frustrating placement. Basic usability should not be paywalled.
+
+A balanced approach:
+
+- Free users receive bounded transplant actions or clearing-level rearrangement.
+- Members receive broader, repeatable relocation and planning tools.
+- Movement never changes a tree's identity or its connection to writing.
+
+### Invited builders and small-group presence
+
+**Strong paid value, but later and technically expensive.**
+
+Private or permissioned collaboration is a natural membership feature because it requires authorization, synchronization, state history, moderation, and hosting.
+
+Development should progress from read-only visits to asynchronous invited edits, then to real-time presence and ephemeral chat.
+
+### Expanded avatar customization
+
+**Suitable supporting value.**
+
+Members may receive more outfits, accessories, saved looks, colors, and patterns. The free creator must still be varied, inclusive, and expressive. Payment should buy breadth, not the only dignified choices.
+
+### Portal creation
+
+**Strong and distinctive.**
+
+All users may use visible portals. Members may create and curate portals within their worlds.
+
+Portals can serve:
+
+- Fast travel
+- Recommendations and backlinks
+- Private-world entrances
+- Shared-project entrances
+- Routes among important areas
+
+Cross-user portals require consent, opt-out controls, blocking, and anti-spam moderation.
+
+### Private Activity Forest
+
+**The strongest core paid feature.**
+
+Private writing creates a category of use the public commons cannot serve: journals, drafts, research notes, family history, personal reflections, unfinished fiction, and private projects.
+
+The private forest turns privacy from a checkbox into a persistent place.
+
+### Removing a market sale cap
+
+**Not recommended as proposed.**
+
+Allowing paid users to earn unlimited gold while free users face a daily limit would make payment purchase economic acceleration. That conflicts with the goal of avoiding paid mechanical superiority.
+
+Safer paid market features include:
+
+- More listing slots
+- Better organization
+- Saved searches
+- Private-group exchanges
+- Larger storage
+- Exportable transaction history
+- Convenience tools that do not dominate public play
+
+If daily limits are needed to prevent abuse, they should be designed as fair safety constraints rather than subscription pressure.
+
+## Writing and creator tools
+
+The membership should carry substantial value even for people who engage lightly with the game.
+
+Promising paid writing features include:
+
+- Private posts and private rooms
+- Private journals and notebooks
+- Private quests and project spaces
+- Full revision history
+- Scheduled or automatic exports
+- Backups and restore points
+- Advanced private search and saved views
+- Collections that span rooms and projects
+- Shared private writing with granular permissions
+- Collaborative drafts and review workflows
+- Larger image and media storage
+- Custom private templates
+- Optional custom-domain or portfolio presentation
+- Archival bundles containing writing and world state
+
+Core public writing, ordinary editing, reading, comments, accessibility, moderation access, and public discovery should remain free.
+
+## Revenue guardrails
+
+Daily Page should avoid:
+
+- Selling public ranking or visibility
+- Paid moderation influence
+- Paid competitive power
+- Real-money purchases of gold or resources
+- Randomized paid rewards
+- Artificial energy systems
+- Tool durability sold as relief
+- Essential mechanics withheld from free users
+- Constant cosmetic microtransactions
+- Resource requirements for publishing or reading
+- Designs that reward spam posting or raw word count
+- Holding private writing hostage through poor export options
+- Making the public forest intentionally dull, cramped, or socially inferior
+
+A useful shorthand remains:
+
+> **Paid privacy, space, and authorship, not paid dignity or power.**
+
+## Ethical retention
+
+Persistent worlds naturally become more valuable as people invest time and meaning in them. This can support healthy subscription retention, but it also creates responsibility.
+
+Members should have:
+
+- Reliable writing exports
+- Clear world-data policies
+- Grace periods after failed payments
+- A reasonable path to recover or archive private work
+- No surprise destruction of worlds
+- Transparent storage and deletion rules
+
+The world may encourage someone to stay because it matters to them. It should never trap them because leaving would erase their memories without recourse.
 
 ## Open-source posture
 
-Daily Page being open source does not inherently weaken this model. The business is not selling access to hidden code. The business would be selling a trusted hosted writing place with identity, continuity, privacy, community, moderation, and stewardship.
+Daily Page being open source does not inherently weaken this model. The business is not selling hidden code. It is selling a trusted hosted place with identity, continuity, privacy, community, moderation, infrastructure, and stewardship.
 
-The official hosted service can remain valuable even when the code is public because most users do not want to operate the full stack themselves. A complete independent deployment can require database setup, object storage, email, environment variables, production hosting, domain and HTTPS configuration, WebRTC/TURN support, backups, updates, monitoring, moderation, and ongoing maintenance.
+The official hosted service can remain valuable even when the code is public because most users do not want to operate the complete stack themselves. Independent deployment may require:
 
-Self-hosting can still be a strength. It can support developers, schools, clubs, experiments, accessibility work, audits, and community contributions. Public source code can increase trust because users can inspect how the site works, understand its values, and contribute improvements to the Activity Forest and the broader app.
+- Database setup
+- Object storage
+- Email delivery
+- Production hosting
+- Domain and HTTPS configuration
+- Real-time networking infrastructure
+- Backups and migrations
+- Monitoring and security maintenance
+- Moderation systems
+- Ongoing updates
 
-The moat should not be secrecy. The moat should be the living bundle:
+Self-hosting can still be a strength. It supports developers, schools, clubs, experiments, audits, accessibility work, and community contribution.
 
-- The canonical Daily Page domain.
-- The public writing commons.
-- User identity and writing history.
-- Hosted private forests.
-- Reliable infrastructure and backups.
-- Moderation and trust.
-- Ongoing design taste.
-- The creator's stewardship.
+The moat should not be secrecy. It should be the living bundle:
+
+- The canonical Daily Page domain
+- The public writing commons
+- User identity and writing history
+- The network of connected forests
+- Hosted private worlds
+- Reliable infrastructure and backups
+- Moderation and trust
+- Ongoing design taste
+- The creator's stewardship
 
 ## License note
 
-The repository currently uses the MIT license. That is a permissive and friendly open-source posture, but it also allows commercial reuse and competing hosted services as long as the license terms are followed.
+The repository currently uses the MIT license. MIT permits commercial reuse and competing hosted services as long as its terms are followed.
 
-This does not make the sustainability model invalid. It does mean the licensing choice should remain intentional, especially if the Activity Forest becomes a central business asset. Future review could consider whether MIT still fits the project, or whether another open-source strategy such as copyleft, network copyleft, or open core better matches Daily Page's goals.
+That does not invalidate the sustainability model, but the choice should remain intentional if Activity Forest becomes a central business asset. Future review may consider whether MIT, copyleft, network copyleft, dual licensing, or another open-source strategy best matches Daily Page's values and goals.
 
-This is a planning note, not legal advice. Any license change should be handled carefully before meaningful revenue or outside contributions make the question more complicated.
+This is a planning note, not legal advice. License changes should be handled carefully before substantial outside contributions or revenue make the question more complicated.
 
-## Forest connection
+## Staged validation
 
-The Activity Forest is the strongest known expression of this model because it turns writing history into an inhabitable place. The public version can show why Daily Page matters:
+Before committing to a complete business model, validate progressively.
 
-> "Here, your writing becomes a place."
+### Stage 1
 
-The private version can make the same promise for writing that users want to keep personal. That is why the forest should be designed first as a meaningful public experience, then extended into private space only in ways that preserve the public commons.
+Prove that the public forest is meaningful as memory and place.
+
+### Stage 2
+
+Prove that lightweight construction and discovery make people return voluntarily.
+
+### Stage 3
+
+Test whether private writing plus a private forest is understandable and desirable as one membership.
+
+### Stage 4
+
+Observe which additional value matters most:
+
+- Larger worlds
+- Collaboration
+- Organization
+- Backup and history
+- Art and media
+- Portal networks
+- Advanced writing workflows
+
+### Stage 5
+
+Price and package around demonstrated use rather than theoretical feature count.
+
+## Final principle
+
+The forest can support a real business precisely because it should not feel engineered primarily to extract money.
+
+The public experience creates trust and meaning. Membership deepens privacy, capacity, continuity, and control.
+
+> **Everyone gets a world worth inhabiting. Members get more room to let that world become their own.**


### PR DESCRIPTION
## Summary

Expands the long-term product direction for the Activity Forest and revises the Daily Page sustainability strategy around a richer but still equitable game experience.

The new gameplay document describes the broader horizon. The existing Part II roadmap remains the near-term implementation spine, with each feature continuing to be tested through small, bounded experiments.

## Changes

- Add `docs/forest/activity-forest-long-term-gameplay-vision.md`.
- Expand `docs/product/sustainability-and-open-source.md`.
- Define the Activity Forest as:
  - A living record of writing
  - A creative authored world
  - An open-ended game
- Describe ambient, curatorial, constructive, expressive, and social participation depths.
- Explore longer-term systems including:
  - Modular construction
  - Planting and ecology
  - Art and authored assets
  - Crafting and expressive exchange
  - Connected public forests and portals
  - Read-only visiting
  - Asynchronous collaboration
  - Small-scale shared presence
- Establish consent, permission, moderation, and safety expectations for connected forests.
- Distinguish generated, writing-derived, authored, and transient world state.
- Describe active-grove capacity as a provisional product and performance hypothesis.
- Expand the candidate membership model around:
  - Private writing and private forests
  - Larger hosted worlds
  - Continuity, backup, and history
  - Collaboration and permissions
  - Broader curation and creative control
  - Authored-asset and media storage
- Clarify that the complete public game should remain available without payment.
- Reject paid visibility, economic acceleration, mechanical superiority, randomized rewards, and essential mechanics withheld from free users.
- Expand the open-source, licensing, ethical-retention, and staged-validation discussion.

## Product principles

The revised direction centers on this boundary:

> Everyone receives the game. Members receive more space, privacy, continuity, and authorship over the world.

The free Activity Forest should remain complete, expressive, and socially meaningful. Membership should correspond to real hosted value rather than public power or creative dignity.

## Relationship to the near-term roadmap

The existing Part II roadmap remains appropriate through the first clearing loop:

1. Place and personalize a small set of clearing objects.
2. Connect at least one authored object back to writing.
3. Evaluate whether the resulting clearing is pleasant, expressive, and worth returning to.

The larger systems in this vision are horizons rather than immediate commitments. Their order should be chosen from evidence gathered through the first clearing experiment.

## Non-goals

This PR does not:

- Implement gameplay systems
- Establish final pricing or membership terms
- Commit to a permanent active-grove capacity
- Add entitlement or payment checks
- Change production persistence
- Choose a final licensing strategy
- Commit to multiplayer, markets, portals, or real-time chat
- Replace the existing near-term roadmap with a full-game implementation plan

## Validation

- Documentation reviewed for consistency between the gameplay and sustainability directions
- Existing near-term roadmap compared against the expanded vision
- `git diff --check` passes
- No automated tests run because this is a documentation-only change