### PR TITLE
Add persistent and customizable clearing objects to Activity Forest

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -508,11 +508,90 @@ the page boundary. Forest controls therefore do not inherit the site's generic f
 font size, or fixed line-height. Satchel controls explicitly own their dimensions, spacing, colors,
 disabled treatment, and focus rings in both site themes.
 
-The next boundary remains explicit: there is no spending, crafting, construction toolbar, large
-inventory, equipment, shops, trading, daily spawn, streak, survival need, destructive harvesting,
-production storage, multiplayer, or generalized entity system. Benches, lanterns, signs, material
-costs, placement refunds, and environmental personalization belong to later milestones and are not
-implied by the Satchel.
+The discovery contract itself still contains no spending or crafting semantics. Milestone 4 adds a
+separate, fixed clearing-object vocabulary and derives commitments from that overlay.
+
+### Milestone 4 clearing-object contract
+
+The initial vocabulary is exactly **trail sign**, **stone bench**, and **seed-pod lantern**. They
+exercise the future `sign`, `seat`, and `light` affordances without introducing a general building
+or crafting system. Their code-owned costs are fixed at two fallen twigs; two smooth stones; and one
+fallen twig plus two seed pods, respectively. Costs, collision footprints, interaction reach,
+visual dimensions and colors are never loaded from personal state. One nine-discovery offering can
+therefore fund one of each object, with one smooth stone and one seed pod left available. The overlay allows at most nine
+clearing objects and at most three of any type.
+
+All three use placed-object schema version 1, stable ids of the form
+`forest-clearing-v1-{type}-{01..03}`, and integer world coordinates. Bench and lantern records have
+exactly five fields:
+
+```text
+schemaVersion, id, type, worldX, worldY
+```
+
+A sign alone adds an exact `text` field. Text is normalized to Unicode NFC, CR/LF sequences become
+one space, surrounding and repeated horizontal whitespace is removed, control characters are
+rejected, and the result is capped at 60 Unicode code points. Empty text is allowed and renders as
+an unnamed sign. It is assigned only through `textContent` or an input value; it is never treated as
+HTML. Unknown types, fields, mismatched identities, malformed text, duplicate ids, unsupported
+versions and per-type or total overflows reject the complete overlay. Visual version 1 remains a
+code boundary independent of mutable placement records.
+
+Material accounting uses a derived commitment ledger. Discovery inventory remains the total ever
+gathered; available inventory is that total minus the fixed costs of every valid clearing object in
+the overlay. Placement validates a complete candidate, checks this derived availability, saves the
+single candidate overlay record, and only then replaces live objects. Removal saves the candidate
+without one identity before live removal, which makes its complete fixed cost available again.
+Moves and sign edits replace a record under the same id and cannot charge or refund. A storage
+exception leaves both the live overlay and derived availability unchanged; repeated placement or
+removal input cannot debit or refund twice because there is no independently mutable debit record.
+The discovery and overlay storage keys remain independently versioned and marker/trail and
+Milestone 3 records load unchanged, but no operation that changes commitment requires two writes.
+
+If loaded collected totals are inconsistent with valid authored objects, diagnostics report
+`impossible-material-commitment`, all new construction is disabled, and the authored overlay remains
+visible and removable so the developer can recover without duplicating material. The discovery
+reset is disabled while clearing objects exist; its label explains that objects must first be
+removed and refunded. `Reset personal overlay` removes the marker, trail, and all clearing objects,
+thereby making every committed material available while leaving gathered inventory and discovery
+progress intact. Renewal changes only the discovery cycle and never consumes objects, trails, or
+committed material.
+
+Placement is one focused mode entered from three 44-pixel Satchel actions. Keyboard placement
+starts at the deterministic point 56 world pixels above the player; movement updates that preview,
+Enter commits, and Escape cancels. Pointer and touch coordinates map through the viewport to bounded
+integer world coordinates and commit once on pointer-down instead of starting the joystick. A
+valid preview has a pale outline; an invalid preview has a red outline plus a drawn cross, so color
+is not the only cue. A polite status names success, rejection, refund, cancellation, or save
+failure. Selecting an object opens a native modal with text-safe, read-only inspection plus move,
+removal, and close actions. A sign exposes a separate `Edit message` action; only that action reveals
+and focuses the input, while cancel restores the read-only view. The development route assumes the
+personal-overlay owner permission that a production surface will eventually need to gate. Closing
+returns focus to exploration.
+
+Validation protects world bounds, tree collision and an additional 28-pixel writing-interaction
+clearance, the 52-pixel entrance region, the current player, marker and stone footprints, active
+discoveries, and an additional 34-pixel gap among clearing objects. These bounded rules preserve the
+flat generated corridor assumptions without pathfinding or terrain analysis. The stone bench is
+solid and joins deterministic axis-separated player collision; signs and lanterns are non-solid.
+Only three benches can exist, their spacing and entrance/tree exclusions prevent this slice from
+closing the entrance or a writing tree, and no navigation mesh or generalized physics is added.
+
+The objects use fixed Canvas primitives. The lantern has one bounded translucent glow with a small,
+deterministic two-frequency pulse in the existing ambient render loop. Reduced-motion mode holds it
+at a fixed midpoint. There is no darkness, power, time-of-day, or lighting engine. Objects enter the existing visibility
+cache, bounded culling rectangles, stable ground-Y/kind/id depth ordering, and deterministic
+distance/kind/id focus query. No visual preparation or regional asset request is needed. Diagnostics
+report total and visible objects, counts by type, placement mode, available and committed counts,
+and the last edit or persistence failure. Candidate generation, normalization, schema validation,
+ledger calculation, JSON and storage remain in initialization or explicit handlers rather than
+animation-frame callbacks; frames perform only preview math, collision, culling, focus and draws.
+
+Milestone 5 writing resurfacing remains deliberately absent: the bench only identifies a quiet
+place, the sign displays its restrained authored text, and the lantern identifies its gentle glow.
+There are no post associations, excerpts, semantic relationships, sitting animation, construction
+parts, arbitrary recipes, terrain edits, generalized lighting, containers, shops, production
+storage, multiplayer, or entity-component framework.
 
 ### Development pressure profiles
 

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -28,6 +28,9 @@ html[data-theme='dark'] .activity-forest label {
   color: inherit;
 }
 
+/* Component display declarations must never override native hidden state. */
+.activity-forest [hidden] { display: none !important; }
+
 .activity-forest__header {
   display: flex;
   align-items: end;
@@ -251,6 +254,7 @@ html[data-theme='dark'] .activity-forest .activity-forest__satchel-button {
 .activity-forest__satchel-actions {
   display: grid;
   gap: 0.5rem;
+  margin-top: 0.75rem;
 }
 .activity-forest__satchel-actions button {
   width: 100%;
@@ -262,6 +266,42 @@ html[data-theme='dark'] .activity-forest .activity-forest__satchel-button {
   background: transparent;
   color: #765146;
 }
+
+.activity-forest__satchel-subheading { margin: 1rem 0 0.45rem; font-size: 0.9rem; }
+.activity-forest__build-list { display: grid; gap: 0.4rem; }
+.activity-forest__build-list button {
+  display: grid;
+  min-height: 44px;
+  border: 1px solid #786f54;
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+  background: #fff8e5;
+  color: #34463d;
+  text-align: left;
+}
+.activity-forest__build-list button span { margin-top: 0.15rem; font-size: 0.72rem; }
+.activity-forest__object-editor {
+  margin: 1rem 0;
+  border: 1px solid rgba(86, 82, 61, 0.25);
+  border-radius: 10px;
+  padding: 0.85rem;
+  background: rgba(255, 248, 229, 0.55);
+}
+.activity-forest__object-text-label { display: grid; gap: 0.35rem; }
+.activity-forest__object-text-label input {
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+  border: 1px solid #786f54;
+  border-radius: 7px;
+  padding: 0.6rem 0.7rem;
+  background: #fffdf4;
+  color: #25352f;
+}
+.activity-forest__object-editor .activity-forest__dialog-context { margin: 0.45rem 0 0.75rem; }
+.activity-forest__object-editor-actions,
+.activity-forest__object-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.activity-forest__object-actions { margin-top: 1.25rem; }
 
 html[data-theme='dark'] .activity-forest__satchel button {
   border-color: #786f54;
@@ -379,9 +419,30 @@ html[data-theme='dark'] .activity-forest .activity-forest__prompt {
 .activity-forest__dialog-excerpt { font-size: 1.08rem; line-height: 1.65; }
 .activity-forest__dialog button {
   min-height: 44px;
+  box-sizing: border-box;
+  border: 1px solid #786f54;
+  border-radius: 7px;
   padding: 0.5rem 0.85rem;
+  background: #fff8e5;
+  color: #34463d;
   font-size: 0.78rem;
   line-height: 1.2;
+}
+.activity-forest__dialog button:hover { border-color: #4f5f52; background: #f2e7c8; }
+.activity-forest__dialog button:focus-visible,
+.activity-forest__object-text-label input:focus-visible {
+  outline: 3px solid #8b4d38;
+  outline-offset: 2px;
+}
+html[data-theme='dark'] .activity-forest .activity-forest__dialog button {
+  border-color: #786f54;
+  background: #fff8e5;
+  color: #34463d;
+}
+html[data-theme='dark'] .activity-forest .activity-forest__object-text-label input {
+  border-color: #786f54;
+  background: #fffdf4;
+  color: #25352f;
 }
 
 .activity-forest__diagnostics {

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -6,6 +6,8 @@ import {
   forestSceneAssetKeysForCells,
   forestSceneCellIdsForViewport,
   forestFoliageMotionGroupDisplacement,
+  forestLanternGlowIntensity,
+  forestSolidClearingPlacements,
   forestPlacementWindParameters,
   moveForestPlayer,
   normalizedMovement,
@@ -28,13 +30,28 @@ import {
   createForestMarker,
   createForestTrailPlacementPreview,
   forestSteppingStoneJoins,
+  FOREST_STONE_BENCH_TYPE,
   FOREST_STEPPING_STONE_TYPE,
+  FOREST_TRAIL_SIGN_TYPE,
   nextForestSteppingStoneId,
   overlayWithForestSteppingStone,
   overlayWithoutForestSteppingStone,
   overlayWithForestMarker,
   validateForestObjectPlacement
 } from './forest-world-overlay.js';
+import {
+  canAffordForestClearingObject,
+  createForestClearingObject,
+  createForestClearingPlacementPreview,
+  FOREST_CLEARING_OBJECT_DEFINITIONS,
+  FOREST_CLEARING_OBJECT_TYPES,
+  forestClearingMaterialLedger,
+  isForestClearingObject,
+  nextForestClearingObjectId,
+  normalizeForestSignText,
+  overlayWithForestClearingObject,
+  overlayWithoutForestClearingObject
+} from './forest-clearing-objects.js';
 
 const payload = document.getElementById('activity-forest-scene');
 const viewportElement = document.querySelector('[data-forest-viewport]');
@@ -74,8 +91,15 @@ if (payload && viewportElement && canvas) {
   const trailStatus = document.querySelector('[data-forest-trail-status]');
   const trailModeLabel = document.querySelector('[data-forest-trail-mode]');
   const trailEditor = { active: false, tool: 'place', preview: null, movingId: null };
+  const clearingTools = document.querySelector('[data-forest-clearing-tools]');
+  const clearingStatus = document.querySelector('[data-forest-clearing-status]');
+  const clearingEditor = { active: false, type: null, preview: null, movingId: null };
   const satchelButton = document.querySelector('[data-forest-satchel-button]');
   const satchel = document.querySelector('[data-forest-satchel]');
+  const objectDialog = document.querySelector('[data-forest-object-dialog]');
+  let selectedClearingObjectId = null;
+  let lastClearingAction = persistedOverlay.error
+    ? `overlay recovery: ${persistedOverlay.error}` : 'No clearing edit yet';
   const pickupFeedback = document.querySelector('[data-forest-pickup-feedback]');
   let pickupFeedbackTimer = null;
   let lastPickupResult = persistedDiscoveries.error
@@ -98,7 +122,10 @@ if (payload && viewportElement && canvas) {
     trail: document.querySelector('[data-forest-trail-diagnostic]'),
     discoveries: document.querySelector('[data-forest-discoveries]'),
     inventory: document.querySelector('[data-forest-inventory]'),
-    pickup: document.querySelector('[data-forest-last-pickup]')
+    pickup: document.querySelector('[data-forest-last-pickup]'),
+    clearing: document.querySelector('[data-forest-clearing-diagnostic]'),
+    commitment: document.querySelector('[data-forest-commitment-diagnostic]'),
+    clearingAction: document.querySelector('[data-forest-clearing-last-action]')
   };
   const loadedCellIds = new Set(scene.assetLoading.initialCellIds);
   const pendingCellIds = new Set();
@@ -135,12 +162,14 @@ if (payload && viewportElement && canvas) {
     const stoneCount = overlay.objects.filter(({ type }) => (
       type === FOREST_STEPPING_STONE_TYPE
     )).length;
-    const markerCount = overlay.objects.length - stoneCount;
+    const clearingCount = overlay.objects.filter(isForestClearingObject).length;
+    const markerCount = overlay.objects.length - stoneCount - clearingCount;
     diagnostics.overlay.textContent = `${markerCount} marker · ${stoneCount} stones · revision ${
-      overlay.revision} · ${status}${error ? ` (${error})` : ''}`;
+      overlay.revision} · ${clearingCount} clearing objects · ${status}${error ? ` (${error})` : ''}`;
   }
 
   function updateDiscoverySurfaces() {
+    const ledger = forestClearingMaterialLedger(discoveryState.inventory, placedObjects);
     const counts = Object.fromEntries(FOREST_DISCOVERY_MATERIALS.map(({ id }) => [
       id, discoveryOffering.filter(({ material }) => material === id).length
     ]));
@@ -149,21 +178,39 @@ if (payload && viewportElement && canvas) {
       FOREST_DISCOVERY_MATERIALS.map(({ id, shortLabel }) => `${shortLabel} ${counts[id]}`)
         .join(' · ')}`;
     diagnostics.inventory.textContent = FOREST_DISCOVERY_MATERIALS.map(({ id, shortLabel }) => (
-      `${shortLabel} ${discoveryState.inventory[id]}`
+      `${shortLabel} ${ledger.available[id]} available / ${discoveryState.inventory[id]} gathered`
     )).join(' · ');
     diagnostics.pickup.textContent = lastPickupResult;
     satchelButton.setAttribute('aria-label', `Satchel: ${FOREST_DISCOVERY_MATERIALS.map(
-      ({ id, shortLabel }) => `${discoveryState.inventory[id]} ${shortLabel.toLowerCase()}`
+      ({ id, shortLabel }) => `${ledger.available[id]} ${shortLabel.toLowerCase()} available`
     ).join(', ')}`);
     for (const { id } of FOREST_DISCOVERY_MATERIALS) {
       document.querySelector(`[data-forest-material-count="${id}"]`).textContent =
-        discoveryState.inventory[id];
+        `${ledger.available[id]} / ${discoveryState.inventory[id]}`;
     }
     const complete = availableDiscoveries.length === 0;
     const renewButton = document.querySelector('[data-forest-renew-discoveries]');
     renewButton.disabled = !complete;
     renewButton.textContent = complete ? 'Welcome another offering' : `${
       availableDiscoveries.length} discoveries remain`;
+    const clearing = placedObjects.filter(isForestClearingObject);
+    diagnostics.clearing.textContent = `${clearing.length} / 9 · ${FOREST_CLEARING_OBJECT_TYPES.map(
+      (type) => `${FOREST_CLEARING_OBJECT_DEFINITIONS[type].label} ${
+        clearing.filter((object) => object.type === type).length}`
+    ).join(' · ')} · ${clearingEditor.active ? `placing ${clearingEditor.type}` : 'placement off'}`;
+    diagnostics.commitment.textContent = `${FOREST_DISCOVERY_MATERIALS.map(({ id, shortLabel }) => (
+      `${shortLabel} ${ledger.committed[id]}`
+    )).join(' · ')}${ledger.valid ? '' : ` · ${ledger.reason}`}`;
+    diagnostics.clearingAction.textContent = lastClearingAction;
+    document.querySelectorAll('[data-forest-build]').forEach((button) => {
+      button.disabled = !canAffordForestClearingObject(
+        discoveryState.inventory, placedObjects, button.dataset.forestBuild
+      ) || !nextForestClearingObjectId(overlay, button.dataset.forestBuild);
+    });
+    const resetButton = document.querySelector('[data-forest-reset-discoveries]');
+    resetButton.disabled = clearing.length > 0;
+    resetButton.textContent = clearing.length
+      ? 'Remove clearing objects before resetting finds' : 'Reset satchel and finds';
   }
 
   function setDiscoveryObjects() {
@@ -516,6 +563,62 @@ if (payload && viewportElement && canvas) {
     context.fillRect(x - 5, y - 25, 10, 2);
   }
 
+  function paintClearingObject(object, preview = false, elapsedSeconds = 0) {
+    const x = Math.round(object.worldX - camera.x);
+    const y = Math.round(object.worldY - camera.y);
+    const valid = !preview || clearingEditor.preview?.valid;
+    if (preview || (focusedItem?.id === object.id)) {
+      context.beginPath();
+      context.ellipse(x, y, object.type === FOREST_STONE_BENCH_TYPE ? 25 : 18, 9,
+        0, 0, Math.PI * 2);
+      context.fillStyle = valid ? 'rgba(255, 239, 164, 0.38)' : 'rgba(173, 78, 62, 0.42)';
+      context.fill();
+      context.strokeStyle = valid ? '#fff0ae' : '#842f27';
+      context.lineWidth = 2;
+      context.stroke();
+      if (preview && !valid) {
+        context.beginPath();
+        context.moveTo(x - 6, y - 6);
+        context.lineTo(x + 6, y + 6);
+        context.moveTo(x + 6, y - 6);
+        context.lineTo(x - 6, y + 6);
+        context.stroke();
+      }
+    }
+    context.fillStyle = 'rgba(22, 35, 31, 0.25)';
+    context.fillRect(x - 12, y - 3, 24, 5);
+    if (object.type === FOREST_TRAIL_SIGN_TYPE) {
+      context.fillStyle = '#65462f';
+      context.fillRect(x - 2, y - 25, 4, 24);
+      context.fillStyle = '#d3ad63';
+      context.fillRect(x - 12, y - 29, 24, 9);
+      context.fillStyle = '#6d4b32';
+      context.fillRect(x - 8, y - 26, 16, 2);
+    } else if (object.type === FOREST_STONE_BENCH_TYPE) {
+      context.fillStyle = '#aaa58f';
+      context.fillRect(x - 19, y - 13, 38, 8);
+      context.fillStyle = '#716f68';
+      context.fillRect(x - 15, y - 5, 6, 7);
+      context.fillRect(x + 9, y - 5, 6, 7);
+      context.fillStyle = '#d5cfb8';
+      context.fillRect(x - 15, y - 11, 23, 2);
+    } else {
+      const glow = forestLanternGlowIntensity(object, elapsedSeconds,
+        ambientMotionActive && !preview);
+      context.fillStyle = `rgba(239, 197, 87, ${glow * 0.38})`;
+      context.beginPath();
+      context.arc(x, y - 24, 19 + Math.round(glow * 6), 0, Math.PI * 2);
+      context.fill();
+      context.fillStyle = '#5b4932';
+      context.fillRect(x - 2, y - 23, 4, 22);
+      context.fillStyle = '#e3b94f';
+      context.fillRect(x - 7, y - 34, 14, 13);
+      context.fillStyle = glow > 0.56 ? '#fff6bd' : '#ffe38a';
+      context.fillRect(x - 3, y - 31 - (glow > 0.62 ? 1 : 0), 6,
+        7 + (glow > 0.62 ? 1 : 0));
+    }
+  }
+
   function paintTrailJoins() {
     const byId = new Map(placedObjects.map((object) => [object.id, object]));
     context.lineWidth = 5;
@@ -584,7 +687,7 @@ if (payload && viewportElement && canvas) {
     focusedItem = focusedForestSceneItem(player, scene.placements.filter(
       ({ assetKey }) => assetsByKey.has(assetKey)
     ), placedObjects, scene.exploration.interactionRadius, availableDiscoveries);
-    prompt.hidden = !focusedItem || trailEditor.active;
+    prompt.hidden = !focusedItem || trailEditor.active || clearingEditor.active;
     const action = focusedItem?.kind === FOREST_DISCOVERY_TYPE
       ? `gather ${forestDiscoveryMaterial(focusedItem.value.material).label.toLowerCase()}`
       : focusedItem?.kind === 'marker' ? 'inspect marker' : 'inspect';
@@ -605,15 +708,22 @@ if (payload && viewportElement && canvas) {
       else if (item.kind === 'marker') paintMarker(item.object);
       else if (item.kind === FOREST_STEPPING_STONE_TYPE) paintSteppingStone(item.object);
       else if (item.kind === FOREST_DISCOVERY_TYPE) paintDiscovery(item.object);
+      else if (isForestClearingObject(item.object)) {
+        paintClearingObject(item.object, false, elapsedSeconds);
+      }
       else paintTree(item.placement, elapsedSeconds);
     }
     if (trailEditor.active && trailEditor.preview) {
       paintSteppingStone(trailEditor.preview.stone, true);
     }
+    if (clearingEditor.active && clearingEditor.preview) {
+      paintClearingObject(clearingEditor.preview.object, true, elapsedSeconds);
+    }
     const { visible, visibleObjects } = visibility;
     diagnostics.visible.textContent = `${visible.length} / ${scene.placements.length} trees · ${
       visibleObjects.filter(({ type }) => type === 'marker').length} markers · ${
       visibleObjects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length} stones · ${
+      visibleObjects.filter(isForestClearingObject).length} clearing objects · ${
       visibleObjects.filter(({ type }) => type === FOREST_DISCOVERY_TYPE).length} discoveries`;
     diagnostics.camera.textContent = `${camera.x}, ${camera.y}`;
     diagnostics.player.textContent = `${Math.round(player.worldX)}, ${Math.round(player.worldY)}`;
@@ -678,15 +788,16 @@ if (payload && viewportElement && canvas) {
     if (lastFrameTime === null) lastFrameTime = timestamp;
     const elapsed = Math.min(0.05, (timestamp - lastFrameTime) / 1000);
     lastFrameTime = timestamp;
-    const moving = hasMovement() && !dialog.open && satchel.hidden;
+    const moving = hasMovement() && !dialog.open && !objectDialog.open && satchel.hidden;
     if (moving) {
       Object.assign(player, moveForestPlayer(player, movementDirection(), elapsed,
-        scene.world, scene.placements));
+        scene.world, [...scene.placements, ...forestSolidClearingPlacements(placedObjects)]));
       followPlayer();
       updateFocus();
       if (trailEditor.active && trailEditor.tool !== 'remove') {
         previewTrailAt(player.worldX, player.worldY, false);
       }
+      if (clearingEditor.active) previewClearingAt(player.worldX, player.worldY, false);
     }
     render(timestamp / 1000, moving, frameGap);
     if (moving || ambientMotionActive) scheduledFrame = requestAnimationFrame(frame);
@@ -783,6 +894,8 @@ if (payload && viewportElement && canvas) {
 
   function openSatchel() {
     clearMovement();
+    if (clearingEditor.active) stopClearingPlacement(false);
+    if (trailEditor.active) toggleTrailEditor(false);
     satchel.hidden = false;
     satchelButton.setAttribute('aria-expanded', 'true');
     satchel.querySelector('[data-forest-satchel-close]').focus();
@@ -816,6 +929,10 @@ if (payload && viewportElement && canvas) {
   }
 
   function resetDiscoveries() {
+    if (placedObjects.some(isForestClearingObject)) {
+      reportPickup('Remove clearing objects before resetting gathered materials.', true);
+      return;
+    }
     try {
       discoveryState = discoveryPersistence.reset(scene.baseIdentity);
     } catch (error) {
@@ -831,6 +948,24 @@ if (payload && viewportElement && canvas) {
   function openInspection() {
     if (!focusedItem || dialog.open) return;
     clearMovement();
+    if (isForestClearingObject(focusedItem.value)) {
+      selectedClearingObjectId = focusedItem.id;
+      const object = focusedItem.value;
+      const definition = FOREST_CLEARING_OBJECT_DEFINITIONS[object.type];
+      objectDialog.querySelector('[data-forest-object-title]').textContent = definition.label;
+      objectDialog.querySelector('[data-forest-object-description]').textContent =
+        object.type === FOREST_TRAIL_SIGN_TYPE
+          ? (object.text || 'An unnamed sign points quietly through the clearing.')
+          : object.type === FOREST_STONE_BENCH_TYPE
+            ? 'A quiet place to sit or reflect.'
+            : 'A gentle seed-pod glow flickers like a small flame.';
+      const sign = object.type === FOREST_TRAIL_SIGN_TYPE;
+      objectDialog.querySelector('[data-forest-sign-editor]').hidden = true;
+      objectDialog.querySelector('[data-forest-object-edit]').hidden = !sign;
+      if (sign) objectDialog.querySelector('[data-forest-sign-text]').value = object.text;
+      objectDialog.showModal();
+      return;
+    }
     if (focusedItem.kind === 'marker') {
       dialog.querySelector('[data-forest-dialog-eyebrow]').textContent = 'A place made personal';
       dialog.querySelector('[data-forest-post-title]').textContent = 'Your clearing marker';
@@ -870,6 +1005,169 @@ if (payload && viewportElement && canvas) {
     updateFocus();
     requestRender();
     return true;
+  }
+
+  const clearingReasonText = {
+    'world-bounds': 'That object would cross the edge of the world.',
+    'tree-collision': 'That position overlaps a tree.',
+    'tree-interaction-space': 'Keep writing-tree interaction space clear.',
+    'entrance-collision': 'Keep the entrance and spawn clear.',
+    'protected-entrance': 'Keep the entrance and spawn clear.',
+    'player-collision': 'Place it a little farther from the player.',
+    'object-collision': 'That position overlaps another overlay object.',
+    'clearing-object-spacing': 'Leave enough room to see and use each clearing object.',
+    'discovery-collision': 'That position overlaps a discovery.',
+    'insufficient-materials': 'Those materials are not currently available.',
+    'clearing-object-limit': 'This experiment allows at most nine clearing objects.',
+    'clearing-object-type-limit': 'This experiment allows at most three of each object.',
+    'clearing-object-not-found': 'That clearing object is no longer present.'
+  };
+
+  function reportClearing(message, action = message, failed = false) {
+    clearingStatus.textContent = message;
+    lastClearingAction = action;
+    updateDiscoverySurfaces();
+    reportPickup(message, failed);
+  }
+
+  function previewClearingAt(worldX, worldY, shouldRender = true) {
+    if (!clearingEditor.active) return;
+    const existing = clearingEditor.movingId
+      ? placedObjects.find(({ id }) => id === clearingEditor.movingId) : null;
+    const id = existing?.id || nextForestClearingObjectId(overlay, clearingEditor.type);
+    if (!id) {
+      clearingEditor.preview = null;
+      reportClearing('This object type has reached its limit.', 'rejected: type limit', true);
+      return;
+    }
+    clearingEditor.preview = createForestClearingPlacementPreview(
+      clearingEditor.type, worldX, worldY, id, scene,
+      placedObjects.filter(({ id: objectId }) => objectId !== id), availableDiscoveries,
+      player, existing?.text || ''
+    );
+    const result = clearingEditor.preview;
+    clearingStatus.textContent = result.valid
+      ? 'Valid position. Click, tap, or press Enter to save.'
+      : (clearingReasonText[result.reason] || result.reason);
+    if (shouldRender) requestRender();
+  }
+
+  function stopClearingPlacement(returnFocus = true) {
+    clearingEditor.active = false;
+    clearingEditor.type = null;
+    clearingEditor.preview = null;
+    clearingEditor.movingId = null;
+    clearingTools.hidden = true;
+    updateDiscoverySurfaces();
+    updateFocus();
+    if (returnFocus) viewportElement.focus();
+    requestRender();
+  }
+
+  function beginClearingPlacement(type, movingId = null) {
+    if (!FOREST_CLEARING_OBJECT_TYPES.includes(type)) return;
+    if (trailEditor.active) toggleTrailEditor(false);
+    clearMovement();
+    clearingEditor.active = true;
+    clearingEditor.type = type;
+    clearingEditor.movingId = movingId;
+    clearingTools.hidden = false;
+    clearingTools.querySelector('[data-forest-clearing-mode]').textContent = movingId
+      ? `Moving ${FOREST_CLEARING_OBJECT_DEFINITIONS[type].label}`
+      : `Placing ${FOREST_CLEARING_OBJECT_DEFINITIONS[type].label}`;
+    previewClearingAt(player.worldX, player.worldY - 56, false);
+    updateDiscoverySurfaces();
+    updateFocus();
+    viewportElement.focus();
+    requestRender();
+  }
+
+  function saveClearingResult(result, action) {
+    if (!result.valid) {
+      reportClearing(clearingReasonText[result.reason] || result.reason,
+        `rejected: ${result.reason}`, true);
+      return false;
+    }
+    try {
+      overlayPersistence.save(result.overlay);
+    } catch (error) {
+      reportClearing(`Save failed; nothing changed: ${error.message}`,
+        'persistence failure', true);
+      return false;
+    }
+    setOverlay(result.overlay, `clearing object ${action}`);
+    reportClearing(`Clearing object ${action}.`, action);
+    stopClearingPlacement();
+    return true;
+  }
+
+  function commitClearingPlacement() {
+    if (!clearingEditor.preview?.valid) {
+      if (clearingEditor.preview) reportClearing(
+        clearingReasonText[clearingEditor.preview.reason] || clearingEditor.preview.reason,
+        `rejected: ${clearingEditor.preview.reason}`, true
+      );
+      return;
+    }
+    const result = overlayWithForestClearingObject(
+      overlay, clearingEditor.preview.object, scene, discoveryState.inventory,
+      availableDiscoveries, player
+    );
+    saveClearingResult(result, clearingEditor.movingId ? 'moved' : 'placed');
+  }
+
+  function saveSelectedSignText() {
+    const existing = placedObjects.find(({ id }) => id === selectedClearingObjectId);
+    if (!existing || existing.type !== FOREST_TRAIL_SIGN_TYPE) return;
+    const normalized = normalizeForestSignText(
+      objectDialog.querySelector('[data-forest-sign-text]').value
+    );
+    if (!normalized.valid) {
+      reportClearing(`Sign not saved: ${normalized.reason}.`, 'sign edit rejected', true);
+      return;
+    }
+    const candidate = createForestClearingObject(existing.type, existing.worldX,
+      existing.worldY, existing.id, normalized.text);
+    const result = overlayWithForestClearingObject(
+      overlay, candidate, scene, discoveryState.inventory, availableDiscoveries
+    );
+    if (saveClearingResult(result, 'sign edited')) objectDialog.close();
+  }
+
+  function setSelectedSignEditing(active) {
+    const existing = placedObjects.find(({ id }) => id === selectedClearingObjectId);
+    const editable = existing?.type === FOREST_TRAIL_SIGN_TYPE;
+    const editor = objectDialog.querySelector('[data-forest-sign-editor]');
+    const editButton = objectDialog.querySelector('[data-forest-object-edit]');
+    editor.hidden = !editable || !active;
+    editButton.hidden = !editable || active;
+    if (editable && active) {
+      const input = objectDialog.querySelector('[data-forest-sign-text]');
+      input.value = existing.text;
+      input.focus();
+    } else if (editable && objectDialog.open) {
+      editButton.focus();
+    }
+  }
+
+  function removeSelectedClearingObject() {
+    const result = overlayWithoutForestClearingObject(overlay, selectedClearingObjectId);
+    if (!result.valid) {
+      reportClearing(clearingReasonText[result.reason] || result.reason,
+        'removal rejected', true);
+      return;
+    }
+    try {
+      overlayPersistence.save(result.overlay);
+    } catch (error) {
+      reportClearing(`Removal not saved; object and materials are unchanged: ${error.message}`,
+        'persistence failure', true);
+      return;
+    }
+    setOverlay(result.overlay, 'clearing object removed and refunded');
+    reportClearing('Object removed. Its complete fixed cost is available again.',
+      'removed and fully refunded');
+    objectDialog.close();
   }
 
   const trailReasonText = {
@@ -934,6 +1232,9 @@ if (payload && viewportElement && canvas) {
   }
 
   function toggleTrailEditor(force) {
+    if (!trailEditor.active && force !== false && clearingEditor.active) {
+      stopClearingPlacement(false);
+    }
     trailEditor.active = typeof force === 'boolean' ? force : !trailEditor.active;
     trailEditor.preview = null;
     trailEditor.movingId = null;
@@ -1038,6 +1339,7 @@ if (payload && viewportElement && canvas) {
       return;
     }
     setOverlay(emptyOverlay, 'reset');
+    stopClearingPlacement(false);
     trailEditor.preview = null;
     trailEditor.movingId = null;
     if (trailEditor.active) setTrailTool('place');
@@ -1079,6 +1381,13 @@ if (payload && viewportElement && canvas) {
     } else if ((event.key === 't' || event.key === 'T')) {
       event.preventDefault();
       toggleTrailEditor();
+    } else if (clearingEditor.active && event.key === 'Escape') {
+      event.preventDefault();
+      reportClearing('Placement cancelled.', 'cancelled');
+      stopClearingPlacement();
+    } else if (clearingEditor.active && event.key === 'Enter') {
+      event.preventDefault();
+      commitClearingPlacement();
     } else if (trailEditor.active && (event.key === 'p' || event.key === 'P')) {
       event.preventDefault();
       setTrailTool('place');
@@ -1112,6 +1421,15 @@ if (payload && viewportElement && canvas) {
     }
   });
   viewportElement.addEventListener('pointerdown', (event) => {
+    if (clearingEditor.active && !event.target.closest('button') && !dialog.open
+      && !objectDialog.open && satchel.hidden) {
+      event.preventDefault();
+      const viewportRect = viewportElement.getBoundingClientRect();
+      previewClearingAt(camera.x + event.clientX - viewportRect.left,
+        camera.y + event.clientY - viewportRect.top, false);
+      commitClearingPlacement();
+      return;
+    }
     if (trailEditor.active && !event.target.closest('button') && !dialog.open && satchel.hidden) {
       event.preventDefault();
       const viewportRect = viewportElement.getBoundingClientRect();
@@ -1136,6 +1454,12 @@ if (payload && viewportElement && canvas) {
     viewportElement.focus();
   });
   viewportElement.addEventListener('pointermove', (event) => {
+    if (clearingEditor.active) {
+      const viewportRect = viewportElement.getBoundingClientRect();
+      previewClearingAt(camera.x + event.clientX - viewportRect.left,
+        camera.y + event.clientY - viewportRect.top);
+      return;
+    }
     if (trailEditor.active) {
       const viewportRect = viewportElement.getBoundingClientRect();
       previewTrailAt(camera.x + event.clientX - viewportRect.left,
@@ -1157,6 +1481,14 @@ if (payload && viewportElement && canvas) {
     viewportElement.focus();
     requestRender();
   });
+  objectDialog.addEventListener('close', () => {
+    clearMovement();
+    objectDialog.querySelector('[data-forest-sign-editor]').hidden = true;
+    objectDialog.querySelector('[data-forest-object-edit]').hidden = true;
+    selectedClearingObjectId = null;
+    viewportElement.focus();
+    requestRender();
+  });
   dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
   prompt.addEventListener('click', () => {
     if (!trailEditor.active) activateFocusedItem();
@@ -1174,6 +1506,13 @@ if (payload && viewportElement && canvas) {
       event.preventDefault();
       closeSatchel();
     }
+  });
+  satchel.querySelectorAll('[data-forest-build]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const type = button.dataset.forestBuild;
+      closeSatchel();
+      beginClearingPlacement(type);
+    });
   });
   document.querySelector('[data-forest-reset]').addEventListener('click', resetPlayer);
   trailToggle.addEventListener('click', () => toggleTrailEditor());
@@ -1194,6 +1533,34 @@ if (payload && viewportElement && canvas) {
   ));
   document.querySelector('[data-forest-place-marker]').addEventListener('click', placeMarker);
   document.querySelector('[data-forest-reset-overlay]').addEventListener('click', resetOverlay);
+  document.querySelector('[data-forest-clearing-commit]').addEventListener(
+    'click', commitClearingPlacement
+  );
+  document.querySelector('[data-forest-clearing-cancel]').addEventListener('click', () => {
+    reportClearing('Placement cancelled.', 'cancelled');
+    stopClearingPlacement();
+  });
+  objectDialog.querySelector('[data-forest-object-save]').addEventListener(
+    'click', saveSelectedSignText
+  );
+  objectDialog.querySelector('[data-forest-object-edit]').addEventListener(
+    'click', () => setSelectedSignEditing(true)
+  );
+  objectDialog.querySelector('[data-forest-object-edit-cancel]').addEventListener(
+    'click', () => setSelectedSignEditing(false)
+  );
+  objectDialog.querySelector('[data-forest-object-move]').addEventListener('click', () => {
+    const object = placedObjects.find(({ id }) => id === selectedClearingObjectId);
+    if (!object) return;
+    objectDialog.close();
+    beginClearingPlacement(object.type, object.id);
+  });
+  objectDialog.querySelector('[data-forest-object-remove]').addEventListener(
+    'click', removeSelectedClearingObject
+  );
+  objectDialog.querySelector('[data-forest-object-close]').addEventListener(
+    'click', () => objectDialog.close()
+  );
   window.addEventListener('resize', resize);
   resize();
   updateTrailControls();

--- a/public/js/forest-clearing-objects.js
+++ b/public/js/forest-clearing-objects.js
@@ -1,0 +1,196 @@
+import {
+  FOREST_PLACED_OBJECT_SCHEMA_VERSION,
+  FOREST_SEED_POD_LANTERN_TYPE,
+  FOREST_STONE_BENCH_TYPE,
+  FOREST_TRAIL_SIGN_TYPE,
+  FOREST_ENTRANCE_PROTECTION_RADIUS,
+  validateForestObjectPlacement,
+  validateForestOverlay
+} from './forest-world-overlay.js';
+
+export const FOREST_CLEARING_OBJECT_TYPES = Object.freeze([
+  FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE, FOREST_SEED_POD_LANTERN_TYPE
+]);
+export const FOREST_CLEARING_OBJECT_MAXIMUM = 9;
+export const FOREST_CLEARING_OBJECT_PER_TYPE_MAXIMUM = 3;
+export const FOREST_CLEARING_SIGN_MAX_CODE_POINTS = 60;
+export const FOREST_CLEARING_OBJECT_INTERACTION_RADIUS = 58;
+export const FOREST_CLEARING_OBJECT_MINIMUM_SPACING = 34;
+export const FOREST_CLEARING_TREE_CLEARANCE = 28;
+export const FOREST_CLEARING_PLAYER_CLEARANCE = 8;
+
+export const FOREST_CLEARING_OBJECT_DEFINITIONS = Object.freeze({
+  [FOREST_TRAIL_SIGN_TYPE]: Object.freeze({
+    type: FOREST_TRAIL_SIGN_TYPE, label: 'Trail sign', affordance: 'sign',
+    collisionRadius: 10, visualVersion: 1,
+    cost: Object.freeze({ 'fallen-twigs': 2, 'smooth-stones': 0, 'seed-pods': 0 })
+  }),
+  [FOREST_STONE_BENCH_TYPE]: Object.freeze({
+    type: FOREST_STONE_BENCH_TYPE, label: 'Stone bench', affordance: 'seat',
+    collisionRadius: 18, visualVersion: 1,
+    cost: Object.freeze({ 'fallen-twigs': 0, 'smooth-stones': 2, 'seed-pods': 0 })
+  }),
+  [FOREST_SEED_POD_LANTERN_TYPE]: Object.freeze({
+    type: FOREST_SEED_POD_LANTERN_TYPE, label: 'Seed-pod lantern', affordance: 'light',
+    collisionRadius: 9, visualVersion: 1,
+    cost: Object.freeze({ 'fallen-twigs': 1, 'smooth-stones': 0, 'seed-pods': 2 })
+  })
+});
+
+const MATERIAL_IDS = ['fallen-twigs', 'smooth-stones', 'seed-pods'];
+
+export function normalizeForestSignText(value) {
+  if (typeof value !== 'string') return { valid: false, reason: 'invalid-sign-text' };
+  const normalized = value.normalize('NFC').replace(/\r\n?/g, '\n');
+  if ([...normalized].some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint <= 9 || codePoint === 11 || codePoint === 12
+      || (codePoint >= 14 && codePoint <= 31) || (codePoint >= 127 && codePoint <= 159);
+  })) {
+    return { valid: false, reason: 'sign-control-character' };
+  }
+  const text = normalized.replace(/\n+/g, ' ')
+    .trim().replace(/[ \t]+/g, ' ');
+  if (!text) return { valid: true, text: '' };
+  if ([...text].length > FOREST_CLEARING_SIGN_MAX_CODE_POINTS) {
+    return { valid: false, reason: 'sign-text-too-long' };
+  }
+  return { valid: true, text };
+}
+
+export function createForestClearingObject(type, worldX, worldY, id, text = '') {
+  if (!FOREST_CLEARING_OBJECT_TYPES.includes(type)) throw new Error('Unknown clearing object type.');
+  const object = {
+    schemaVersion: FOREST_PLACED_OBJECT_SCHEMA_VERSION,
+    id, type, worldX: Math.round(worldX), worldY: Math.round(worldY)
+  };
+  if (type === FOREST_TRAIL_SIGN_TYPE) {
+    const normalized = normalizeForestSignText(text);
+    if (!normalized.valid) throw new Error(normalized.reason);
+    object.text = normalized.text;
+  }
+  return object;
+}
+
+export function isForestClearingObject(value) {
+  if (!value || !FOREST_CLEARING_OBJECT_TYPES.includes(value.type)) return false;
+  const definition = FOREST_CLEARING_OBJECT_DEFINITIONS[value.type];
+  if (value.schemaVersion !== FOREST_PLACED_OBJECT_SCHEMA_VERSION
+    || typeof value.id !== 'string'
+    || !new RegExp(`^forest-clearing-v1-${value.type}-[0-9]{2}$`).test(value.id)
+    || !Number.isSafeInteger(value.worldX) || !Number.isSafeInteger(value.worldY)) return false;
+  if (value.type === FOREST_TRAIL_SIGN_TYPE) {
+    const normalized = normalizeForestSignText(value.text);
+    return Object.keys(value).length === 6 && normalized.valid && normalized.text === value.text;
+  }
+  return Object.keys(value).length === 5 && Boolean(definition);
+}
+
+export function nextForestClearingObjectId(overlay, type) {
+  if (!FOREST_CLEARING_OBJECT_TYPES.includes(type)) return null;
+  const used = new Set(overlay.objects.map(({ id }) => id));
+  for (let ordinal = 1; ordinal <= FOREST_CLEARING_OBJECT_PER_TYPE_MAXIMUM; ordinal += 1) {
+    const id = `forest-clearing-v1-${type}-${String(ordinal).padStart(2, '0')}`;
+    if (!used.has(id)) return id;
+  }
+  return null;
+}
+
+export function forestClearingMaterialLedger(inventory, objects) {
+  const committed = Object.fromEntries(MATERIAL_IDS.map((id) => [id, 0]));
+  objects.filter(isForestClearingObject).forEach(({ type }) => {
+    MATERIAL_IDS.forEach((id) => { committed[id] += FOREST_CLEARING_OBJECT_DEFINITIONS[type].cost[id]; });
+  });
+  const available = Object.fromEntries(MATERIAL_IDS.map((id) => [id, inventory[id] - committed[id]]));
+  const valid = MATERIAL_IDS.every((id) => Number.isSafeInteger(inventory[id]) && available[id] >= 0);
+  return { committed, available, valid, reason: valid ? null : 'impossible-material-commitment' };
+}
+
+export function canAffordForestClearingObject(inventory, objects, type) {
+  const definition = FOREST_CLEARING_OBJECT_DEFINITIONS[type];
+  if (!definition) return false;
+  const ledger = forestClearingMaterialLedger(inventory, objects);
+  return ledger.valid && MATERIAL_IDS.every((id) => ledger.available[id] >= definition.cost[id]);
+}
+
+export function validateForestClearingObjectPlacement(object, scene, otherObjects = [],
+  discoveries = [], player = null) {
+  if (!isForestClearingObject(object)) return { valid: false, reason: 'invalid-clearing-object' };
+  const definition = FOREST_CLEARING_OBJECT_DEFINITIONS[object.type];
+  const basic = validateForestObjectPlacement(object, scene, otherObjects);
+  if (!basic.valid) return basic;
+  const spawn = scene.exploration?.spawn;
+  if (spawn && Math.hypot(object.worldX - spawn.worldX, object.worldY - spawn.worldY)
+    < FOREST_ENTRANCE_PROTECTION_RADIUS + definition.collisionRadius) {
+    return { valid: false, reason: 'protected-entrance' };
+  }
+  if (player && Math.hypot(object.worldX - player.worldX, object.worldY - player.worldY)
+    < definition.collisionRadius + player.radius + FOREST_CLEARING_PLAYER_CLEARANCE) {
+    return { valid: false, reason: 'player-collision' };
+  }
+  if (scene.placements.some((tree) => Math.hypot(
+    object.worldX - tree.worldX, object.worldY - tree.worldY
+  ) < definition.collisionRadius + tree.collisionRadius + FOREST_CLEARING_TREE_CLEARANCE)) {
+    return { valid: false, reason: 'tree-interaction-space' };
+  }
+  if (otherObjects.some((other) => other.id !== object.id && isForestClearingObject(other)
+    && Math.hypot(object.worldX - other.worldX, object.worldY - other.worldY)
+      < definition.collisionRadius
+        + FOREST_CLEARING_OBJECT_DEFINITIONS[other.type].collisionRadius
+        + FOREST_CLEARING_OBJECT_MINIMUM_SPACING)) {
+    return { valid: false, reason: 'clearing-object-spacing' };
+  }
+  if (discoveries.some((discovery) => Math.hypot(
+    object.worldX - discovery.worldX, object.worldY - discovery.worldY
+  ) < definition.collisionRadius + 28)) return { valid: false, reason: 'discovery-collision' };
+  return { valid: true, reason: null };
+}
+
+export function createForestClearingPlacementPreview(type, worldX, worldY, id, scene,
+  otherObjects = [], discoveries = [], player = null, text = '') {
+  const object = createForestClearingObject(type, worldX, worldY, id, text);
+  return { object, ...validateForestClearingObjectPlacement(
+    object, scene, otherObjects, discoveries, player
+  ) };
+}
+
+export function overlayWithForestClearingObject(overlay, object, scene, inventory,
+  discoveries = [], player = null) {
+  const validation = validateForestOverlay(overlay, overlay?.baseIdentity);
+  if (!validation.valid) throw new Error(`Invalid forest overlay: ${validation.reason}.`);
+  const existing = overlay.objects.find(({ id }) => id === object.id);
+  if (existing && !isForestClearingObject(existing)) {
+    return { overlay, valid: false, reason: 'object-type-conflict' };
+  }
+  const clearing = overlay.objects.filter(isForestClearingObject);
+  if (!existing && clearing.length >= FOREST_CLEARING_OBJECT_MAXIMUM) {
+    return { overlay, valid: false, reason: 'clearing-object-limit' };
+  }
+  if (!existing && clearing.filter(({ type }) => type === object.type).length
+    >= FOREST_CLEARING_OBJECT_PER_TYPE_MAXIMUM) {
+    return { overlay, valid: false, reason: 'clearing-object-type-limit' };
+  }
+  if (!existing && !canAffordForestClearingObject(inventory, overlay.objects, object.type)) {
+    return { overlay, valid: false, reason: 'insufficient-materials' };
+  }
+  if (existing && existing.type !== object.type) {
+    return { overlay, valid: false, reason: 'object-type-conflict' };
+  }
+  const otherObjects = overlay.objects.filter(({ id }) => id !== object.id);
+  const placement = validateForestClearingObjectPlacement(
+    object, scene, otherObjects, discoveries, player
+  );
+  if (!placement.valid) return { overlay, ...placement };
+  return { overlay: { ...overlay, revision: overlay.revision + 1,
+    objects: [...otherObjects, { ...object }].sort((a, b) => a.id.localeCompare(b.id)) },
+  valid: true, reason: null };
+}
+
+export function overlayWithoutForestClearingObject(overlay, objectId) {
+  const existing = overlay.objects.find(({ id }) => id === objectId);
+  if (!isForestClearingObject(existing)) {
+    return { overlay, valid: false, reason: 'clearing-object-not-found' };
+  }
+  return { overlay: { ...overlay, revision: overlay.revision + 1,
+    objects: overlay.objects.filter(({ id }) => id !== objectId) }, valid: true, reason: null };
+}

--- a/public/js/forest-discoveries.js
+++ b/public/js/forest-discoveries.js
@@ -1,6 +1,9 @@
 import {
   FOREST_MARKER_TYPE,
+  FOREST_SEED_POD_LANTERN_TYPE,
+  FOREST_STONE_BENCH_TYPE,
   FOREST_STEPPING_STONE_TYPE,
+  FOREST_TRAIL_SIGN_TYPE,
   isForestBaseIdentity,
   sameForestBaseIdentity
 } from './forest-world-overlay.js';
@@ -62,7 +65,9 @@ function corridorCenter(scene, worldY) {
 
 function overlayRadius(object) {
   return object.type === FOREST_STEPPING_STONE_TYPE ? 14
-    : object.type === FOREST_MARKER_TYPE ? 12 : 12;
+    : object.type === FOREST_STONE_BENCH_TYPE ? 20
+      : [FOREST_TRAIL_SIGN_TYPE, FOREST_SEED_POD_LANTERN_TYPE,
+        FOREST_MARKER_TYPE].includes(object.type) ? 12 : 12;
 }
 
 export function isForestDiscoveryMaterial(value) {

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -1,7 +1,14 @@
 import {
   FOREST_MARKER_INTERACTION_RADIUS,
+  FOREST_SEED_POD_LANTERN_TYPE,
+  FOREST_STONE_BENCH_TYPE,
+  FOREST_TRAIL_SIGN_TYPE,
   FOREST_STEPPING_STONE_TYPE
 } from './forest-world-overlay.js';
+import {
+  FOREST_CLEARING_OBJECT_DEFINITIONS,
+  FOREST_CLEARING_OBJECT_INTERACTION_RADIUS
+} from './forest-clearing-objects.js';
 import {
   FOREST_DISCOVERY_PICKUP_RADIUS,
   FOREST_DISCOVERY_TYPE
@@ -34,9 +41,11 @@ export function visibleForestPlacements(placements, assetsByKey, viewport, margi
 export function visibleForestObjects(objects, viewport, margin = 24) {
   return objects.filter((object) => {
     const horizontalRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 14
-      : object.type === FOREST_DISCOVERY_TYPE ? 10 : 12;
+      : object.type === FOREST_DISCOVERY_TYPE ? 10
+        : object.type === FOREST_STONE_BENCH_TYPE ? 24 : 16;
     const upperRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 7
-      : object.type === FOREST_DISCOVERY_TYPE ? 10 : 28;
+      : object.type === FOREST_DISCOVERY_TYPE ? 10
+        : object.type === FOREST_SEED_POD_LANTERN_TYPE ? 48 : 32;
     const lowerRadius = object.type === FOREST_STEPPING_STONE_TYPE ? 7
       : object.type === FOREST_DISCOVERY_TYPE ? 8 : 28;
     return (
@@ -102,6 +111,14 @@ export function forestFoliageMotionGroupDisplacement(
   return Math.round(
     FOREST_AMBIENT_WIND.maximumDisplacement * parameters.amplitude * response * signal
   );
+}
+
+export function forestLanternGlowIntensity(lantern, elapsedSeconds, active = true) {
+  if (!active) return 0.56;
+  const phase = (placementHash(lantern.id) / 4294967296) * Math.PI * 2;
+  const slowPulse = Math.sin((elapsedSeconds * 2.4) + phase) * 0.09;
+  const flameFlicker = Math.sin((elapsedSeconds * 7.1) + (phase * 1.7)) * 0.04;
+  return Math.max(0.4, Math.min(0.72, 0.56 + slowPulse + flameFlicker));
 }
 
 export function forestAmbientMotionActive({ documentHidden = false, reducedMotion = false } = {}) {
@@ -272,7 +289,9 @@ export function focusedForestSceneItem(
     ...objects.filter(({ type }) => type !== FOREST_STEPPING_STONE_TYPE).map((object) => ({
       kind: object.type || 'marker', id: object.id, value: object,
       distance: Math.hypot(player.worldX - object.worldX, player.worldY - object.worldY),
-      reach: FOREST_MARKER_INTERACTION_RADIUS
+      reach: [FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE,
+        FOREST_SEED_POD_LANTERN_TYPE].includes(object.type)
+        ? FOREST_CLEARING_OBJECT_INTERACTION_RADIUS : FOREST_MARKER_INTERACTION_RADIUS
     })),
     ...discoveries.map((discovery) => ({
       kind: FOREST_DISCOVERY_TYPE, id: discovery.id, value: discovery,
@@ -283,6 +302,12 @@ export function focusedForestSceneItem(
   return candidates.filter(({ distance, reach }) => distance <= reach)
     .sort((left, right) => left.distance - right.distance
       || left.kind.localeCompare(right.kind) || left.id.localeCompare(right.id))[0] || null;
+}
+
+export function forestSolidClearingPlacements(objects) {
+  return objects.filter(({ type }) => type === FOREST_STONE_BENCH_TYPE).map((object) => ({
+    ...object, collisionRadius: FOREST_CLEARING_OBJECT_DEFINITIONS[object.type].collisionRadius
+  }));
 }
 
 export function forestDepthOrder(placements, player, objects = []) {

--- a/public/js/forest-world-overlay.js
+++ b/public/js/forest-world-overlay.js
@@ -3,6 +3,9 @@ export const FOREST_PLACED_OBJECT_SCHEMA_VERSION = 1;
 export const FOREST_MARKER_ID = 'forest-marker-v1-personal-clearing';
 export const FOREST_MARKER_TYPE = 'marker';
 export const FOREST_STEPPING_STONE_TYPE = 'stepping-stone';
+export const FOREST_TRAIL_SIGN_TYPE = 'trail-sign';
+export const FOREST_STONE_BENCH_TYPE = 'stone-bench';
+export const FOREST_SEED_POD_LANTERN_TYPE = 'seed-pod-lantern';
 export const FOREST_MARKER_COLLISION_RADIUS = 9;
 export const FOREST_MARKER_INTERACTION_RADIUS = 54;
 export const FOREST_OVERLAY_MAX_OBJECTS = 32;
@@ -16,6 +19,7 @@ export const FOREST_TREE_TRAIL_CLEARANCE = 14;
 const OVERLAY_ID_PATTERN = /^forest-overlay-v1-[a-z0-9-]{1,48}$/;
 const MARKER_ID_PATTERN = /^forest-marker-v1-[a-z0-9-]{1,48}$/;
 const STONE_ID_PATTERN = /^forest-stone-v1-[a-z0-9-]{1,48}$/;
+const CLEARING_ID_PATTERN = /^forest-clearing-v1-(trail-sign|stone-bench|seed-pod-lantern)-[0-9]{2}$/;
 
 function exactKeys(value, keys) {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -43,12 +47,20 @@ export function sameForestBaseIdentity(left, right) {
 }
 
 export function isForestPlacedObject(value) {
-  return exactKeys(value, ['schemaVersion', 'id', 'type', 'worldX', 'worldY'])
+  const basicKeys = ['schemaVersion', 'id', 'type', 'worldX', 'worldY'];
+  const sign = value?.type === FOREST_TRAIL_SIGN_TYPE;
+  return exactKeys(value, sign ? [...basicKeys, 'text'] : basicKeys)
     && value.schemaVersion === FOREST_PLACED_OBJECT_SCHEMA_VERSION
     && typeof value.id === 'string'
     && ((value.type === FOREST_MARKER_TYPE && MARKER_ID_PATTERN.test(value.id))
-      || (value.type === FOREST_STEPPING_STONE_TYPE && STONE_ID_PATTERN.test(value.id)))
-    && validCoordinate(value.worldX) && validCoordinate(value.worldY);
+      || (value.type === FOREST_STEPPING_STONE_TYPE && STONE_ID_PATTERN.test(value.id))
+      || ([FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE,
+        FOREST_SEED_POD_LANTERN_TYPE].includes(value.type) && CLEARING_ID_PATTERN.test(value.id)
+        && value.id.startsWith(`forest-clearing-v1-${value.type}-`)))
+    && validCoordinate(value.worldX) && validCoordinate(value.worldY)
+    && (!sign || (typeof value.text === 'string' && value.text === value.text.normalize('NFC')
+      && value.text === value.text.trim() && !/[\n\r]/.test(value.text)
+      && !/\p{Cc}/u.test(value.text) && [...value.text].length <= 60));
 }
 
 export function createForestMarker(worldX, worldY, id = FOREST_MARKER_ID) {
@@ -122,6 +134,13 @@ export function validateForestOverlay(value, expectedBaseIdentity) {
   }
   if (value.objects.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE).length
     > FOREST_TRAIL_MAX_STONES) return { valid: false, reason: 'too-many-stones' };
+  const clearingObjects = value.objects.filter(({ type }) => [FOREST_TRAIL_SIGN_TYPE,
+    FOREST_STONE_BENCH_TYPE, FOREST_SEED_POD_LANTERN_TYPE].includes(type));
+  if (clearingObjects.length > 9) return { valid: false, reason: 'too-many-clearing-objects' };
+  if ([FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE,
+    FOREST_SEED_POD_LANTERN_TYPE].some((type) => (
+    clearingObjects.filter((object) => object.type === type).length > 3
+  ))) return { valid: false, reason: 'too-many-clearing-objects-of-type' };
   return { valid: true, reason: null };
 }
 
@@ -140,8 +159,11 @@ export function overlayWithForestMarker(overlay, marker) {
 
 
 function objectRadius(object) {
-  return object.type === FOREST_STEPPING_STONE_TYPE
-    ? FOREST_STONE_COLLISION_RADIUS : FOREST_MARKER_COLLISION_RADIUS;
+  if (object.type === FOREST_STEPPING_STONE_TYPE) return FOREST_STONE_COLLISION_RADIUS;
+  if (object.type === FOREST_STONE_BENCH_TYPE) return 18;
+  if (object.type === FOREST_TRAIL_SIGN_TYPE) return 10;
+  if (object.type === FOREST_SEED_POD_LANTERN_TYPE) return 9;
+  return FOREST_MARKER_COLLISION_RADIUS;
 }
 
 function stoneTrailConnected(stones) {
@@ -274,6 +296,26 @@ export function applyForestOverlay(scene, overlay) {
       ? validateForestTrailPlacement(object, scene, otherObjects)
       : validateForestObjectPlacement(object, scene, otherObjects);
     if (!placement.valid) return { objects: [], error: placement.reason };
+    if ([FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE,
+      FOREST_SEED_POD_LANTERN_TYPE].includes(object.type)) {
+      const radius = objectRadius(object);
+      const spawn = scene.exploration?.spawn;
+      if (spawn && Math.hypot(object.worldX - spawn.worldX, object.worldY - spawn.worldY)
+        < FOREST_ENTRANCE_PROTECTION_RADIUS + radius) {
+        return { objects: [], error: 'protected-entrance' };
+      }
+      if (scene.placements.some((tree) => Math.hypot(
+        object.worldX - tree.worldX, object.worldY - tree.worldY
+      ) < radius + tree.collisionRadius + 28)) {
+        return { objects: [], error: 'tree-interaction-space' };
+      }
+      if (otherObjects.some((other) => [FOREST_TRAIL_SIGN_TYPE, FOREST_STONE_BENCH_TYPE,
+        FOREST_SEED_POD_LANTERN_TYPE].includes(other.type) && Math.hypot(
+        object.worldX - other.worldX, object.worldY - other.worldY
+      ) < radius + objectRadius(other) + 34)) {
+        return { objects: [], error: 'clearing-object-spacing' };
+      }
+    }
   }
   if (!stoneTrailConnected(ordered.filter(({ type }) => type === FOREST_STEPPING_STONE_TYPE))) {
     return { objects: [], error: 'trail-disconnected' };

--- a/spec/forestClearingObjectSpec.js
+++ b/spec/forestClearingObjectSpec.js
@@ -1,0 +1,207 @@
+import {
+  canAffordForestClearingObject,
+  createForestClearingObject,
+  createForestClearingPlacementPreview,
+  FOREST_CLEARING_OBJECT_DEFINITIONS,
+  FOREST_CLEARING_OBJECT_MAXIMUM,
+  FOREST_CLEARING_OBJECT_PER_TYPE_MAXIMUM,
+  FOREST_CLEARING_OBJECT_TYPES,
+  forestClearingMaterialLedger,
+  isForestClearingObject,
+  nextForestClearingObjectId,
+  normalizeForestSignText,
+  overlayWithForestClearingObject,
+  overlayWithoutForestClearingObject,
+  validateForestClearingObjectPlacement
+} from '../public/js/forest-clearing-objects.js';
+import {
+  createEmptyForestOverlay,
+  FOREST_SEED_POD_LANTERN_TYPE,
+  FOREST_STONE_BENCH_TYPE,
+  FOREST_TRAIL_SIGN_TYPE,
+  validateForestOverlay
+} from '../public/js/forest-world-overlay.js';
+import { createForestDevOverlayPersistence } from '../public/js/forest-overlay-persistence.js';
+import {
+  focusedForestSceneItem,
+  forestDepthOrder,
+  forestLanternGlowIntensity,
+  forestSolidClearingPlacements,
+  moveForestPlayer,
+  visibleForestObjects
+} from '../public/js/forest-scene-math.js';
+import { createForestExploration } from '../server/services/forestSceneExploration.js';
+import { generateForestSceneLayout } from '../server/services/forestSceneLayout.js';
+
+const fullInventory = { 'fallen-twigs': 3, 'smooth-stones': 3, 'seed-pods': 3 };
+
+function openScene() {
+  const scene = createForestExploration(generateForestSceneLayout({
+    seed: 'clearing-contract', world: { width: 700, height: 700 }, placementCount: 0
+  }));
+  return { ...scene, exploration: { ...scene.exploration,
+    spawn: { ...scene.exploration.spawn, worldX: 50, worldY: 650 } } };
+}
+
+function memoryStorage(fail = false) {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      if (fail) throw new Error('write unavailable');
+      values.set(key, value);
+    },
+    removeItem: (key) => values.delete(key)
+  };
+}
+
+function place(overlay, scene, type, x, y, inventory = fullInventory, text = '') {
+  const id = nextForestClearingObjectId(overlay, type);
+  return overlayWithForestClearingObject(overlay,
+    createForestClearingObject(type, x, y, id, text), scene, inventory);
+}
+
+describe('Activity Forest clearing objects', () => {
+  it('defines exactly three versioned affordances with fixed costs', () => {
+    expect(FOREST_CLEARING_OBJECT_TYPES).toEqual([
+      'trail-sign', 'stone-bench', 'seed-pod-lantern'
+    ]);
+    expect(FOREST_CLEARING_OBJECT_DEFINITIONS[FOREST_TRAIL_SIGN_TYPE].cost).toEqual({
+      'fallen-twigs': 2, 'smooth-stones': 0, 'seed-pods': 0
+    });
+    expect(FOREST_CLEARING_OBJECT_DEFINITIONS[FOREST_STONE_BENCH_TYPE].cost).toEqual({
+      'fallen-twigs': 0, 'smooth-stones': 2, 'seed-pods': 0
+    });
+    expect(FOREST_CLEARING_OBJECT_DEFINITIONS[FOREST_SEED_POD_LANTERN_TYPE].cost).toEqual({
+      'fallen-twigs': 1, 'smooth-stones': 0, 'seed-pods': 2
+    });
+    expect(Object.isFrozen(FOREST_CLEARING_OBJECT_DEFINITIONS)).toBeTrue();
+  });
+
+  it('uses discriminated exact schemas and normalized bounded sign text', () => {
+    const sign = createForestClearingObject(FOREST_TRAIL_SIGN_TYPE, 100.4, 120.7,
+      'forest-clearing-v1-trail-sign-01', '  Cafe\u0301\npath  ');
+    const bench = createForestClearingObject(FOREST_STONE_BENCH_TYPE, 200, 220,
+      'forest-clearing-v1-stone-bench-01');
+    expect(sign.text).toBe('Café path');
+    expect(Object.keys(sign).sort()).toEqual([
+      'id', 'schemaVersion', 'text', 'type', 'worldX', 'worldY'
+    ]);
+    expect(Object.keys(bench).sort()).toEqual([
+      'id', 'schemaVersion', 'type', 'worldX', 'worldY'
+    ]);
+    expect(isForestClearingObject(sign)).toBeTrue();
+    expect(isForestClearingObject({ ...bench, text: 'not allowed' })).toBeFalse();
+    expect(normalizeForestSignText('bad\u0000text').reason).toBe('sign-control-character');
+    expect(normalizeForestSignText('🌲'.repeat(61)).reason).toBe('sign-text-too-long');
+    expect(JSON.parse(JSON.stringify(sign))).toEqual(sign);
+  });
+
+  it('derives exact available and committed materials from valid objects', () => {
+    const scene = openScene();
+    let overlay = createEmptyForestOverlay(scene.baseIdentity);
+    overlay = place(overlay, scene, FOREST_TRAIL_SIGN_TYPE, 180, 180).overlay;
+    overlay = place(overlay, scene, FOREST_STONE_BENCH_TYPE, 280, 280).overlay;
+    overlay = place(overlay, scene, FOREST_SEED_POD_LANTERN_TYPE, 380, 380).overlay;
+    expect(forestClearingMaterialLedger(fullInventory, overlay.objects)).toEqual({
+      committed: { 'fallen-twigs': 3, 'smooth-stones': 2, 'seed-pods': 2 },
+      available: { 'fallen-twigs': 0, 'smooth-stones': 1, 'seed-pods': 1 },
+      valid: true, reason: null
+    });
+    expect(canAffordForestClearingObject(fullInventory, overlay.objects,
+      FOREST_TRAIL_SIGN_TYPE)).toBeFalse();
+    expect(forestClearingMaterialLedger({ ...fullInventory, 'fallen-twigs': 2 },
+      overlay.objects).reason).toBe('impossible-material-commitment');
+  });
+
+  it('places once, preserves identity and cost on move/edit, and refunds once on removal', () => {
+    const scene = openScene();
+    const empty = createEmptyForestOverlay(scene.baseIdentity);
+    const placed = place(empty, scene, FOREST_TRAIL_SIGN_TYPE, 180, 180,
+      fullInventory, 'North path');
+    expect(placed.valid).toBeTrue();
+    const moved = overlayWithForestClearingObject(placed.overlay,
+      createForestClearingObject(FOREST_TRAIL_SIGN_TYPE, 280, 220,
+        placed.overlay.objects[0].id, 'A quieter path'), scene, fullInventory);
+    expect(moved.valid).toBeTrue();
+    expect(moved.overlay.objects[0].id).toBe(placed.overlay.objects[0].id);
+    expect(forestClearingMaterialLedger(fullInventory, moved.overlay.objects).committed)
+      .toEqual(forestClearingMaterialLedger(fullInventory, placed.overlay.objects).committed);
+    const removed = overlayWithoutForestClearingObject(moved.overlay, moved.overlay.objects[0].id);
+    expect(removed.valid).toBeTrue();
+    expect(forestClearingMaterialLedger(fullInventory, removed.overlay.objects).available)
+      .toEqual(fullInventory);
+    expect(overlayWithoutForestClearingObject(removed.overlay,
+      moved.overlay.objects[0].id).reason).toBe('clearing-object-not-found');
+  });
+
+  it('rejects unaffordable, colliding, bounded, duplicate, and unknown placements', () => {
+    const scene = openScene();
+    const empty = createEmptyForestOverlay(scene.baseIdentity);
+    expect(place(empty, scene, FOREST_TRAIL_SIGN_TYPE, 180, 180,
+      { ...fullInventory, 'fallen-twigs': 1 }).reason).toBe('insufficient-materials');
+    const preview = createForestClearingPlacementPreview(FOREST_STONE_BENCH_TYPE,
+      scene.exploration.spawn.worldX, scene.exploration.spawn.worldY,
+      'forest-clearing-v1-stone-bench-01', scene, [], [], scene.exploration.spawn);
+    expect(preview.valid).toBeFalse();
+    expect(['entrance-collision', 'protected-entrance', 'player-collision'])
+      .toContain(preview.reason);
+    expect(() => createForestClearingObject('house', 1, 1, 'bad')).toThrow();
+
+    let overlay = empty;
+    for (let index = 0; index < FOREST_CLEARING_OBJECT_PER_TYPE_MAXIMUM; index += 1) {
+      overlay = place(overlay, scene, FOREST_STONE_BENCH_TYPE,
+        140 + index * 100, 160, { ...fullInventory, 'smooth-stones': 20 }).overlay;
+    }
+    expect(place(overlay, scene, FOREST_STONE_BENCH_TYPE, 500, 160,
+      { ...fullInventory, 'smooth-stones': 20 }).reason).toBe('clearing-object-type-limit');
+    expect(FOREST_CLEARING_OBJECT_MAXIMUM).toBe(9);
+  });
+
+  it('persists the complete candidate before live state changes on success or failure', () => {
+    const scene = openScene();
+    const live = createEmptyForestOverlay(scene.baseIdentity);
+    const candidate = place(live, scene, FOREST_TRAIL_SIGN_TYPE, 180, 180).overlay;
+    const failing = createForestDevOverlayPersistence(memoryStorage(true));
+    expect(() => failing.save(candidate)).toThrowError(/write unavailable/);
+    expect(live.objects).toEqual([]);
+    expect(forestClearingMaterialLedger(fullInventory, live.objects).available).toEqual(fullInventory);
+    const persistence = createForestDevOverlayPersistence(memoryStorage());
+    const saved = persistence.save(candidate);
+    expect(saved).toEqual(candidate);
+    expect(validateForestOverlay(saved, scene.baseIdentity).valid).toBeTrue();
+  });
+
+  it('participates in deterministic focus, culling, depth order, and solid collision', () => {
+    const sign = createForestClearingObject(FOREST_TRAIL_SIGN_TYPE, 100, 100,
+      'forest-clearing-v1-trail-sign-01', 'Here');
+    const bench = createForestClearingObject(FOREST_STONE_BENCH_TYPE, 100, 130,
+      'forest-clearing-v1-stone-bench-01');
+    const player = { worldX: 100, worldY: 100, radius: 8, movementSpeed: 100 };
+    expect(visibleForestObjects([sign, bench], { x: 0, y: 0, width: 200, height: 200 }))
+      .toEqual([sign, bench]);
+    expect(focusedForestSceneItem(player, [], [bench, sign], 40).id).toBe(sign.id);
+    expect(forestDepthOrder([], player, [bench, sign]).map(({ id }) => id)).toEqual([
+      sign.id, '~player', bench.id
+    ]);
+    const moved = moveForestPlayer({ ...player, worldX: 60 }, { x: 1, y: 0 }, 0.4,
+      { width: 500, height: 500 }, forestSolidClearingPlacements([
+        { ...bench, worldY: 100 }
+      ]));
+    expect(moved.worldX).toBe(60);
+    expect(validateForestClearingObjectPlacement(sign, openScene(), [], [], player).reason)
+      .toBe('player-collision');
+  });
+
+  it('gives lanterns a deterministic bounded flicker and a static reduced-motion treatment', () => {
+    const lantern = createForestClearingObject(FOREST_SEED_POD_LANTERN_TYPE, 100, 100,
+      'forest-clearing-v1-seed-pod-lantern-01');
+    const samples = [0, 0.2, 0.8, 1.4].map((time) => (
+      forestLanternGlowIntensity(lantern, time)
+    ));
+    expect(new Set(samples).size).toBeGreaterThan(1);
+    expect(samples.every((value) => value >= 0.4 && value <= 0.72)).toBeTrue();
+    expect(forestLanternGlowIntensity(lantern, 0, false)).toBe(0.56);
+    expect(forestLanternGlowIntensity(lantern, 50, false)).toBe(0.56);
+  });
+});

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -50,6 +50,7 @@ block content
     p#activity-forest-help.activity-forest__help
       | Move with arrow keys or WASD, or touch and drag in the forest. Inspect nearby trees or your marker.
       | Gather nearby fallen twigs, smooth stones, and seed pods with the same interaction prompt.
+      | Open the Satchel to place a trail sign, stone bench, or seed-pod lantern.
       | “Place marker here” saves one development-only personal overlay independently of the grove.
       | Press T or choose “Edit trail” to place, move, or reversibly remove up to 12 stepping stones.
 
@@ -61,6 +62,13 @@ block content
         button(type='button' data-forest-trail-move aria-pressed='false') Move nearest
         button(type='button' data-forest-trail-remove aria-pressed='false') Remove
         button(type='button' data-forest-trail-done) Done
+
+    .activity-forest__trail-tools(data-forest-clearing-tools hidden aria-label='Clearing object placement controls')
+      strong(data-forest-clearing-mode) Placing clearing object
+      span(data-forest-clearing-status role='status' aria-live='polite') Choose clear ground.
+      .activity-forest__trail-actions
+        button(type='button' data-forest-clearing-commit) Place here
+        button(type='button' data-forest-clearing-cancel) Cancel
 
     .activity-forest__viewport(
       tabindex='0'
@@ -117,6 +125,17 @@ block content
         p.activity-forest__satchel-note
           | These small finds are renewable. Once an offering is complete, the forest can offer another
           | without taking anything from your satchel.
+        h3.activity-forest__satchel-subheading Make for the clearing
+        .activity-forest__build-list
+          button(type='button' data-forest-build='trail-sign')
+            strong Trail sign
+            span 2 twigs · up to 60 characters
+          button(type='button' data-forest-build='stone-bench')
+            strong Stone bench
+            span 2 stones
+          button(type='button' data-forest-build='seed-pod-lantern')
+            strong Seed-pod lantern
+            span 1 twig · 2 seed pods
         .activity-forest__satchel-actions
           button(type='button' data-forest-renew-discoveries disabled) 9 discoveries remain
           button(type='button' data-forest-reset-discoveries) Reset satchel and finds
@@ -157,6 +176,15 @@ block content
       div
         dt Satchel inventory
         dd(data-forest-inventory) —
+      div
+        dt Clearing objects
+        dd(data-forest-clearing-diagnostic) —
+      div
+        dt Material commitment
+        dd(data-forest-commitment-diagnostic) —
+      div
+        dt Last clearing edit
+        dd(data-forest-clearing-last-action) —
       div
         dt Last pickup
         dd(data-forest-last-pickup) —
@@ -236,5 +264,24 @@ block content
         time(data-forest-post-date)
       p.activity-forest__dialog-excerpt(data-forest-post-excerpt)
       button(type='button' data-forest-dialog-close) Return to the forest
+
+    dialog.activity-forest__dialog(data-forest-object-dialog aria-labelledby='forest-object-title')
+      p.activity-forest__dialog-eyebrow A clearing object
+      h2#forest-object-title(data-forest-object-title)
+      p.activity-forest__dialog-excerpt(data-forest-object-description)
+      .activity-forest__object-editor(data-forest-sign-editor hidden)
+        label.activity-forest__object-text-label
+          span Sign name or note
+          input(type='text' maxlength='120' data-forest-sign-text aria-describedby='forest-sign-help')
+        p#forest-sign-help.activity-forest__dialog-context
+          | Up to 60 Unicode characters. Line breaks become spaces.
+        .activity-forest__object-editor-actions
+          button(type='button' data-forest-object-save) Save message
+          button(type='button' data-forest-object-edit-cancel) Cancel editing
+      .activity-forest__object-actions
+        button(type='button' data-forest-object-edit hidden) Edit message
+        button(type='button' data-forest-object-move) Move
+        button(type='button' data-forest-object-remove) Remove and refund
+        button(type='button' data-forest-object-close) Return to the forest
 
     script#activity-forest-scene(type='application/json')!= JSON.stringify(scene).replace(/</g, '\\u003c')


### PR DESCRIPTION
## Summary

Implement the Milestone 4 Activity Forest vertical slice, allowing gathered materials to support visible, persistent, and reversible clearing customization.

## What changed

- Add three fixed clearing-object types:
  - Trail sign: 2 fallen twigs
  - Stone bench: 2 smooth stones
  - Seed-pod lantern: 1 fallen twig and 2 seed pods
- Add exact, versioned object schemas and stable identities.
- Limit personal overlays to nine clearing objects and three of each type.
- Derive committed and available materials from fixed object costs.
- Support placement previews, validation, cancellation, movement, and removal.
- Refund an object's complete material cost when it is removed.
- Preserve identity and cost when objects are moved or signs are edited.
- Add normalized, bounded player-authored messages to trail signs.
- Present sign messages read-only before entering an explicit editing mode.
- Add fixed inspection descriptions for benches and lanterns.
- Add a deterministic flame-like lantern pulse with a static reduced-motion treatment.
- Integrate objects into culling, focus selection, depth ordering, player collision, diagnostics, and discovery placement.
- Extend the in-frame Satchel with construction choices and affordability states.
- Isolate Forest controls from legacy global button, label, input, and hidden-state styles.
- Document persistence, reset, compatibility, accessibility, and Milestone 5 boundaries.

## Persistence and material accounting

Collected inventory remains independently persisted as the total amount gathered.

Material commitment is derived from valid clearing objects and their code-defined costs. Placement and removal therefore require only one atomic overlay save, avoiding a failure window between separate inventory and overlay writes.

Persistence failures leave both live objects and available materials unchanged.

## Accessibility

- Keyboard, pointer, and touch placement
- Explicit placement and cancellation
- Non-color invalid-preview indicator
- Read-only sign inspection with a separate edit action
- Predictable dialog and viewport focus return
- Polite success, rejection, refund, and failure feedback
- At least 44-pixel primary controls
- Static lantern treatment under reduced motion

## Compatibility

Existing marker, stepping-stone, discovery, inventory, tree, and asset identities remain unchanged. Existing Milestones 1–3 personal state continues to load through the current versioned adapters.

## Verification

- 609 specs passing
- ESLint passing
- Activity Forest Pug template compiles
- `git diff --check` passing

## Non-goals

This does not add generalized construction, crafting recipes, terrain editing, production persistence, writing resurfacing, time-of-day lighting, shops, durability, multiplayer, or an entity-component system.