### PR TITLE
Fix homepage trending tags sidebar positioning and shading

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -958,7 +958,7 @@ html[data-theme="dark"] .home-support-widget__fill {
   display: grid;
   gap: 1rem;
   position: sticky;
-  top: 1rem;
+  top: calc(var(--site-header-height, 0px) + 1rem);
 }
 
 .home-discovery__panel {
@@ -977,14 +977,26 @@ html[data-theme="dark"] .home-support-widget__fill {
   padding: 1rem;
   border: 1px solid #dce5eb;
   border-radius: 16px;
-  background: var(--surface-bg);
   box-shadow: 0 8px 22px rgba(20, 40, 60, 0.05);
+}
+
+.home-discovery__panel--tags {
+  background: var(--primary-bg);
+}
+
+.home-discovery__panel--quests {
+  background: var(--surface-bg);
 }
 
 .home-discovery .trending-tags-widget {
   margin: 0;
   padding: 0;
   border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+html[data-theme='dark'] .home-discovery .trending-tags-widget {
   background: transparent;
   box-shadow: none;
 }
@@ -1086,11 +1098,16 @@ html[data-theme="dark"] .home-support-widget__fill {
 }
 
 html[data-theme='dark'] .homepage-header .stat-item,
-html[data-theme='dark'] .home-discovery__panel--tags,
 html[data-theme='dark'] .home-discovery__panel--quests {
   color: var(--text-color);
   border-color: var(--border-color);
   background: var(--surface-bg);
+}
+
+html[data-theme='dark'] .home-discovery__panel--tags {
+  color: var(--text-color);
+  border-color: var(--border-color);
+  background: var(--primary-bg);
 }
 
 html[data-theme='dark'] .home-discovery__panel > h2,

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -60,10 +60,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     if (window.innerWidth < 980) {
       siteHeader.classList.remove('site-header--nav-inline');
-      return;
+    } else {
+      siteHeader.classList.toggle('site-header--nav-inline', measureInlineHeaderFit());
     }
 
-    siteHeader.classList.toggle('site-header--nav-inline', measureInlineHeaderFit());
+    const headerHeight = Math.ceil(siteHeader.getBoundingClientRect().height);
+    document.documentElement.style.setProperty('--site-header-height', `${headerHeight}px`);
   };
 
   const scheduleHeaderLayoutUpdate = () => {
@@ -87,6 +89,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     [
+      siteHeader,
       headerRow,
       brandLink,
       mainMenu,
@@ -94,6 +97,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       navbarRight
     ].filter(Boolean).forEach((element) => headerResizeObserver.observe(element));
   }
+
+  scheduleHeaderLayoutUpdate();
 
   document.fonts?.ready
     ?.then(() => {

--- a/spec/homeDiscoveryLayoutSpec.js
+++ b/spec/homeDiscoveryLayoutSpec.js
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+
+const homeStyles = fs.readFileSync('public/css/home.css', 'utf8');
+const authScript = fs.readFileSync('public/js/auth.js', 'utf8');
+
+describe('home discovery layout', () => {
+  it('keeps the desktop sidebar below the measured sticky header', () => {
+    const sidebarRule = homeStyles.match(/\.home-discovery__sidebar \{[\s\S]*?\n\}/)?.[0] || '';
+
+    expect(sidebarRule).toContain('position: sticky');
+    expect(sidebarRule).toContain('top: calc(var(--site-header-height, 0px) + 1rem)');
+    expect(authScript).toContain("style.setProperty('--site-header-height'");
+    expect(authScript).toContain('siteHeader.getBoundingClientRect().height');
+  });
+
+  it('uses the page background behind the trending tag pills', () => {
+    const tagsPanelRule = homeStyles.match(/\.home-discovery__panel--tags \{[\s\S]*?\n\}/)?.[0] || '';
+    const darkWidgetRule = homeStyles.match(/html\[data-theme='dark'\] \.home-discovery \.trending-tags-widget \{[\s\S]*?\n\}/)?.[0] || '';
+
+    expect(tagsPanelRule).toContain('background: var(--primary-bg)');
+    expect(darkWidgetRule).toContain('background: transparent');
+    expect(darkWidgetRule).toContain('box-shadow: none');
+  });
+});


### PR DESCRIPTION
## Summary

- Offset the sticky homepage sidebar by the dynamically measured site header height
- Keep the offset accurate across responsive and changing header layouts
- Remove the mismatched background behind the trending tag pills in dark mode
- Add regression coverage for the sidebar offset and tag-area background

## Testing

- `npx jasmine`
- 629 specs passing