### PR TITLE
Fix post translation picker positioning and header overlap

### DIFF
--- a/public/css/block-lang-switcher.css
+++ b/public/css/block-lang-switcher.css
@@ -2,7 +2,8 @@
 .block-lang-switcher {
   position: relative;
   display: inline-block;
-  z-index: var(--z-popover);
+  /* Keep post controls below the sticky site header's stacking context. */
+  z-index: 1;
 }
 
 .block-lang-summary {
@@ -62,7 +63,7 @@
   border: 1px solid var(--border-color);
   box-shadow: 0 10px 30px rgba(0,0,0,0.18);
   border-radius: 12px;
-  z-index: calc(var(--z-popover) + 1);
+  z-index: 1;
 }
 
 .block-lang-menu {
@@ -137,12 +138,9 @@ html[data-theme="dark"] .block-lang-option.is-active:hover {
 
 @media (max-width: 600px) {
   .block-lang-menu {
-    position: fixed;
-    inset-inline: 12px;
-    top: auto;
-    bottom: 12px;
     box-sizing: border-box;
-    min-width: 0;
+    min-width: min(200px, calc(100vw - 24px));
+    max-width: calc(100vw - 24px);
     max-height: min(60vh, 360px);
   }
 }

--- a/spec/languageSwitcherLayeringSpec.js
+++ b/spec/languageSwitcherLayeringSpec.js
@@ -1,0 +1,29 @@
+import fs from 'node:fs';
+
+const blockStyles = fs.readFileSync('public/css/block-lang-switcher.css', 'utf8');
+const uiStyles = fs.readFileSync('public/css/ui-lang-switcher.css', 'utf8');
+const autoCloseScript = fs.readFileSync('public/js/details-autoclose.js', 'utf8');
+
+describe('post and site language picker layering', () => {
+  it('keeps the post translation menu anchored below its summary on small screens', () => {
+    const baseMenu = blockStyles.match(/\.block-lang-menu \{[\s\S]*?\n\}/)?.[0] || '';
+    const mobileStyles = blockStyles.slice(blockStyles.indexOf('@media (max-width: 600px)'));
+
+    expect(baseMenu).toContain('position: absolute');
+    expect(baseMenu).toContain('top: calc(100% + 0.45rem)');
+    expect(mobileStyles).not.toContain('position: fixed');
+    expect(mobileStyles).not.toContain('bottom:');
+    expect(mobileStyles).toContain('max-width: calc(100vw - 24px)');
+  });
+
+  it('keeps the sticky header above the post picker and closes sibling pickers', () => {
+    const blockRoot = blockStyles.match(/\.block-lang-switcher \{[\s\S]*?\n\}/)?.[0] || '';
+
+    expect(uiStyles).toContain('.ui-lang-switcher {');
+    expect(uiStyles).toContain('z-index: var(--z-popover)');
+    expect(blockRoot).toContain('z-index: 1');
+    expect(blockRoot).not.toContain('var(--z-popover)');
+    expect(autoCloseScript).toContain('details.ui-lang-switcher, details.block-lang-switcher');
+    expect(autoCloseScript).toContain('if (d !== except) d.removeAttribute(\'open\')');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two UI issues affecting the post translation picker:

- Keeps the translation menu directly below its trigger on narrow screens instead of displaying it at the bottom of the viewport.
- Prevents the post translation picker from appearing above the site-wide language menu.

## Implementation

- Removed the mobile `position: fixed` bottom-sheet behavior from the post translation menu.
- Added viewport-aware width and height constraints for smaller screens.
- Moved the post translation picker into a local stacking layer beneath the sticky site header.
- Preserved the existing behavior that closes other open pickers when a language picker is opened.
- Added regression tests covering picker positioning, layering, and mutual-close behavior.

## Testing

- `npm run lint`
- `npm test`
- 627 specs passing