### PR TITLE
Add wind-shaped highland conifer and expand shared phenotype architecture

### DIFF
--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -198,6 +198,55 @@ The recommended near-term technical sequence is:
 3. Begin deterministic forest composition and basic exploration.
 4. Add shared ambient motion once a representative multi-tree scene exists.
 
+### Milestone 6A: wind-shaped highland conifer
+
+The third registered phenotype is `wind-shaped-highland-conifer`, asset version 1. It is a tall,
+narrow evergreen organized around a sturdy, persistent central leader. Twelve scaffold boughs,
+near-horizontal lower branch angles, restrained droop, a very low split-trunk probability, sparse
+foliage, and a cool deep-green palette give it a weathered highland character. A small deterministic
+growth bias produces mild prevailing-wind asymmetry. Seed variation changes lean, taper, branch
+occupancy, crown width, needle count, and palette without turning the family into identical cones.
+
+Most of this character uses existing phenotype data: canvas and crown proportions, branch-start
+height, trunk top and base, apical dominance, branch count and angle, fork and vigor controls,
+foliage counts and radii, coverage repair, root flare, and palettes. Two bounded shared additions
+were needed:
+
+- `attractionDensityByHeight` accepts 2–16 values between zero and one. It varies attraction-point
+  acceptance by crown height, creating reusable tiering and negative-space control without encoding
+  a conifer renderer.
+- `foliageStyle` accepts only `broadleaf` or `needle-spray`. Both styles use the same shoots, depth
+  split, shading, color runs, raster transport, and three motion groups; only the bounded pixel
+  footprint changes. The two established phenotypes explicitly declare `broadleaf`.
+
+The optional directional-growth vector is also bounded to ±0.2 per axis and feeds the shared growth
+blend. Invalid density, bias, or foliage-style values fail generation instead of becoming unbounded
+inputs. No runtime phenotype switch or asset-contract field was added.
+
+These shared capabilities changed the renderer vocabulary, so renderer v3's cache version advanced
+from 3 to 4. The runtime tree-asset schema remains version 2. The conifer starts at phenotype asset
+version 1; the two established phenotype versions remain 2. Their broadleaf pixels and layer runs
+for explicit prior inputs are unchanged, but the renderer-version component deliberately gives
+every new asset a fresh cache key rather than silently reusing version-3 entries. The default scene keeps
+its established 68/32 deciduous/lanternwood selection and generated-base configuration; the conifer
+is not selected there yet.
+
+Forest Lab derives its 24 fixtures from the immutable canonical registry and shows eight seeds per
+phenotype in final, leafless, and graph views. The leafless conifers expose the long leader, tiered
+bough origins, taper, and rare split state without relying on green pixels. A separate
+`botanical-range` pressure profile keeps representative density at 180 placements, balances all
+three phenotypes, and caps the shared pool at 24 assets. It uses the normal regional loading,
+collision, inspection, culling, motion, color-run, and lossless-raster paths.
+
+This first slice deliberately defers a fourth fanciful phenotype until the conifer receives visual
+review. The experiment shows that a strongly different woody structure fits the common generator;
+the main remaining question for a fourth phenotype is whether its foliage can fit the two-style
+vocabulary or justifies one similarly small, botanical shared extension. Current limitations are
+that tier bands remain probabilistic rather than explicit whorls, wind shaping is mild and global,
+and representative seeds still need review at ordinary scene scale for occasional overly full
+upper crowns. Seeds 2 and 3 in the initial zero-through-seven review are the fullest current cases
+and are useful visual-tuning fixtures rather than generation failures.
+
 ### Generation results and runtime tree assets
 
 The procedural generation result is an authoring and diagnostic object. It retains the mutable inputs and derived architecture, three-dimensional branch graph, attraction points, termination diagnostics, foliage shoots and leaves, logical masks, shaded pixel grids, and compact color runs. Forest Lab needs this complete result to explain why a specimen has its shape, but a game-facing renderer does not.
@@ -231,7 +280,7 @@ Forest Lab owns a narrow process-local in-memory cache of complete generation re
 
 - `server/services/forestTreeGeneratorV3.js`: experimental v3 orchestration.
 - `server/services/forest/v3/architecture.js`: deterministic per-tree architectural traits.
-- `server/services/forest/v3/phenotype.js`: registered deciduous and lanternwood phenotypes and
+- `server/services/forest/v3/phenotype.js`: registered deciduous, lanternwood, and conifer phenotypes and
   their distinct growth, architecture, foliage, and palette tendencies.
 - `server/services/forest/v3/growth.js`: deterministic three-dimensional branch growth.
 - `server/services/forest/v3/rasterizeWood.js`: tapered wood, root flare, and bark rendering.
@@ -260,7 +309,7 @@ key. Layout randomness is derived independently for X, Y, phenotype, specimen, a
 the scene seed and candidate index. Rejection sampling enforces trunk spacing and reserves a
 winding central corridor; camera position is never an input to layout or tree identity.
 
-The representative scene uses a bounded pool of eight specimens for each registered phenotype;
+The representative scene uses a bounded pool of eight specimens for each active default phenotype;
 pressure profiles can deliberately select broader pools. Its process-local cache is separate from
 Forest Lab's diagnostic cache and retains runtime assets only. The asset's schema, renderer,
 phenotype, and seed identities form the invalidation key. The browser receives the complete compact

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -30,8 +30,7 @@ import {
   forestScenePlacementCellId
 } from '../../public/js/forest-scene-math.js';
 import {
-  DECIDUOUS_PHENOTYPE,
-  LANTERNWOOD_PHENOTYPE
+  FOREST_PHENOTYPES
 } from '../services/forest/v3/phenotype.js';
 
 const router = express.Router();
@@ -67,7 +66,7 @@ const forestFixtureRooms = [
   'united-states', 'daily-inspiration', 'physics', 'history', 'united-states', 'mathematics'
 ];
 
-function forestFixtures() {
+export function forestFixtures() {
   return forestFixtureTitles.map((title, index) => {
     const post = {
       id: `forest-lab-post-${index + 1}`,
@@ -82,7 +81,7 @@ function forestFixtures() {
       questApproved: index % 4 === 0,
       excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.'
     };
-    const phenotype = index % 2 === 0 ? DECIDUOUS_PHENOTYPE : LANTERNWOOD_PHENOTYPE;
+    const phenotype = FOREST_PHENOTYPES[index % FOREST_PHENOTYPES.length];
     const { generation: tree, asset } = getForestLabTree(post, { phenotype });
     return {
       ...post,

--- a/server/services/forest/v3/growth.js
+++ b/server/services/forest/v3/growth.js
@@ -58,6 +58,18 @@ function insideCrown(position, phenotype, overscan = 1) {
 }
 
 export function generateAttractionPoints(seed, phenotype) {
+  if (phenotype.attractionDensityByHeight && (
+    !Array.isArray(phenotype.attractionDensityByHeight)
+    || phenotype.attractionDensityByHeight.length < 2
+    || phenotype.attractionDensityByHeight.length > 16
+    || phenotype.attractionDensityByHeight.some(value => value < 0 || value > 1)
+  )) throw new Error('Crown height-density profiles require 2–16 values between zero and one.');
+  if (phenotype.directionalGrowthBias && ['x', 'y', 'z'].some(axis => (
+    !Number.isFinite(phenotype.directionalGrowthBias[axis])
+    || Math.abs(phenotype.directionalGrowthBias[axis]) > 0.2
+  ))) {
+    throw new Error('Directional growth bias components must be between -0.2 and 0.2.');
+  }
   const random = createRandom(seed ^ 0xA77AC710);
   const points = [];
   let attempts = 0;
@@ -71,8 +83,16 @@ export function generateAttractionPoints(seed, phenotype) {
     };
     const normalizedHeight = (phenotype.crown.centerY + phenotype.crown.radiusY - position.y)
       / (phenotype.crown.radiusY * 2);
+    const densityProfile = phenotype.attractionDensityByHeight;
+    const density = densityProfile?.length
+      ? densityProfile[Math.min(
+        densityProfile.length - 1,
+        Math.floor(normalizedHeight * densityProfile.length)
+      )]
+      : 1;
     if (insideCrown(position, phenotype)
-      && random() >= phenotype.attractionGap * (0.45 + normalizedHeight)) {
+      && random() >= phenotype.attractionGap * (0.45 + normalizedHeight)
+      && (!densityProfile || random() < density)) {
       const projected = projectPosition(position, phenotype);
       points.push({
         id: points.length,
@@ -290,6 +310,11 @@ function blendedDirection(node, points, phenotype) {
   y /= Math.max(1, points.length);
   z /= Math.max(1, points.length);
   y -= phenotype.apicalDominance + phenotype.phototropism;
+  if (phenotype.directionalGrowthBias) {
+    x += phenotype.directionalGrowthBias.x;
+    y += phenotype.directionalGrowthBias.y;
+    z += phenotype.directionalGrowthBias.z;
+  }
   return constrainDirection(node, normalize({ x, y, z }), phenotype);
 }
 

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -2,6 +2,8 @@ export const DECIDUOUS_PHENOTYPE_ID = 'open-crown-deciduous';
 export const DECIDUOUS_PHENOTYPE_ASSET_VERSION = 2;
 export const LANTERNWOOD_PHENOTYPE_ID = 'sunset-lanternwood';
 export const LANTERNWOOD_PHENOTYPE_ASSET_VERSION = 2;
+export const HIGHLAND_CONIFER_PHENOTYPE_ID = 'wind-shaped-highland-conifer';
+export const HIGHLAND_CONIFER_PHENOTYPE_ASSET_VERSION = 1;
 
 export const DECIDUOUS_PHENOTYPE = Object.freeze({
   id: DECIDUOUS_PHENOTYPE_ID,
@@ -58,6 +60,7 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
   vigorDecay: 0.965,
   terminalRadius: 0.55,
   pipeExponent: 2.15,
+  foliageStyle: 'broadleaf',
   foliageMinimumOrder: 2,
   foliageTerminalCoverage: 1,
   foliageCoverageColumns: 6,
@@ -159,6 +162,7 @@ export const LANTERNWOOD_PHENOTYPE = Object.freeze({
   vigorDecay: 0.97,
   terminalRadius: 0.58,
   pipeExponent: 2.1,
+  foliageStyle: 'broadleaf',
   foliageMinimumOrder: 2,
   foliageTerminalCoverage: 1,
   foliageCoverageColumns: 7,
@@ -214,7 +218,125 @@ export const LANTERNWOOD_PHENOTYPE = Object.freeze({
   rootFlareStrength: 5.2
 });
 
-export const FOREST_PHENOTYPES = Object.freeze([DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE]);
+export const HIGHLAND_CONIFER_PHENOTYPE = Object.freeze({
+  id: HIGHLAND_CONIFER_PHENOTYPE_ID,
+  assetVersion: HIGHLAND_CONIFER_PHENOTYPE_ASSET_VERSION,
+  name: 'wind-shaped highland conifer',
+  width: 82,
+  height: 142,
+  groundY: 134,
+  crown: Object.freeze({ centerX: 41, centerY: 68, radiusX: 29, radiusY: 61, radiusZ: 24 }),
+  cameraYaw: 0.26,
+  perspectiveStrength: 0.055,
+  growthEnvelopeOverscan: 1.03,
+  attractionPointCount: 168,
+  attractionGap: 0.18,
+  attractionDensityByHeight: Object.freeze([0.72, 0.96, 0.42, 0.9, 0.5, 0.82, 0.62]),
+  directionalGrowthBias: Object.freeze({ x: 0.075, y: 0, z: -0.018 }),
+  architecture: Object.freeze({
+    branchStartHeight: Object.freeze([18, 27]),
+    trunkBaseRadius: Object.freeze([4.2, 5.2]),
+    trunkTaper: Object.freeze([0.78, 1.12]),
+    trunkLeanAngle: Object.freeze([0.035, 0.09]),
+    trunkLeanAzimuth: Object.freeze([-0.35, 0.55]),
+    splitTrunkProbability: 0.035,
+    splitTrunkHeight: Object.freeze([52, 64]),
+    splitTrunkAngle: Object.freeze([0.16, 0.24]),
+    splitTrunkAzimuth: Object.freeze([0, Math.PI * 2]),
+    leaderBalance: Object.freeze([0.9, 1])
+  }),
+  trunkTopY: 13,
+  primaryBranchCount: 12,
+  primaryBranchAngle: 1.48,
+  internodeLength: 3.25,
+  influenceRadius: 20,
+  killRadius: 3.8,
+  maxIterations: 78,
+  maxNodes: 430,
+  maxGeneration: 4,
+  apicalDominance: 0.38,
+  parentDirectionWeight: 0.5,
+  maximumTurnAngle: 0.24,
+  maximumAxisDeviation: 0.7,
+  lowerBranchFloorY: 92,
+  lowerBranchTransitionHeight: 30,
+  lowerBranchMaximumDroop: 0.34,
+  phototropism: 0.2,
+  forkProbability: 0.13,
+  minimumForkPoints: 8,
+  forkSeparation: 0.3,
+  minimumVigor: 0.085,
+  vigorDecay: 0.955,
+  terminalRadius: 0.5,
+  pipeExponent: 2.2,
+  foliageStyle: 'needle-spray',
+  foliageMinimumOrder: 1,
+  foliageTerminalCoverage: 1,
+  foliageCoverageColumns: 5,
+  foliageCoverageRows: 9,
+  foliageCoverageSamples: 3,
+  foliageMinimumCellCoverage: 0.18,
+  foliageMaximumTopUpCells: 5,
+  foliageTopUpSupportsPerCell: 2,
+  foliageSupplementalLeafCount: Object.freeze([5, 8]),
+  foliageSupportRadius: 13,
+  foliageMinimumLeafSpacing: 0.7,
+  terminalLeafCount: Object.freeze([7, 11]),
+  highOrderLeafCount: Object.freeze([4, 7]),
+  secondaryLeafCount: Object.freeze([2, 4]),
+  secondaryShootProbability: 0.56,
+  leafRadiusX: Object.freeze([0.7, 1.15]),
+  leafRadiusY: Object.freeze([2.1, 3.7]),
+  leafShootSpread: Object.freeze([3.2, 6.4]),
+  foliagePalettes: Object.freeze([
+    Object.freeze({
+      id: 'highland-evergreen', weight: 82,
+      colors: Object.freeze({
+        highlight: '#8faf75', light: '#668f68', mid: '#416f59',
+        dark: '#2d554c', deep: '#213f3d'
+      })
+    }),
+    Object.freeze({
+      id: 'blue-ridge', weight: 13,
+      colors: Object.freeze({
+        highlight: '#91aaa0', light: '#668b82', mid: '#456c69',
+        dark: '#345459', deep: '#293f49'
+      })
+    }),
+    Object.freeze({
+      id: 'lichen-tips', weight: 5,
+      colors: Object.freeze({
+        highlight: '#b0ba7b', light: '#798f68', mid: '#526f58',
+        dark: '#38554c', deep: '#293f3d'
+      })
+    })
+  ]),
+  woodPalette: Object.freeze({
+    light: '#b49268', mid: '#826348', dark: '#594737', deep: '#3c342e'
+  }),
+  rootFlareHeight: 14,
+  rootFlareStrength: 5.8
+});
+
+export const FOREST_PHENOTYPES = Object.freeze([
+  DECIDUOUS_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE,
+  HIGHLAND_CONIFER_PHENOTYPE
+]);
+
+const FOREST_PHENOTYPES_BY_ID = new Map(FOREST_PHENOTYPES.map(phenotype => [
+  phenotype.id, phenotype
+]));
+
+export const FOREST_PHENOTYPE_SCENE_TRAITS = Object.freeze({
+  [DECIDUOUS_PHENOTYPE_ID]: Object.freeze({ defaultWeight: 68, collisionRadius: 11 }),
+  [LANTERNWOOD_PHENOTYPE_ID]: Object.freeze({ defaultWeight: 32, collisionRadius: 13 }),
+  [HIGHLAND_CONIFER_PHENOTYPE_ID]: Object.freeze({ defaultWeight: 0, collisionRadius: 12 })
+});
+
+export function resolveForestPhenotype(phenotypeId) {
+  return FOREST_PHENOTYPES_BY_ID.get(phenotypeId) || null;
+}
 
 export function isRegisteredForestPhenotype(phenotype) {
   return FOREST_PHENOTYPES.includes(phenotype);

--- a/server/services/forest/v3/rasterizeFoliage.js
+++ b/server/services/forest/v3/rasterizeFoliage.js
@@ -3,6 +3,7 @@ import { createRandom } from './random.js';
 const EMPTY = null;
 
 export const FOREST_FOLIAGE_MOTION_GROUP_COUNT = 3;
+export const FOREST_FOLIAGE_STYLES = Object.freeze(['broadleaf', 'needle-spray']);
 
 export const FOLIAGE_PALETTE = Object.freeze({
   highlight: '#9fbe59',
@@ -165,6 +166,7 @@ export function generateLeafBearingShoots(graph, phenotype, seed) {
         tone: random(),
         massLight: 0
       };
+      leaf.style = phenotype.foliageStyle;
       const crownX = (leaf.x - phenotype.crown.centerX) / phenotype.crown.radiusX;
       const crownY = (leaf.y - phenotype.crown.centerY) / phenotype.crown.radiusY;
       leaf.massLight = clampLight(
@@ -234,8 +236,11 @@ function leafContainsPoint(leaf, x, y) {
   const dy = y - leaf.y;
   const localX = (dx * cosine) + (dy * sine);
   const localY = (-dx * sine) + (dy * cosine);
-  return Math.abs(localX / leaf.radiusX) ** 1.55
-    + Math.abs(localY / leaf.radiusY) ** 1.18 <= 1;
+  const style = leaf.style || 'broadleaf';
+  const xPower = style === 'needle-spray' ? 1.2 : 1.55;
+  const yPower = style === 'needle-spray' ? 1.65 : 1.18;
+  return Math.abs(localX / leaf.radiusX) ** xPower
+    + Math.abs(localY / leaf.radiusY) ** yPower <= 1;
 }
 
 function measureCoverageCells(leaves, supports, phenotype) {
@@ -292,7 +297,9 @@ function paintLeaf(mask, owner, leaf, phenotype) {
       const localY = (-dx * sine) + (dy * cosine);
       const normalizedX = localX / leaf.radiusX;
       const normalizedY = localY / leaf.radiusY;
-      const almond = Math.abs(normalizedX) ** 1.55 + Math.abs(normalizedY) ** 1.18;
+      const needleSpray = phenotype.foliageStyle === 'needle-spray';
+      const almond = Math.abs(normalizedX) ** (needleSpray ? 1.2 : 1.55)
+        + Math.abs(normalizedY) ** (needleSpray ? 1.65 : 1.18);
       if (almond > 1) continue;
       mask[y][x] = true;
       owner[y][x] = { leaf, localX, localY, normalizedX, normalizedY };
@@ -419,6 +426,9 @@ function rasterizeLayer(leaves, layer, phenotype, palette, motionGroups) {
 }
 
 export function rasterizeFoliage(graph, phenotype, seed) {
+  if (!FOREST_FOLIAGE_STYLES.includes(phenotype.foliageStyle)) {
+    throw new Error(`Unsupported forest foliage style: ${phenotype.foliageStyle}`);
+  }
   const paletteVariant = selectFoliagePalette(phenotype, seed);
   const palette = paletteVariant.colors;
   const { shoots, leaves, coverageCells } = generateLeafBearingShoots(graph, phenotype, seed);

--- a/server/services/forestSceneAssetPool.js
+++ b/server/services/forestSceneAssetPool.js
@@ -2,16 +2,11 @@ import { performance } from 'node:perf_hooks';
 
 import { generateForestTreeAssetV3 } from './forestTreeGeneratorV3.js';
 import {
-  DECIDUOUS_PHENOTYPE,
-  LANTERNWOOD_PHENOTYPE
+  resolveForestPhenotype
 } from './forest/v3/phenotype.js';
 
 // Scene-owned, process-local runtime assets. No graphs or diagnostics are retained.
 const sceneAssetCache = new Map();
-const phenotypesById = new Map([
-  [DECIDUOUS_PHENOTYPE.id, DECIDUOUS_PHENOTYPE],
-  [LANTERNWOOD_PHENOTYPE.id, LANTERNWOOD_PHENOTYPE]
-]);
 
 export function clearForestSceneAssetPool() {
   sceneAssetCache.clear();
@@ -31,7 +26,7 @@ export function prepareForestSceneAssets(placements) {
   for (const [assetKey, placement] of required) {
     if (!sceneAssetCache.has(assetKey)) {
       const generationStartedAt = performance.now();
-      const phenotype = phenotypesById.get(placement.phenotypeId);
+      const phenotype = resolveForestPhenotype(placement.phenotypeId);
       if (!phenotype) throw new Error(`Unknown forest phenotype: ${placement.phenotypeId}`);
       const asset = generateForestTreeAssetV3(
         { id: `forest-scene-specimen-${placement.treeSeed}` },

--- a/server/services/forestSceneExploration.js
+++ b/server/services/forestSceneExploration.js
@@ -1,5 +1,6 @@
 import { forestCorridorCenter } from './forestSceneLayout.js';
 import { hashSeed } from './forest/v3/random.js';
+import { FOREST_PHENOTYPE_SCENE_TRAITS } from './forest/v3/phenotype.js';
 
 export const FOREST_PLAYER_RADIUS = 10;
 export const FOREST_PLAYER_SPEED = 150;
@@ -23,8 +24,9 @@ const FIXTURES = Object.freeze([
 })));
 
 export function forestPlacementCollisionRadius(placement) {
-  const phenotypeRadius = placement.phenotypeId === 'sunset-lanternwood' ? 13 : 11;
-  return phenotypeRadius * placement.scale;
+  const traits = FOREST_PHENOTYPE_SCENE_TRAITS[placement.phenotypeId];
+  if (!traits) throw new Error(`Unknown forest phenotype: ${placement.phenotypeId}`);
+  return traits.collisionRadius * placement.scale;
 }
 
 export function createForestExploration(scene) {

--- a/server/services/forestSceneLayout.js
+++ b/server/services/forestSceneLayout.js
@@ -1,7 +1,7 @@
 import { FOREST_RENDERER_VERSION_V3 } from './forestTreeGeneratorV3.js';
 import {
-  DECIDUOUS_PHENOTYPE,
-  LANTERNWOOD_PHENOTYPE
+  FOREST_PHENOTYPES,
+  FOREST_PHENOTYPE_SCENE_TRAITS
 } from './forest/v3/phenotype.js';
 import { createRandom, hashSeed } from './forest/v3/random.js';
 import { treeAssetCacheKey } from './forest/v3/treeAsset.js';
@@ -19,12 +19,11 @@ export const DEFAULT_FOREST_SCENE_CONFIG = Object.freeze({
   scale: Object.freeze({ minimum: 1, maximum: 2 }),
   specimenPoolSize: 8,
   phenotypeWeights: Object.freeze({
-    [DECIDUOUS_PHENOTYPE.id]: 68,
-    [LANTERNWOOD_PHENOTYPE.id]: 32
+    ...Object.fromEntries(FOREST_PHENOTYPES.map(phenotype => [
+      phenotype.id, FOREST_PHENOTYPE_SCENE_TRAITS[phenotype.id].defaultWeight
+    ]).filter(([, weight]) => weight > 0))
   })
 });
-
-const PHENOTYPES = [DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE];
 
 function decisionRandom(sceneSeed, candidateIndex, decision) {
   return createRandom(hashSeed([
@@ -57,14 +56,14 @@ export function forestBaseIdentity(config) {
 }
 
 function selectPhenotype(config, sceneSeed, candidateIndex) {
-  const total = PHENOTYPES.reduce((sum, phenotype) => (
+  const total = FOREST_PHENOTYPES.reduce((sum, phenotype) => (
     sum + (config.phenotypeWeights[phenotype.id] || 0)
   ), 0);
   let selection = decisionRandom(sceneSeed, candidateIndex, 'phenotype') * total;
-  return PHENOTYPES.find((phenotype) => {
+  return FOREST_PHENOTYPES.find((phenotype) => {
     selection -= config.phenotypeWeights[phenotype.id] || 0;
     return selection < 0;
-  }) || PHENOTYPES[0];
+  }) || FOREST_PHENOTYPES[0];
 }
 
 function specimenIdentity(config, sceneSeed, phenotype, specimenIndex) {

--- a/server/services/forestScenePressure.js
+++ b/server/services/forestScenePressure.js
@@ -13,6 +13,21 @@ export const FOREST_PRESSURE_PROFILES = Object.freeze([
     layout: Object.freeze({})
   }),
   Object.freeze({
+    id: 'botanical-range',
+    label: 'Botanical range',
+    description: '180 placements balancing all registered phenotypes across 24 shared assets.',
+    pressure: true,
+    layout: Object.freeze({
+      seed: 'pressure-botanical-range',
+      assetPoolSize: 24,
+      phenotypeWeights: Object.freeze({
+        'open-crown-deciduous': 1,
+        'sunset-lanternwood': 0.8,
+        'wind-shaped-highland-conifer': 1.4
+      })
+    })
+  }),
+  Object.freeze({
     id: 'asset-variety',
     label: 'Asset variety',
     description: '180 placements sharing 60 assets.',

--- a/server/services/forestTreeGeneratorV3.js
+++ b/server/services/forestTreeGeneratorV3.js
@@ -6,7 +6,8 @@ import { rasterizeFoliage } from './forest/v3/rasterizeFoliage.js';
 import { rasterizeWood } from './forest/v3/rasterizeWood.js';
 import { buildForestTreeAsset } from './forest/v3/treeAsset.js';
 
-export const FOREST_RENDERER_VERSION_V3 = 3;
+// Version 4 adds bounded height-density and foliage-shape vocabulary. Asset schema remains v2.
+export const FOREST_RENDERER_VERSION_V3 = 4;
 
 export function generateForestTreeGraph(post, options = {}) {
   if (!post?.id) throw new Error('V3 forest trees require a post id.');

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -121,14 +121,30 @@ describe('static Activity Forest scene', () => {
 
   it('defines explicit development pressure profiles without changing the default layout', () => {
     const representative = resolveForestPressureProfile('representative');
+    const botanical = resolveForestPressureProfile('botanical-range');
     const variety = resolveForestPressureProfile('asset-variety');
     const unique = resolveForestPressureProfile('unique-assets');
     const large = resolveForestPressureProfile('large-world');
 
-    expect(FOREST_PRESSURE_PROFILES.length).toBe(4);
+    expect(FOREST_PRESSURE_PROFILES.length).toBe(5);
     expect(representative.pressure).toBeFalse();
     expect(representative.layout).toEqual({});
     expect(resolveForestPressureProfile('unknown')).toBe(representative);
+    const botanicalScene = generateForestSceneLayout(botanical.layout);
+    expect(botanicalScene.placements.length).toBe(180);
+    expect(new Set(botanicalScene.placements.map(({ phenotypeId }) => phenotypeId))).toEqual(
+      new Set([
+        'open-crown-deciduous',
+        'sunset-lanternwood',
+        'wind-shaped-highland-conifer'
+      ])
+    );
+    expect(new Set(botanicalScene.placements.map(({ assetKey }) => assetKey)).size)
+      .toBeLessThanOrEqual(24);
+    const botanicalCounts = [...new Set(botanicalScene.placements.map(
+      ({ phenotypeId }) => phenotypeId
+    ))].map(id => botanicalScene.placements.filter(({ phenotypeId }) => phenotypeId === id).length);
+    expect(Math.max(...botanicalCounts) - Math.min(...botanicalCounts)).toBeLessThan(20);
     expect(generateForestSceneLayout(variety.layout).placements
       .map(({ assetKey }) => assetKey).filter((key, index, keys) => keys.indexOf(key) === index)
       .length).toBe(60);
@@ -159,7 +175,12 @@ describe('static Activity Forest scene', () => {
 
   it('encodes and caches deterministic lossless layer rasters by versioned asset key', async () => {
     const layout = generateForestSceneLayout({
-      seed: 'raster-transport', placementCount: 1, assetPoolSize: 1
+      seed: 'raster-transport', placementCount: 1, assetPoolSize: 1,
+      phenotypeWeights: {
+        'open-crown-deciduous': 0,
+        'sunset-lanternwood': 0,
+        'wind-shaped-highland-conifer': 1
+      }
     });
     const [runtimeAsset] = prepareForestSceneAssets(layout.placements).assets;
     const cold = await encodeForestSceneAssets(
@@ -474,6 +495,9 @@ describe('static Activity Forest scene', () => {
     expect(sliding.worldY).toBe(70);
     expect(forestPlacementCollisionRadius({ phenotypeId: 'sunset-lanternwood', scale: 2 }))
       .toBe(26);
+    expect(forestPlacementCollisionRadius({
+      phenotypeId: 'wind-shaped-highland-conifer', scale: 2
+    })).toBe(24);
     expect(playerCollides({ ...player, worldX: 30 }, [obstacle])).toBeFalse();
   });
 

--- a/spec/forestTreeAssetSpec.js
+++ b/spec/forestTreeAssetSpec.js
@@ -10,14 +10,21 @@ import {
 } from '../server/services/forest/v3/treeAsset.js';
 import {
   DECIDUOUS_PHENOTYPE,
-  LANTERNWOOD_PHENOTYPE
+  FOREST_PHENOTYPES,
+  HIGHLAND_CONIFER_PHENOTYPE,
+  LANTERNWOOD_PHENOTYPE,
+  resolveForestPhenotype
 } from '../server/services/forest/v3/phenotype.js';
-import { selectFoliagePalette } from '../server/services/forest/v3/rasterizeFoliage.js';
+import {
+  FOREST_FOLIAGE_STYLES,
+  selectFoliagePalette
+} from '../server/services/forest/v3/rasterizeFoliage.js';
 import {
   clearForestLabTreeCache,
   forestLabTreeCacheSize,
   getForestLabTree
 } from '../server/services/forestLabTreeCache.js';
+import { forestFixtures } from '../server/routes/devViews.js';
 
 describe('v3 forest runtime tree assets', () => {
   const post = { id: 'tree-asset-post' };
@@ -113,8 +120,36 @@ describe('v3 forest runtime tree assets', () => {
       .flatMap(layerRuns).every(run => lanternColors.has(run.color))).toBeTrue();
   });
 
+  it('registers and resolves every immutable phenotype once', () => {
+    expect(FOREST_PHENOTYPES.map(({ id }) => id)).toEqual([
+      'open-crown-deciduous',
+      'sunset-lanternwood',
+      'wind-shaped-highland-conifer'
+    ]);
+    expect(new Set(FOREST_PHENOTYPES.map(({ id }) => id)).size).toBe(FOREST_PHENOTYPES.length);
+    expect(HIGHLAND_CONIFER_PHENOTYPE.assetVersion).toBe(1);
+    expect(Object.isFrozen(FOREST_PHENOTYPES)).toBeTrue();
+    for (const phenotype of FOREST_PHENOTYPES) {
+      expect(resolveForestPhenotype(phenotype.id)).toBe(phenotype);
+      expect(FOREST_FOLIAGE_STYLES).toContain(phenotype.foliageStyle);
+    }
+    expect(resolveForestPhenotype('unknown-tree')).toBeNull();
+  });
+
+  it('gives Forest Lab eight deterministic fixtures for every registered phenotype', () => {
+    const fixtures = forestFixtures();
+    const counts = Object.fromEntries(FOREST_PHENOTYPES.map(phenotype => [
+      phenotype.id,
+      fixtures.filter(item => item.tree.phenotype.id === phenotype.id).length
+    ]));
+
+    expect(fixtures.length).toBe(FOREST_PHENOTYPES.length * 8);
+    expect(Object.values(counts).every(count => count === 8)).toBeTrue();
+    expect(fixtures.every(item => item.tree.seed === item.asset.seed)).toBeTrue();
+  });
+
   it('selects deterministic whole-tree foliage palettes with weighted rarity', () => {
-    for (const phenotype of [DECIDUOUS_PHENOTYPE, LANTERNWOOD_PHENOTYPE]) {
+    for (const phenotype of FOREST_PHENOTYPES) {
       const selections = Array.from({ length: 1000 }, (_, seed) => (
         selectFoliagePalette(phenotype, seed).id
       ));
@@ -157,11 +192,13 @@ describe('v3 forest runtime tree assets', () => {
     const first = getForestLabTree(post, { seed: 404, phenotype: LANTERNWOOD_PHENOTYPE });
     const repeated = getForestLabTree(post, { seed: 404, phenotype: LANTERNWOOD_PHENOTYPE });
     const deciduous = getForestLabTree(post, { seed: 404, phenotype: DECIDUOUS_PHENOTYPE });
+    const conifer = getForestLabTree(post, { seed: 404, phenotype: HIGHLAND_CONIFER_PHENOTYPE });
 
     expect(first.cacheHit).toBeFalse();
     expect(repeated.cacheHit).toBeTrue();
     expect(deciduous.cacheHit).toBeFalse();
-    expect(forestLabTreeCacheSize()).toBe(2);
+    expect(conifer.cacheHit).toBeFalse();
+    expect(forestLabTreeCacheSize()).toBe(3);
   });
 
   it('does not silently cache custom phenotype overrides without a stable identity', () => {

--- a/spec/forestTreeGeneratorV3Spec.js
+++ b/spec/forestTreeGeneratorV3Spec.js
@@ -3,6 +3,10 @@ import {
   generateForestTreeV3
 } from '../server/services/forestTreeGeneratorV3.js';
 import { FOREST_FOLIAGE_MOTION_GROUP_COUNT } from '../server/services/forest/v3/rasterizeFoliage.js';
+import {
+  DECIDUOUS_PHENOTYPE,
+  HIGHLAND_CONIFER_PHENOTYPE
+} from '../server/services/forest/v3/phenotype.js';
 
 describe('v3 forest branch graph generator', () => {
   const post = { id: 'post-forest-v3-1' };
@@ -595,5 +599,63 @@ describe('v3 forest branch graph generator', () => {
 
     expect(bottomWidth).toBeGreaterThan(upperWidth);
     expect(root.radius).toBeGreaterThan(Math.max(...terminalRadii));
+  });
+
+  it('produces a narrow, single-leader conifer family with tiered needle sprays', () => {
+    const ratios = { conifer: [], deciduous: [] };
+    const coniferWidths = new Set();
+    const coniferLeafCounts = new Set();
+    let splitCount = 0;
+    for (let seed = 0; seed < 24; seed += 1) {
+      const conifer = generateForestTreeV3(post, {
+        seed, phenotype: HIGHLAND_CONIFER_PHENOTYPE
+      });
+      const repeated = generateForestTreeV3(post, {
+        seed, phenotype: HIGHLAND_CONIFER_PHENOTYPE
+      });
+      const deciduous = generateForestTreeGraph(post, { seed, phenotype: DECIDUOUS_PHENOTYPE });
+      const dimensions = graph => ({
+        width: Math.max(...graph.nodes.map(node => node.x))
+          - Math.min(...graph.nodes.map(node => node.x)),
+        height: graph.phenotype.groundY - Math.min(...graph.nodes.map(node => node.y))
+      });
+      const coniferSize = dimensions(conifer);
+      const deciduousSize = dimensions(deciduous);
+      ratios.conifer.push(coniferSize.height / coniferSize.width);
+      ratios.deciduous.push(deciduousSize.height / deciduousSize.width);
+      coniferWidths.add(Math.round(coniferSize.width));
+      coniferLeafCounts.add(conifer.foliage.leaves.length);
+      if (conifer.architecture.hasSplitTrunk) splitCount += 1;
+
+      expect(repeated).toEqual(conifer);
+      expect(conifer.stats.terminationReason).toBe('growth-exhausted');
+      expect(conifer.nodes.length).toBeLessThanOrEqual(conifer.phenotype.maxNodes);
+      expect(conifer.nodes.filter(node => node.generation === 0).some(
+        node => node.y < conifer.phenotype.crown.centerY - (conifer.phenotype.crown.radiusY * 0.8)
+      )).toBeTrue();
+      expect(conifer.foliage.leaves.every(leaf => leaf.style === 'needle-spray')).toBeTrue();
+      expect(new Set(conifer.foliage.coverageCells.filter(cell => cell.supported)
+        .map(cell => cell.row)).size).toBeGreaterThan(5);
+    }
+    const average = values => values.reduce((sum, value) => sum + value, 0) / values.length;
+    expect(average(ratios.conifer)).toBeGreaterThan(average(ratios.deciduous) * 1.35);
+    expect(splitCount).toBeLessThanOrEqual(2);
+    expect(coniferWidths.size).toBeGreaterThan(5);
+    expect(coniferLeafCounts.size).toBeGreaterThan(18);
+  });
+
+  it('rejects unbounded shared crown-density, wind-bias, and foliage-style inputs', () => {
+    expect(() => generateForestTreeGraph(post, {
+      phenotype: { ...HIGHLAND_CONIFER_PHENOTYPE, attractionDensityByHeight: [1.2, 0.5] }
+    })).toThrowError(/height-density/);
+    expect(() => generateForestTreeGraph(post, {
+      phenotype: {
+        ...HIGHLAND_CONIFER_PHENOTYPE,
+        directionalGrowthBias: { x: 0.3, y: 0, z: 0 }
+      }
+    })).toThrowError(/Directional growth bias/);
+    expect(() => generateForestTreeV3(post, {
+      phenotype: { ...HIGHLAND_CONIFER_PHENOTYPE, foliageStyle: 'frond' }
+    })).toThrowError(/foliage style/);
   });
 });

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -13,7 +13,7 @@ block content
       p.forest-lab__eyebrow Development preview
       h1 Activity Forest Lab
       p.forest-lab__lede
-        | Two procedural phenotypes are shown as finished trees, leafless wood rasters, and
+        | Every registered procedural phenotype is shown as finished trees, leafless wood rasters, and
         | its deterministic branch graph so structural and rendering changes remain diagnosable.
 
     section.forest-lab__legend(aria-labelledby='forest-lab-legend')
@@ -22,8 +22,8 @@ block content
         li Post identity supplies the stable seed for every growth and rendering decision.
         li Three-dimensional radial growth is projected into a crisp two-dimensional tree.
         li Branch hierarchy and specimen architecture shape taper from the trunk through terminal twigs.
-        li Individual leaves grow from eligible branches while preserving intentional crown gaps.
-        li Open-crown deciduous trees and fantastical sunset lanternwoods share one runtime asset contract.
+        li Broad leaves or needle sprays grow from eligible branches while preserving intentional crown gaps.
+        li Deciduous, lanternwood, and highland-conifer structures share one runtime asset contract.
 
     section.forest-gallery(aria-label='Generated post tree gallery')
       each item, treeIndex in trees


### PR DESCRIPTION
## Summary

Adds the `wind-shaped-highland-conifer` as the Activity Forest’s third procedural-tree phenotype.

The new tree is tall, narrow, sparse, and organized around a persistent central leader. Tiered boughs, mild directional asymmetry, needle-like foliage, a sturdy lower trunk, and restrained evergreen palettes give it a weathered highland character while keeping it visually consistent with the existing pixel-art forest.

## Shared architecture

This change keeps all three phenotypes on the same procedural generator and runtime tree-asset contract.

It adds three small, phenotype-controlled capabilities:

- Bounded crown-density profiles by height, supporting irregular tiers and negative space
- A bounded directional-growth bias
- A foliage-style vocabulary containing `broadleaf` and `needle-spray`

The existing deciduous and lanternwood phenotypes explicitly retain broadleaf behavior. No phenotype-specific renderer or client-side phenotype switch was introduced.

Phenotype registration and resolution are consolidated around the canonical immutable registry. Forest Lab fixtures, scene selection, asset pooling, and collision traits now consume that shared registration seam.

## Forest Lab and scene integration

- Provides eight deterministic Forest Lab fixtures per registered phenotype
- Preserves final-tree, leafless-wood, and structural graph views
- Adds a `Botanical range` pressure profile with:
  - 180 placements
  - All three phenotypes at deliberately visible weights
  - A bounded pool of 24 shared assets
- Leaves the default forest’s existing deciduous/lanternwood distribution unchanged

The conifer uses the existing:

- Rear-foliage, wood, and front-foliage layer order
- Three foliage motion groups
- Color-run transport
- Lossless-raster transport
- Reduced-motion behavior
- Culling, inspection, collision, and regional asset-loading paths

## Versioning

- Conifer phenotype: `wind-shaped-highland-conifer@1`
- Renderer cache version: `3` → `4`
- Runtime tree-asset schema remains version `2`
- Existing deciduous and lanternwood phenotype versions remain unchanged

The renderer-version bump deliberately invalidates previous renderer cache keys because the shared renderer vocabulary has expanded. No runtime asset-contract migration is required.

## Validation

- Reviewed final and leafless output across multiple deterministic conifer seeds
- Verified a taller and narrower structural tendency than the open-crown deciduous phenotype
- Verified persistent central leaders and a low split-trunk rate
- Verified bounded nodes, iterations, dimensions, foliage, and color-run counts
- Verified deterministic generation and meaningful specimen variation
- Verified both runtime transports
- Verified the representative botanical-range scene

Test results:

- 114 relevant Forest specs passing
- 60 focused generator, asset, and scene specs passing after final changes
- ESLint passing
- `git diff --check` passing

## Documentation

Updates the procedural-tree documentation with:

- The conifer’s visual and structural grammar
- Phenotype-data changes versus shared-generator additions
- Versioning and cache-invalidation decisions
- Forest Lab and botanical-range coverage
- Known visual-tuning limitations
- The decision to defer a fourth phenotype until this experiment has been reviewed

## Non-goals

This PR does not add habitat simulation, semantic post-to-tree selection, seasonal behavior, a fourth phenotype, or a phenotype-specific runtime renderer.