### PR TITLE
Fix translation fields race during post creation

### DIFF
--- a/public/js/create-block.js
+++ b/public/js/create-block.js
@@ -36,6 +36,15 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
 
+    const sourceReady = await queueSourceLookup();
+    const currentSourceValue = sourceInput.value.trim();
+    if (
+      !sourceReady
+      || (currentSourceValue && resolvedSourceValue !== currentSourceValue)
+    ) {
+      return;
+    }
+
     if (existingLangs.includes(langSelect.value)) {
       alert(t('createBlock.messages.langExists'));
       return;
@@ -95,6 +104,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const groupIdField = document.getElementById('groupId');
   const originalBlockField = document.getElementById('originalBlock');
   submitBtn = document.querySelector('button[type="submit"]');
+  let sourceLookup = Promise.resolve(true);
+  let sourceLookupValue = null;
+  let sourceLookupVersion = 0;
+  let resolvedSourceValue = '';
 
   existingLangs = [];
 
@@ -108,16 +121,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const short = String(guess).split('-')[0];
   langSelect.value = short;
 
-  // Fetch info del bloque origen
-  sourceInput.addEventListener('blur', async () => {
-    const raw = sourceInput.value.trim();
+  function clearSourceLink() {
+    groupIdField.value = '';
+    originalBlockField.value = '';
+    resolvedSourceValue = '';
+    existingLangs = [];
+    langSelect.querySelectorAll('option').forEach(option => {
+      option.disabled = false;
+    });
+    bumpIfDup();
+  }
+
+  // Resolve the source before serializing the form. A click on submit blurs this
+  // input first, so submission must share and await the lookup started by blur.
+  async function resolveSource(raw, version) {
     if (!raw) {
-      groupIdField.value = '';
-      originalBlockField.value = '';
-      langSelect.querySelectorAll('option').forEach(o => (o.disabled = false));
-      existingLangs = [];
-      bumpIfDup();
-      return;
+      clearSourceLink();
+      return true;
     }
 
     const match =
@@ -125,9 +145,8 @@ document.addEventListener('DOMContentLoaded', () => {
       || raw.match(/^([0-9a-fA-F]{24})$/);
     if (!match) {
       alert(t('createBlock.advanced.translate.invalid'));
-      groupIdField.value = '';
-      originalBlockField.value = '';
-      return;
+      clearSourceLink();
+      return false;
     }
 
     const id = match[1];
@@ -135,26 +154,56 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch(`/api/v1/blocks/${id}`);
       if (!res.ok) throw new Error('NOT_FOUND');
       const json = await res.json();
+
+      // Ignore a response for a value the user has since changed.
+      if (version !== sourceLookupVersion || sourceInput.value.trim() !== raw) {
+        return false;
+      }
+
       existingLangs = json.translations.map(ti => ti.lang);
       groupIdField.value = json.block.groupId;
       originalBlockField.value = id;
+      resolvedSourceValue = raw;
 
-      // elegir primer idioma libre
-      const allOpts = [...langSelect.options].map(o => o.value);
-      const firstFree = allOpts.find(l => !existingLangs.includes(l)) || 'en';
-      langSelect.value = firstFree;
-
-      existingLangs.forEach(lang => {
-        const option = langSelect.querySelector(`option[value="${lang}"]`);
-        if (option) option.disabled = true;
+      langSelect.querySelectorAll('option').forEach(option => {
+        option.disabled = existingLangs.includes(option.value);
       });
 
+      // Preserve the user's choice unless that language is genuinely occupied.
+      if (existingLangs.includes(langSelect.value)) {
+        const firstFree = [...langSelect.options]
+          .find(option => !option.disabled);
+        if (firstFree) langSelect.value = firstFree.value;
+      }
+
       bumpIfDup();
+      return true;
     } catch {
+      if (version !== sourceLookupVersion || sourceInput.value.trim() !== raw) {
+        return false;
+      }
       alert(t('createBlock.advanced.translate.fetchError'));
-      groupIdField.value = '';
+      clearSourceLink();
+      return false;
     }
+  }
+
+  function queueSourceLookup() {
+    const raw = sourceInput.value.trim();
+    if (sourceLookupValue === raw) return sourceLookup;
+
+    sourceLookupValue = raw;
+    const version = ++sourceLookupVersion;
+    sourceLookup = resolveSource(raw, version);
+    return sourceLookup;
+  }
+
+  sourceInput.addEventListener('input', () => {
+    sourceLookupVersion += 1;
+    sourceLookupValue = null;
+    clearSourceLink();
   });
+  sourceInput.addEventListener('blur', queueSourceLookup);
 
   langSelect.addEventListener('change', bumpIfDup);
 

--- a/spec/createBlockFormSpec.js
+++ b/spec/createBlockFormSpec.js
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+const script = fs.readFileSync('public/js/create-block.js', 'utf8');
+const sourceId = '0123456789abcdef01234567';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function render(fetch) {
+  const dom = new JSDOM(`
+    <!doctype html>
+    <html lang="en"><body>
+      <form id="block-form" action="/api/v1/rooms/room-1/blocks">
+        <input id="title" name="title" value="A translated post">
+        <textarea name="content"></textarea>
+        <select id="lang" name="lang">
+          <option value="en">English</option>
+          <option value="es">Spanish</option>
+          <option value="ru">Russian</option>
+        </select>
+        <input id="source-block" type="text">
+        <input id="groupId" name="groupId" type="hidden">
+        <input id="originalBlock" name="originalBlock" type="hidden">
+        <button type="submit">Create</button>
+      </form>
+    </body></html>
+  `, {
+    runScripts: 'outside-only',
+    url: 'https://example.test/rooms/room-1/blocks/create'
+  });
+  dom.window.fetch = fetch;
+  dom.window.alert = jasmine.createSpy('alert');
+  const ready = new Promise(resolve => {
+    dom.window.document.addEventListener('DOMContentLoaded', resolve, { once: true });
+  });
+  dom.window.eval(script);
+  await ready;
+  return dom;
+}
+
+describe('create block translation fields', () => {
+  it('waits for source lookup and preserves an available selected language', async () => {
+    const lookup = deferred();
+    let submittedData;
+    const dom = await render((url, options = {}) => {
+      if (!options.method) return lookup.promise;
+      submittedData = JSON.parse(options.body);
+      return new Promise(() => {});
+    });
+    const { document } = dom.window;
+    const sourceInput = document.getElementById('source-block');
+    const langSelect = document.getElementById('lang');
+
+    langSelect.value = 'ru';
+    sourceInput.value = sourceId;
+    sourceInput.dispatchEvent(new dom.window.Event('blur'));
+    document.getElementById('block-form').dispatchEvent(
+      new dom.window.Event('submit', { bubbles: true, cancelable: true })
+    );
+
+    expect(submittedData).toBeUndefined();
+
+    lookup.resolve({
+      ok: true,
+      json: async () => ({
+        block: { groupId: 'translation-group-1' },
+        translations: [{ lang: 'en' }]
+      })
+    });
+    await lookup.promise;
+    await new Promise(resolve => dom.window.setTimeout(resolve, 0));
+
+    expect(langSelect.value).toBe('ru');
+    expect(submittedData.lang).toBe('ru');
+    expect(submittedData.groupId).toBe('translation-group-1');
+    expect(submittedData.originalBlock).toBe(sourceId);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a race condition in the post creation form when linking a new post as a translation of an existing post.

## Problem

Looking up the referenced source post happened asynchronously when the translation field lost focus. Submitting immediately afterward could serialize the form before that lookup completed.

This could cause:

- `groupId` and `originalBlock` to be omitted, creating a freestanding post.
- The selected language to change while submission was underway.
- A valid language selection to be replaced unnecessarily with the first available language.

## Changes

- Wait for the translation-source lookup before serializing and submitting the form.
- Preserve the selected language when it is available.
- Ignore stale lookup responses after the source field changes.
- Clear stale translation metadata when the source is changed or cannot be resolved.
- Add regression coverage for submitting while the source lookup is still pending.

## Testing

- Added a browser-level regression spec covering the race condition.
- ESLint passes.
- All 634 specs pass.