### PR TITLE
Add the Activity Forest post-to-tree meaning contract

### DIFF
--- a/docs/forest/post-to-tree-meaning-contract.md
+++ b/docs/forest/post-to-tree-meaning-contract.md
@@ -1,0 +1,170 @@
+# Activity Forest post-to-tree meaning contract
+
+## Status and purpose
+
+Milestone 7A introduces a development-only, fixture-backed boundary between writing data and the
+renderer-v3 procedural-tree generator. It is deliberately small: stable writing identity chooses a
+specimen, a broad habitat hint softly biases phenotype eligibility, and creation season leaves one
+bounded permanent foliage tint. It is not a production post query, migration system, biome model,
+or final semantic mapping.
+
+The contract lives in `server/services/forestPostTreeProjection.js`. Projection schema version 1
+and mapping version 1 are separate from runtime tree-asset schema version 2, renderer cache version
+4, and each phenotype's asset version.
+
+## Input and decision policy
+
+The projection rejects unknown fields. Strings and counts are bounded, timestamps must be exact
+ISO-8601 UTC strings, and the context must contain exactly one known habitat. Titles, descriptions,
+body content, excerpts, tags, personal-overlay state, and transient presentation do not cross the
+boundary.
+
+| Source | Accepted | Stability | Milestone 7A expression | Existing tree changes automatically? | Identity/invalidation | Forest Lab explanation |
+| --- | --- | --- | --- | --- | --- | --- |
+| Stable post `id` | Yes, required and bounded | Stable | Specimen seed and deterministic phenotype draw | A different id is a different specimen | Mapping version, derived seed, phenotype identity | Stable writing identity selected the seed |
+| Explicit `habitat` context | Yes: `neutral-grove` or `rocky-edge` | Generated-base context | Soft phenotype-selection bias; no hard one-species habitat | No. A deliberate base reprojection may change it | Selected phenotype affects pixels; an explanation-only habitat difference does not | Habitat favored forms without requiring one species |
+| `createdAt` | Yes, optional exact UTC timestamp | Permanent evidence at projection time | UTC creation season selects one phenotype-owned palette | No polling. A correction requires deliberate reprojection | Palette decision and mapping version affect the visual key | Creation season left a restrained permanent tint |
+| `roomId` | Yes, optional and bounded | Mutable categorization | None in this slice | No | None | None |
+| `wordCount` | Yes, optional and bounded | Mutable with edits | None; never size, rarity, brightness, or complexity | No | None | None |
+| Collaborator and translation counts | Yes, optional and bounded | Mutable activity | Deferred; possible surrounding evidence, not a core-tree reward | No | None | None |
+| Comment and reaction counts | Yes, optional and bounded | Mutable activity | Deferred; possible surrounding/transient evidence, not a core-tree reward | No | None | None |
+| Quest approval | Yes, optional boolean | Mutable workflow state | Deferred; no tree or surroundings output yet | No | None | None |
+| Title, body, excerpt, tags | No | Mutable/private content | Outside the projection | No | None | None |
+| Placement, paths, markers, benches, reflections, relationships | No | Personal overlay | Overlay only | No effect on projection or asset identity | Overlay/base identity rules only | None |
+| Current season, time, weather, wind | No | Transient presentation | Outside permanent tree identity | No | None | None |
+
+Missing `createdAt` deterministically produces `creationSeason: "unknown"` and no palette override;
+the ordinary phenotype-weighted, seed-selected palette remains in use. Optional ignored fields may
+be absent without changing the result.
+
+## Projection schema
+
+The pure projection returns exactly JSON-serializable bounded decisions:
+
+```text
+schemaVersion, mappingVersion
+specimen: derived unsigned seed and stable-identity source token
+phenotype: canonical id and asset version
+habitat: bounded id and soft-bias classification
+permanentTraits: creation-season token and phenotype-owned foliage palette id or null
+surroundings: empty bounded object in this slice
+explanations: three code-owned reason tokens and short botanical statements
+identity: complete projection fingerprint and output-only visual fingerprint
+```
+
+It does not return the post id, room, counts, content, or a serialized metadata snapshot. The full
+projection remains a server-side development diagnostic. Only its output-only visual fingerprint
+participates in the runtime asset cache key.
+
+## Deterministic phenotype selection
+
+Selection enumerates the canonical phenotype registry, sorts by stable phenotype id, and performs a
+mapping-versioned deterministic weighted draw. Sorting makes a registry reorder harmless. Adding or
+removing a registered phenotype or changing its meaning weights is a mapping change and requires a
+mapping-version increment.
+
+The phenotype-owned development weights are:
+
+| Phenotype | Neutral grove | Rocky edge |
+| --- | ---: | ---: |
+| Open-crown deciduous | 5 | 3 |
+| Sunset lanternwood | 3 | 2 |
+| Wind-shaped highland conifer | 2 | 5 |
+
+Both habitats retain all three phenotypes. Across the fixed 1,200-id distribution test, neutral
+grove selected deciduous/lanternwood/conifer 602/345/253 times; rocky edge selected them
+375/240/585 times. These numbers are diagnostics, not user-facing scores or a room taxonomy.
+
+## Permanent creation-season evidence
+
+UTC creation season selects exactly one existing foliage palette declared by the selected
+phenotype. It does not spread or mutate phenotype objects, change the branch graph, alter
+architecture, enlarge the canvas, increase leaves or nodes, or expand generator limits. Spring,
+summer, autumn, and winter therefore leave a restrained color trace while every architectural
+decision remains controlled by the stable specimen seed and phenotype ranges.
+
+Changing only creation season preserves seed, phenotype, branch graph, architecture, bounds, and
+complexity but changes the chosen palette and visual cache identity. The mapping is code-owned and
+versioned; it is intentionally not a user-authored rule language.
+
+## Mutation and historical evidence policy
+
+The projection describes a stable writing-layer record, not a live activity dashboard. A future
+persistent system should capture its mapping version and derived decisions when a tree is created.
+It should not silently reproject on ordinary post reads.
+
+- Correcting a title or body, moving rooms, or changing activity counts does not restyle the tree.
+- Correcting `createdAt` may change permanent evidence, but only through an explicit reprojection or
+  repair operation whose old version can be audited.
+- Changing explicit habitat is a generated-base decision and may change phenotype only through an
+  explicit base reprojection. Manually relocating a tree through personal curation does not change
+  habitat, projection, seed, phenotype, or asset.
+- Upgrading the meaning mapping does not silently rewrite historical trees. A future migration must
+  explicitly choose whether to retain the captured projection or create a versioned replacement.
+- Renderer and phenotype upgrades may produce new pixels while preserving the captured semantic
+  projection. Their existing renderer and phenotype versions remain the relevant invalidators.
+
+No production persistence or migration mechanism is implemented by this experiment.
+
+## Runtime identity and cache rules
+
+Ordinary renderer-v3 assets keep their established key:
+
+```text
+tree schema + renderer id/version + phenotype id/version + seed
+```
+
+Projected assets append:
+
+```text
+meaning mapping version + bounded visual fingerprint
+```
+
+The visual fingerprint contains only derived output decisions (currently the palette decision).
+The cache already contains the seed and phenotype identity, so it does not duplicate raw source
+data. Two habitat inputs that happen to select the same phenotype and palette reuse pixels even
+though their full diagnostic projection fingerprints and explanations differ. A creation-season
+palette change or mapping-version change gets a different key. This preserves the rule that
+nonvisual explanation changes do not invalidate pixels while no two different rendered outputs
+share an identity.
+
+Runtime asset schema version remains 2. Projected assets retain the same ordered rear foliage,
+wood, and front foliage layers, up to three motion groups per foliage layer, architectural identity,
+dimensions, anchor, and bounds. Neither the projection nor explanations are added to runtime assets
+or either transport. Explicit-seed generator and diagnostic behavior remains unchanged.
+
+## Forest Lab evidence
+
+Forest Lab now runs its 24 fixtures through the projection instead of forcing phenotypes directly.
+The curated set still contains exactly eight fixtures per registered phenotype and exposes each
+fixture's phenotype, specimen seed, habitat, creation season, palette decision, three explanations,
+mapping version, and diagnostic fingerprint. Final-tree, leafless-wood, and branch-graph views are
+unchanged.
+
+Three adjacent pairs isolate the contract:
+
+- one post identity and creation date under neutral-grove versus rocky-edge habitat;
+- one post identity and habitat with spring versus autumn creation evidence;
+- one post identity, date, and habitat with very low versus very high word/activity counts.
+
+The habitat pair preserves the specimen seed while selecting different phenotypes. The season pair
+preserves its graph and architecture while changing only foliage palette and visual key. The
+activity pair produces the exact same projection and reuses the same asset object.
+
+On Node 24.15.0, one local cold generation of this fixture set took about 1.43 seconds, produced 23
+unique assets (the activity pair shares one), and stayed within the registered maximum dimensions
+of 112 by 142 logical pixels. The same assets serialized to 3,007,300 bytes as color runs and
+215,783 bytes through the existing lossless-raster transport. These are local architecture checks,
+not device benchmarks.
+
+## Remaining unknowns and Milestone 8 boundary
+
+Real post distributions may reveal clustering by creation month, missing or corrected timestamps,
+and whether the two habitat biases feel too weak or too classificatory. The permanent tint also
+needs ordinary scene-scale visual review; a palette that is tasteful in a Lab card may be too
+prominent in a grove. No conclusion should be drawn about mutable activity or surrounding features
+until representative product data and humane visual studies exist.
+
+Habitat here is an explicit two-value fixture input used only to prove selection. It is not inferred
+from rooms, placement, terrain, or user behavior. Terrain regions, habitat transitions, water,
+environmental grammar, and biome generation remain Milestone 8 work.

--- a/docs/forest/post-to-tree-meaning-contract.md
+++ b/docs/forest/post-to-tree-meaning-contract.md
@@ -157,12 +157,55 @@ of 112 by 142 logical pixels. The same assets serialized to 3,007,300 bytes as c
 215,783 bytes through the existing lossless-raster transport. These are local architecture checks,
 not device benchmarks.
 
+## Projected writing grove evidence
+
+Milestone 7B adds the explicit `post-tree-meaning` development profile to the explorable Activity
+Forest. It does not change the representative default or `botanical-range` profile. The semantic
+profile generates the ordinary deterministic 180-placement layout, then cycles the 24 projection
+fixtures across those placements. Each placement receives only its normal bounded spatial fields,
+fixture id, phenotype id, specimen seed, and complete versioned asset key. It does not receive the
+projection, habitat, creation time, counts, or explanations.
+
+The server retains a request-local map from asset key to the projection needed to prepare that
+asset. Initial and regional asset preparation consult this map and call the validated projected
+generator; ordinary profiles use the established seed-and-phenotype path. The process-local scene
+pool and lossless-raster cache remain keyed by the same complete runtime asset key. The map is not
+serialized into the scene response.
+
+The exploration fixture associated with each placement contains ordinary bounded writing display
+fields plus a `treeMeaning` explanation projection. It includes mapping version, specimen seed,
+phenotype id, habitat token, creation-season token, palette id, and the three code-owned explanation
+tokens and sentences. It excludes counts, raw post identity, projection fingerprints, title/body
+source fields beyond what the existing writing dialog already presents, and all generation data.
+Inspecting a tree displays this explanation in the existing accessible dialog. Nearby-bench
+reflection resolves the same full fixture before opening it, so it presents the same meaning without
+changing nearby-writing selection or persistence.
+
+This inspection panel is development instrumentation, not a proposed final player-facing design.
+Phenotype ids, specimen seeds, mapping versions, palette ids, and rule explanations exist here so
+the contract can be reviewed. A future product may offer a gentler optional “why this tree?” view,
+but it should not expose cache identity or turn selection mechanics into an optimization guide.
+
+The fixed scene has 180 placements, 24 inspectable writing fixtures, and 23 unique projected assets;
+the controlled activity pair deliberately shares one asset. Its placement distribution is 61
+open-crown deciduous, 59 sunset lanternwood, and 60 wind-shaped highland conifers. Habitat inputs
+appear on 128 neutral-grove and 52 rocky-edge placements because the scene repeats the representative
+fixture set rather than synthesizing a biome distribution. Every fixture appears seven or eight
+times, making paired comparisons reachable without expanding the asset pool.
+
+On Node 24.15.0, one local cold preparation of all 23 projected assets took about 1.37 seconds. The
+complete asset array serialized to 2,874,169 bytes as color runs and 206,394 bytes through the
+existing lossless-raster transport. Runtime assets retain schema 2, renderer version 4, their
+registered phenotype versions, ordered layers, and at most three foliage motion groups. These are
+local architecture observations, not browser or baseline-device frame-time claims.
+
 ## Remaining unknowns and Milestone 8 boundary
 
 Real post distributions may reveal clustering by creation month, missing or corrected timestamps,
-and whether the two habitat biases feel too weak or too classificatory. The permanent tint also
-needs ordinary scene-scale visual review; a palette that is tasteful in a Lab card may be too
-prominent in a grove. No conclusion should be drawn about mutable activity or surrounding features
+and whether the two habitat biases feel too weak or too classificatory. The projected grove now
+makes ordinary scene-scale review possible, but the permanent tint still requires human judgment on
+the intended baseline display and with representative source data. No conclusion should be drawn
+about mutable activity or surrounding features
 until representative product data and humane visual studies exist.
 
 Habitat here is an explicit two-value fixture input used only to prove selection. It is not inferred

--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -903,7 +903,7 @@ Its projection was:
 }
 ```
 
-Current semantic mappings are:
+Its historical semantic mappings were:
 
 | Post property | Tree expression |
 | --- | --- |
@@ -916,6 +916,12 @@ Current semantic mappings are:
 | Approved quest association | Fruit |
 | Comments | Ground flowers |
 | Reactions | Fireflies |
+
+This table is renderer-v2 research evidence, not the active renderer-v3 contract. The focused v3
+Milestone 7A policy, versioned projection, mutation rules, and cache boundary are documented in
+[`post-to-tree-meaning-contract.md`](./post-to-tree-meaning-contract.md). In particular, v3 does not
+restore room-to-species rules, metric-driven size, split trunks as collaboration rewards, or the v2
+adornment mappings.
 
 The v2 tree has a shared trunk, branch-tip, and crown-center anatomy, correcting the visibly unsupported crowns in v1. Blossoms, fruit, flowers, and fireflies are multi-pixel motifs placed in semantic zones rather than as unrelated random pixels.
 

--- a/docs/forest/procedural-tree-design.md
+++ b/docs/forest/procedural-tree-design.md
@@ -725,11 +725,13 @@ browser, generalized object scripting, or entity-component framework.
 
 ### Development pressure profiles
 
-The development route accepts four labeled profiles through its on-page profile links:
+The development route accepts six labeled profiles through its on-page profile links:
 
 | Profile | Placements | Unique runtime assets | Purpose |
 | --- | ---: | ---: | --- |
 | Representative grove | 180 | up to 16 | The unchanged calm default and normal comparison point. |
+| Botanical range | 180 | up to 24 | Balances all three registered phenotypes without semantic writing projection. |
+| Projected writing grove | 180 | 23 | Cycles the 24 Milestone 7 meaning-contract fixtures through a separately selectable semantic scene. |
 | Asset variety | 180 | 60 | Isolates the cost of a moderately broader asset set. |
 | Unique assets | 180 | 180 | Exercises the current eager asset boundary at maximum variety. |
 | Large world | 600 | 60 | Separates placement, culling, and movement cost from asset variety. |

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -493,6 +493,32 @@ html[data-theme='dark'] .activity-forest .activity-forest__prompt {
 }
 .activity-forest__dialog-context { margin: 0.3rem 0 1.2rem; color: #5f6a61; }
 .activity-forest__dialog-excerpt { font-size: 1.08rem; line-height: 1.65; }
+.activity-forest__tree-meaning {
+  margin: 1rem 0;
+  padding: 0.85rem;
+  border-radius: 9px;
+  background: #e9e2ca;
+}
+.activity-forest__tree-meaning h3 { margin: 0 0 0.7rem; font-size: 0.9rem; }
+.activity-forest__tree-meaning dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+}
+.activity-forest__tree-meaning dt {
+  color: #6d705f;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.activity-forest__tree-meaning dd { margin: 0.15rem 0 0; font-size: 0.78rem; }
+.activity-forest__tree-meaning ul {
+  margin: 0.7rem 0 0;
+  padding-left: 1.15rem;
+  color: #536158;
+  font-size: 0.76rem;
+}
 .activity-forest__dialog button {
   min-height: 44px;
   box-sizing: border-box;

--- a/public/css/forest-lab.css
+++ b/public/css/forest-lab.css
@@ -100,6 +100,50 @@
   font-size: 0.92rem;
 }
 
+.forest-comparison__pair {
+  margin: 0;
+  padding: 0 0.8rem 0.35rem;
+  color: var(--highlight-color);
+  font-family: var(--font-rubik-medium);
+  font-size: 0.72rem;
+}
+
+.forest-comparison__error {
+  margin: 0.8rem;
+  padding: 0.8rem;
+  border: 1px solid #b95756;
+  border-radius: 8px;
+  color: #b95756;
+}
+
+.forest-comparison__error p {
+  margin: 0.35rem 0 0;
+}
+
+.forest-comparison__meaning {
+  margin: 0 0.8rem 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  background: var(--secondary-bg);
+  color: var(--muted-text-color);
+  font-size: 0.72rem;
+}
+
+.forest-comparison__meaning p,
+.forest-comparison__meaning ul {
+  margin: 0;
+}
+
+.forest-comparison__meaning ul {
+  padding: 0.4rem 0 0.45rem 1.1rem;
+}
+
+.forest-comparison__meaning code {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 0.64rem;
+}
+
 .forest-comparison__meta {
   margin: 0;
   padding: 0 0.8rem 0.85rem;

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1014,6 +1014,7 @@ if (payload && viewportElement && canvas) {
       dialog.querySelector('[data-forest-dialog-eyebrow]').textContent = 'A place made personal';
       dialog.querySelector('[data-forest-post-title]').textContent = 'Your clearing marker';
       dialog.querySelector('[data-forest-dialog-context]').hidden = true;
+      dialog.querySelector('[data-forest-tree-meaning]').hidden = true;
       dialog.querySelector('[data-forest-post-excerpt]').textContent =
         'This simple marker is stored in the personal overlay, independently of the generated trees.';
       dialog.showModal();
@@ -1032,6 +1033,25 @@ if (payload && viewportElement && canvas) {
     dialog.querySelector('[data-forest-post-date]').textContent = new Intl.DateTimeFormat(undefined,
       { dateStyle: 'long' }).format(new Date(`${fixture.createdAt}T12:00:00Z`));
     dialog.querySelector('[data-forest-post-excerpt]').textContent = fixture.excerpt;
+    const meaning = fixture.treeMeaning;
+    const meaningSurface = dialog.querySelector('[data-forest-tree-meaning]');
+    meaningSurface.hidden = !meaning;
+    if (meaning) {
+      meaningSurface.querySelector('[data-forest-meaning-phenotype]').textContent =
+        meaning.phenotypeId;
+      meaningSurface.querySelector('[data-forest-meaning-seed]').textContent =
+        String(meaning.specimenSeed);
+      meaningSurface.querySelector('[data-forest-meaning-habitat]').textContent =
+        meaning.habitat.replaceAll('-', ' ');
+      meaningSurface.querySelector('[data-forest-meaning-tint]').textContent =
+        `${meaning.creationSeason} · ${meaning.foliagePaletteId || 'seed-selected'}`;
+      const reasons = meaningSurface.querySelector('[data-forest-meaning-reasons]');
+      reasons.replaceChildren(...meaning.explanations.map((explanation) => {
+        const item = document.createElement('li');
+        item.textContent = explanation.text;
+        return item;
+      }));
+    }
     dialog.showModal();
   }
 
@@ -1043,7 +1063,10 @@ if (payload && viewportElement && canvas) {
         diagnostics.benchResurfaced.textContent =
           `${candidate.fixtureId} via ${selectedBenchWriting.benchId}`;
         objectDialog.close();
-        openFixtureWriting(candidate.fixture, 'Writing reflected from nearby trees');
+        openFixtureWriting(
+          fixturesById.get(candidate.fixtureId) || candidate.fixture,
+          'Writing reflected from nearby trees'
+        );
       }
     );
     objectDialog.querySelector('[data-forest-bench-reflect]').hidden = true;

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -2,7 +2,8 @@ import express from 'express';
 
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
-import { getForestLabTree } from '../services/forestLabTreeCache.js';
+import { getForestLabProjectedTree } from '../services/forestLabTreeCache.js';
+import { projectPostToForestTree } from '../services/forestPostTreeProjection.js';
 import {
   clearForestSceneAssetPool,
   prepareForestSceneAssets
@@ -29,9 +30,6 @@ import {
   forestSceneCellIdsForViewport,
   forestScenePlacementCellId
 } from '../../public/js/forest-scene-math.js';
-import {
-  FOREST_PHENOTYPES
-} from '../services/forest/v3/phenotype.js';
 
 const router = express.Router();
 
@@ -66,28 +64,76 @@ const forestFixtureRooms = [
   'united-states', 'daily-inspiration', 'physics', 'history', 'united-states', 'mathematics'
 ];
 
+const forestFixtureSemantics = Object.freeze([
+  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'neutral-grove',
+    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair A' }),
+  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'rocky-edge',
+    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair B' }),
+  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
+    createdAt: '2025-04-12T00:00:00.000Z', pair: 'Creation-season pair A' }),
+  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
+    createdAt: '2025-10-12T00:00:00.000Z', pair: 'Creation-season pair B' }),
+  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
+    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair A', lowActivity: true }),
+  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
+    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair B', highActivity: true }),
+  ...Array.from({ length: 18 }, (_, index) => Object.freeze({
+    id: `forest-meaning-fixture-${index + 7}`,
+    habitat: index % 3 === 0 ? 'rocky-edge' : 'neutral-grove',
+    createdAt: new Date(Date.UTC(2024 + (index % 3), index % 12, 7 + index)).toISOString(),
+    pair: null
+  }))
+]);
+
+export function projectForestLabFixture(post, context) {
+  try {
+    const projection = projectPostToForestTree({
+      id: post.id,
+      roomId: post.roomId,
+      createdAt: post.createdAt,
+      wordCount: post.wordCount,
+      collaboratorCount: post.collaboratorCount,
+      translationCount: post.translationCount,
+      commentCount: post.commentCount,
+      reactionCount: post.reactionCount,
+      questApproved: post.questApproved
+    }, context);
+    const { generation: tree, asset } = getForestLabProjectedTree(projection);
+    return { projection, tree, asset, projectionError: null };
+  } catch (error) {
+    return {
+      projection: null,
+      tree: null,
+      asset: null,
+      projectionError: error instanceof Error ? error.message : 'Unknown projection failure.'
+    };
+  }
+}
+
 export function forestFixtures() {
   return forestFixtureTitles.map((title, index) => {
+    const semantics = forestFixtureSemantics[index];
     const post = {
-      id: `forest-lab-post-${index + 1}`,
+      id: semantics.id,
       title,
       roomId: forestFixtureRooms[index % forestFixtureRooms.length],
-      createdAt: new Date(Date.UTC(2024 + (index % 3), index % 12, 3 + index)).toISOString(),
-      wordCount: 280 + ((index * 347) % 2500),
-      collaboratorCount: index % 5 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
-      translationCount: index % 6,
-      commentCount: (index * 3) % 15,
-      reactionCount: (index * 5) % 21,
-      questApproved: index % 4 === 0,
+      createdAt: semantics.createdAt,
+      wordCount: semantics.highActivity ? 8000 : semantics.lowActivity ? 80
+        : 280 + ((index * 347) % 2500),
+      collaboratorCount: semantics.highActivity ? 20 : semantics.lowActivity ? 0
+        : index % 5 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
+      translationCount: semantics.highActivity ? 40 : semantics.lowActivity ? 0 : index % 6,
+      commentCount: semantics.highActivity ? 500 : semantics.lowActivity ? 0 : (index * 3) % 15,
+      reactionCount: semantics.highActivity ? 1000 : semantics.lowActivity ? 0 : (index * 5) % 21,
+      questApproved: semantics.highActivity || (!semantics.lowActivity && index % 4 === 0),
       excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.'
     };
-    const phenotype = FOREST_PHENOTYPES[index % FOREST_PHENOTYPES.length];
-    const { generation: tree, asset } = getForestLabTree(post, { phenotype });
+    const projected = projectForestLabFixture(post, { habitat: semantics.habitat });
     return {
       ...post,
       url: `/rooms/${post.roomId}/blocks/${post.id}`,
-      tree,
-      asset
+      pair: semantics.pair,
+      ...projected
     };
   });
 }

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -3,6 +3,7 @@ import express from 'express';
 import optionalAuth from '../middleware/optionalAuth.js';
 import { addI18n } from '../services/i18n.js';
 import { getForestLabProjectedTree } from '../services/forestLabTreeCache.js';
+import { forestPostTreeFixtures } from '../services/forestPostTreeFixtures.js';
 import { projectPostToForestTree } from '../services/forestPostTreeProjection.js';
 import {
   clearForestSceneAssetPool,
@@ -16,6 +17,7 @@ import {
 } from '../services/forestSceneAssetTransport.js';
 import { generateForestSceneLayout } from '../services/forestSceneLayout.js';
 import { createForestExploration } from '../services/forestSceneExploration.js';
+import { composeProjectedForestScene } from '../services/forestProjectedScene.js';
 import {
   FOREST_PRESSURE_PROFILES,
   FOREST_SCENE_MAX_ASSET_REQUEST,
@@ -32,58 +34,6 @@ import {
 } from '../../public/js/forest-scene-math.js';
 
 const router = express.Router();
-
-const forestFixtureTitles = [
-  'Coos County at the Edge of the Continent',
-  'Notes from a Summer Thunderstorm',
-  'Why Saturn Has Rings',
-  'A Small Museum of Lost Buttons',
-  'Walking Across Lower Manhattan',
-  'The Mathematics of Honeycombs',
-  'Letter to an Unfamiliar City',
-  'Yalobusha County Field Notes',
-  'The Quiet Work of Repair',
-  'What the Telescope Remembered',
-  'A Recipe Written from Memory',
-  'Gosper County Beneath a Wide Sky',
-  'How Rivers Choose Their Paths',
-  'Three Poems About Streetlights',
-  'A Brief History of Public Benches',
-  'The Physics of Skipping Stones',
-  'Postcard from a Winter Harbor',
-  'On Learning the Names of Birds',
-  'The Last Independent Bookshop',
-  'A Map of Neighborhood Kindness',
-  'Cloud Chambers and Cosmic Rays',
-  'An Orchard at the City Limit',
-  'Notes on Translation and Distance',
-  'The Road Home After Midnight'
-];
-
-const forestFixtureRooms = [
-  'united-states', 'daily-inspiration', 'physics', 'history', 'united-states', 'mathematics'
-];
-
-const forestFixtureSemantics = Object.freeze([
-  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'neutral-grove',
-    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair A' }),
-  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'rocky-edge',
-    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair B' }),
-  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
-    createdAt: '2025-04-12T00:00:00.000Z', pair: 'Creation-season pair A' }),
-  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
-    createdAt: '2025-10-12T00:00:00.000Z', pair: 'Creation-season pair B' }),
-  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
-    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair A', lowActivity: true }),
-  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
-    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair B', highActivity: true }),
-  ...Array.from({ length: 18 }, (_, index) => Object.freeze({
-    id: `forest-meaning-fixture-${index + 7}`,
-    habitat: index % 3 === 0 ? 'rocky-edge' : 'neutral-grove',
-    createdAt: new Date(Date.UTC(2024 + (index % 3), index % 12, 7 + index)).toISOString(),
-    pair: null
-  }))
-]);
 
 export function projectForestLabFixture(post, context) {
   try {
@@ -111,35 +61,28 @@ export function projectForestLabFixture(post, context) {
 }
 
 export function forestFixtures() {
-  return forestFixtureTitles.map((title, index) => {
-    const semantics = forestFixtureSemantics[index];
-    const post = {
-      id: semantics.id,
-      title,
-      roomId: forestFixtureRooms[index % forestFixtureRooms.length],
-      createdAt: semantics.createdAt,
-      wordCount: semantics.highActivity ? 8000 : semantics.lowActivity ? 80
-        : 280 + ((index * 347) % 2500),
-      collaboratorCount: semantics.highActivity ? 20 : semantics.lowActivity ? 0
-        : index % 5 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
-      translationCount: semantics.highActivity ? 40 : semantics.lowActivity ? 0 : index % 6,
-      commentCount: semantics.highActivity ? 500 : semantics.lowActivity ? 0 : (index * 3) % 15,
-      reactionCount: semantics.highActivity ? 1000 : semantics.lowActivity ? 0 : (index * 5) % 21,
-      questApproved: semantics.highActivity || (!semantics.lowActivity && index % 4 === 0),
-      excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.'
-    };
-    const projected = projectForestLabFixture(post, { habitat: semantics.habitat });
+  return forestPostTreeFixtures().map((fixture) => {
+    const post = { ...fixture.post, title: fixture.title, excerpt: fixture.excerpt };
+    const projected = projectForestLabFixture(post, fixture.context);
     return {
       ...post,
       url: `/rooms/${post.roomId}/blocks/${post.id}`,
-      pair: semantics.pair,
+      pair: fixture.pair,
       ...projected
     };
   });
 }
 
 function forestSceneForProfile(profile) {
-  return createForestExploration(generateForestSceneLayout(profile.layout));
+  const baseLayout = generateForestSceneLayout(profile.layout);
+  if (!profile.projectedWriting) {
+    return { scene: createForestExploration(baseLayout), assetProjections: new Map() };
+  }
+  const projected = composeProjectedForestScene(baseLayout);
+  return {
+    scene: createForestExploration(projected.layout, { fixtures: projected.fixtures }),
+    assetProjections: projected.assetProjections
+  };
 }
 
 function placementsInForestCells(scene, cellIds) {
@@ -192,7 +135,7 @@ router.get(
   async (req, res) => {
     const profile = resolveForestPressureProfile(req.query.pressure);
     const transport = resolveForestAssetTransport(req.query.transport);
-    const scene = forestSceneForProfile(profile);
+    const { scene, assetProjections } = forestSceneForProfile(profile);
     const cellIds = validRequestedForestCellIds(req.query.cells, scene.world);
     if (!cellIds.length) return res.status(400).json({ error: 'Valid forest cells are required.' });
     const assetKeys = validRequestedForestAssetKeys(req.query.assetKeys, scene, cellIds);
@@ -203,7 +146,8 @@ router.get(
     const { assets: runtimeAssets, diagnostics } = prepareForestSceneAssets(
       placementsInForestCells(scene, cellIds).filter(
         ({ assetKey }) => requestedAssetKeys.has(assetKey)
-      )
+      ),
+      assetProjections
     );
     const { assets, diagnostics: encoding } = await encodeForestSceneAssets(
       runtimeAssets, transport
@@ -235,10 +179,11 @@ router.get(
       clearForestSceneAssetPool();
       clearForestSceneRasterAssetCache();
     }
-    const layout = forestSceneForProfile(profile);
+    const { scene: layout, assetProjections } = forestSceneForProfile(profile);
     const initialCellIds = initialForestCellIds(layout);
     const { assets: runtimeAssets, diagnostics: preparation } = prepareForestSceneAssets(
-      placementsInForestCells(layout, initialCellIds)
+      placementsInForestCells(layout, initialCellIds),
+      assetProjections
     );
     const { assets, diagnostics: encoding } = await encodeForestSceneAssets(
       runtimeAssets, transport
@@ -267,7 +212,7 @@ router.get(
     };
     res.render('dev/activity-forest', {
       title: profile.pressure ? `Activity Forest Pressure Test: ${profile.label}`
-        : 'Activity Forest Scene',
+        : profile.projectedWriting ? `Activity Forest: ${profile.label}` : 'Activity Forest Scene',
       user: req.user || null,
       uiLang: res.locals.uiLang,
       scene,

--- a/server/services/forest/v3/phenotype.js
+++ b/server/services/forest/v3/phenotype.js
@@ -109,6 +109,12 @@ export const DECIDUOUS_PHENOTYPE = Object.freeze({
       })
     })
   ]),
+  postTreeMeaning: Object.freeze({
+    habitatWeights: Object.freeze({ 'neutral-grove': 5, 'rocky-edge': 3 }),
+    creationSeasonPaletteIds: Object.freeze({
+      spring: 'meadow-green', summer: 'summer-green', autumn: 'early-gold', winter: 'blue-grove'
+    })
+  }),
   rootFlareHeight: 11,
   rootFlareStrength: 3.8
 });
@@ -211,6 +217,12 @@ export const LANTERNWOOD_PHENOTYPE = Object.freeze({
       })
     })
   ]),
+  postTreeMeaning: Object.freeze({
+    habitatWeights: Object.freeze({ 'neutral-grove': 3, 'rocky-edge': 2 }),
+    creationSeasonPaletteIds: Object.freeze({
+      spring: 'spring-bloom', summer: 'sunset', autumn: 'harvest', winter: 'enchanted-plum'
+    })
+  }),
   woodPalette: Object.freeze({
     light: '#d8b987', mid: '#aa795d', dark: '#704b4b', deep: '#49333f'
   }),
@@ -311,6 +323,12 @@ export const HIGHLAND_CONIFER_PHENOTYPE = Object.freeze({
       })
     })
   ]),
+  postTreeMeaning: Object.freeze({
+    habitatWeights: Object.freeze({ 'neutral-grove': 2, 'rocky-edge': 5 }),
+    creationSeasonPaletteIds: Object.freeze({
+      spring: 'lichen-tips', summer: 'highland-evergreen', autumn: 'lichen-tips', winter: 'blue-ridge'
+    })
+  }),
   woodPalette: Object.freeze({
     light: '#b49268', mid: '#826348', dark: '#594737', deep: '#3c342e'
   }),

--- a/server/services/forest/v3/rasterizeFoliage.js
+++ b/server/services/forest/v3/rasterizeFoliage.js
@@ -13,10 +13,16 @@ export const FOLIAGE_PALETTE = Object.freeze({
   deep: '#214a35'
 });
 
-export function selectFoliagePalette(phenotype, seed) {
+export function selectFoliagePalette(phenotype, seed, paletteId = null) {
   const variants = phenotype.foliagePalettes;
   if (!variants?.length) {
+    if (paletteId) throw new Error(`Unknown foliage palette: ${paletteId}`);
     return { id: 'default', colors: phenotype.foliagePalette || FOLIAGE_PALETTE };
+  }
+  if (paletteId) {
+    const selected = variants.find(variant => variant.id === paletteId);
+    if (!selected) throw new Error(`Unknown foliage palette for ${phenotype.id}: ${paletteId}`);
+    return selected;
   }
   const totalWeight = variants.reduce((sum, variant) => sum + variant.weight, 0);
   if (!(totalWeight > 0)) throw new Error('Foliage palette weights must total more than zero.');
@@ -425,11 +431,11 @@ function rasterizeLayer(leaves, layer, phenotype, palette, motionGroups) {
   };
 }
 
-export function rasterizeFoliage(graph, phenotype, seed) {
+export function rasterizeFoliage(graph, phenotype, seed, options = {}) {
   if (!FOREST_FOLIAGE_STYLES.includes(phenotype.foliageStyle)) {
     throw new Error(`Unsupported forest foliage style: ${phenotype.foliageStyle}`);
   }
-  const paletteVariant = selectFoliagePalette(phenotype, seed);
+  const paletteVariant = selectFoliagePalette(phenotype, seed, options.paletteId);
   const palette = paletteVariant.colors;
   const { shoots, leaves, coverageCells } = generateLeafBearingShoots(graph, phenotype, seed);
   const motionGroups = assignFoliageMotionGroups(graph, shoots, leaves);

--- a/server/services/forest/v3/treeAsset.js
+++ b/server/services/forest/v3/treeAsset.js
@@ -18,17 +18,27 @@ export function treeAssetCacheKey({
   rendererVersion,
   phenotypeId,
   phenotypeAssetVersion,
-  schemaVersion = FOREST_TREE_ASSET_SCHEMA_VERSION
+  schemaVersion = FOREST_TREE_ASSET_SCHEMA_VERSION,
+  meaningProjection = null
 }) {
   if (!phenotypeId || !Number.isInteger(phenotypeAssetVersion)) {
     throw new Error('Cached tree assets require an explicit phenotype id and asset version.');
+  }
+  if (meaningProjection && (!Number.isInteger(meaningProjection.version)
+    || meaningProjection.version < 1
+    || typeof meaningProjection.visualFingerprint !== 'string'
+    || meaningProjection.visualFingerprint.length > 200
+    || !/^[a-z0-9@._:-]+$/i.test(meaningProjection.visualFingerprint))) {
+    throw new Error('Projected tree assets require a bounded meaning-projection identity.');
   }
   return [
     `tree-asset-v${schemaVersion}`,
     `${FOREST_RENDERER_ID}@${rendererVersion}`,
     `${phenotypeId}@${phenotypeAssetVersion}`,
-    `seed-${seed >>> 0}`
-  ].join(':');
+    `seed-${seed >>> 0}`,
+    meaningProjection
+      ? `meaning-v${meaningProjection.version}-${meaningProjection.visualFingerprint}` : null
+  ].filter(Boolean).join(':');
 }
 
 export function buildForestTreeAsset(generationResult) {
@@ -37,7 +47,8 @@ export function buildForestTreeAsset(generationResult) {
     seed,
     rendererVersion,
     phenotypeId: phenotype.id,
-    phenotypeAssetVersion: phenotype.assetVersion
+    phenotypeAssetVersion: phenotype.assetVersion,
+    meaningProjection: generationResult.meaningProjectionIdentity
   });
   const layers = [
     { id: 'rear-foliage', motionGroups: foliage.backMotionGroups },

--- a/server/services/forestLabTreeCache.js
+++ b/server/services/forestLabTreeCache.js
@@ -1,4 +1,7 @@
-import { generateForestTreeV3 } from './forestTreeGeneratorV3.js';
+import {
+  generateForestTreeV3,
+  generateProjectedForestTreeV3
+} from './forestTreeGeneratorV3.js';
 import { buildForestTreeAsset, treeAssetCacheKey } from './forest/v3/treeAsset.js';
 import {
   DECIDUOUS_PHENOTYPE,
@@ -43,6 +46,25 @@ export function getForestLabTree(post, options = {}) {
     assetVersion: identity.version
   };
   const generation = generateForestTreeV3(post, { ...options, seed, phenotype: identifiedPhenotype });
+  const value = { generation, asset: buildForestTreeAsset(generation) };
+  fixtureCache.set(key, value);
+  return { ...value, cacheHit: false };
+}
+
+export function getForestLabProjectedTree(projection) {
+  const identity = {
+    version: projection.mappingVersion,
+    visualFingerprint: projection.identity.visualFingerprint
+  };
+  const key = treeAssetCacheKey({
+    seed: projection.specimen.seed,
+    rendererVersion: FOREST_RENDERER_VERSION_V3,
+    phenotypeId: projection.phenotype.id,
+    phenotypeAssetVersion: projection.phenotype.version,
+    meaningProjection: identity
+  });
+  if (fixtureCache.has(key)) return { ...fixtureCache.get(key), cacheHit: true };
+  const generation = generateProjectedForestTreeV3(projection);
   const value = { generation, asset: buildForestTreeAsset(generation) };
   fixtureCache.set(key, value);
   return { ...value, cacheHit: false };

--- a/server/services/forestPostTreeFixtures.js
+++ b/server/services/forestPostTreeFixtures.js
@@ -1,0 +1,86 @@
+import { projectPostToForestTree } from './forestPostTreeProjection.js';
+
+const TITLES = Object.freeze([
+  'Coos County at the Edge of the Continent',
+  'Notes from a Summer Thunderstorm',
+  'Why Saturn Has Rings',
+  'A Small Museum of Lost Buttons',
+  'Walking Across Lower Manhattan',
+  'The Mathematics of Honeycombs',
+  'Letter to an Unfamiliar City',
+  'Yalobusha County Field Notes',
+  'The Quiet Work of Repair',
+  'What the Telescope Remembered',
+  'A Recipe Written from Memory',
+  'Gosper County Beneath a Wide Sky',
+  'How Rivers Choose Their Paths',
+  'Three Poems About Streetlights',
+  'A Brief History of Public Benches',
+  'The Physics of Skipping Stones',
+  'Postcard from a Winter Harbor',
+  'On Learning the Names of Birds',
+  'The Last Independent Bookshop',
+  'A Map of Neighborhood Kindness',
+  'Cloud Chambers and Cosmic Rays',
+  'An Orchard at the City Limit',
+  'Notes on Translation and Distance',
+  'The Road Home After Midnight'
+]);
+
+const ROOMS = Object.freeze([
+  'united-states', 'daily-inspiration', 'physics', 'history', 'united-states', 'mathematics'
+]);
+
+const SEMANTICS = Object.freeze([
+  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'neutral-grove',
+    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair A' }),
+  Object.freeze({ id: 'forest-pair-habitat-0', habitat: 'rocky-edge',
+    createdAt: '2025-06-12T00:00:00.000Z', pair: 'Habitat pair B' }),
+  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
+    createdAt: '2025-04-12T00:00:00.000Z', pair: 'Creation-season pair A' }),
+  Object.freeze({ id: 'forest-pair-season', habitat: 'neutral-grove',
+    createdAt: '2025-10-12T00:00:00.000Z', pair: 'Creation-season pair B' }),
+  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
+    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair A', lowActivity: true }),
+  Object.freeze({ id: 'forest-pair-activity', habitat: 'neutral-grove',
+    createdAt: '2025-07-12T00:00:00.000Z', pair: 'Mutable-activity pair B', highActivity: true }),
+  ...Array.from({ length: 18 }, (_, index) => Object.freeze({
+    id: `forest-meaning-fixture-${index + 7}`,
+    habitat: index % 3 === 0 ? 'rocky-edge' : 'neutral-grove',
+    createdAt: new Date(Date.UTC(2024 + (index % 3), index % 12, 7 + index)).toISOString(),
+    pair: null
+  }))
+]);
+
+function roomName(roomId) {
+  return roomId.split('-').map(word => `${word[0].toUpperCase()}${word.slice(1)}`).join(' ');
+}
+
+export function forestPostTreeFixtures() {
+  return TITLES.map((title, index) => {
+    const semantics = SEMANTICS[index];
+    const post = {
+      id: semantics.id,
+      roomId: ROOMS[index % ROOMS.length],
+      createdAt: semantics.createdAt,
+      wordCount: semantics.highActivity ? 8000 : semantics.lowActivity ? 80
+        : 280 + ((index * 347) % 2500),
+      collaboratorCount: semantics.highActivity ? 20 : semantics.lowActivity ? 0
+        : index % 5 === 0 ? 2 : index % 3 === 0 ? 1 : 0,
+      translationCount: semantics.highActivity ? 40 : semantics.lowActivity ? 0 : index % 6,
+      commentCount: semantics.highActivity ? 500 : semantics.lowActivity ? 0 : (index * 3) % 15,
+      reactionCount: semantics.highActivity ? 1000 : semantics.lowActivity ? 0 : (index * 5) % 21,
+      questApproved: semantics.highActivity || (!semantics.lowActivity && index % 4 === 0)
+    };
+    return {
+      fixtureId: `forest-meaning-fixture-${String(index + 1).padStart(2, '0')}`,
+      title,
+      excerpt: 'A fixture post used to explore the visual grammar of a personal writing forest.',
+      pair: semantics.pair,
+      post,
+      context: { habitat: semantics.habitat },
+      roomName: roomName(post.roomId),
+      projection: projectPostToForestTree(post, { habitat: semantics.habitat })
+    };
+  });
+}

--- a/server/services/forestPostTreeProjection.js
+++ b/server/services/forestPostTreeProjection.js
@@ -1,0 +1,160 @@
+import { FOREST_PHENOTYPES } from './forest/v3/phenotype.js';
+import { createRandom, hashSeed } from './forest/v3/random.js';
+
+export const FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION = 1;
+export const FOREST_POST_TREE_MAPPING_VERSION = 1;
+export const FOREST_POST_TREE_HABITATS = Object.freeze(['neutral-grove', 'rocky-edge']);
+
+const POST_FIELDS = Object.freeze([
+  'id', 'createdAt', 'roomId', 'wordCount', 'collaboratorCount', 'translationCount',
+  'commentCount', 'reactionCount', 'questApproved'
+]);
+const CONTEXT_FIELDS = Object.freeze(['habitat']);
+const MUTABLE_COUNTS = Object.freeze([
+  'wordCount', 'collaboratorCount', 'translationCount', 'commentCount', 'reactionCount'
+]);
+
+function exactObject(value, allowedFields, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  const extra = Object.keys(value).filter(field => !allowedFields.includes(field));
+  if (extra.length) throw new Error(`${label} contains unsupported fields: ${extra.join(', ')}.`);
+}
+
+function boundedString(value, field, maximum, { required = false } = {}) {
+  if (value === undefined && !required) return;
+  if (typeof value !== 'string' || !value.length || value.length > maximum) {
+    throw new Error(`${field} must be a non-empty string of at most ${maximum} characters.`);
+  }
+}
+
+function validatePost(post) {
+  exactObject(post, POST_FIELDS, 'Forest post projection input');
+  boundedString(post.id, 'id', 128, { required: true });
+  boundedString(post.roomId, 'roomId', 120);
+  if (post.createdAt !== undefined) {
+    boundedString(post.createdAt, 'createdAt', 32);
+    const parsed = new Date(post.createdAt);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== post.createdAt) {
+      throw new Error('createdAt must be an exact ISO-8601 UTC timestamp.');
+    }
+  }
+  for (const field of MUTABLE_COUNTS) {
+    if (post[field] !== undefined
+      && (!Number.isSafeInteger(post[field]) || post[field] < 0 || post[field] > 1000000)) {
+      throw new Error(`${field} must be a safe integer from 0 through 1000000.`);
+    }
+  }
+  if (post.questApproved !== undefined && typeof post.questApproved !== 'boolean') {
+    throw new Error('questApproved must be boolean when provided.');
+  }
+}
+
+function validateContext(context) {
+  exactObject(context, CONTEXT_FIELDS, 'Forest generation context');
+  if (!FOREST_POST_TREE_HABITATS.includes(context.habitat)) {
+    throw new Error(`habitat must be one of: ${FOREST_POST_TREE_HABITATS.join(', ')}.`);
+  }
+}
+
+function creationSeason(createdAt) {
+  if (createdAt === undefined) return 'unknown';
+  const month = new Date(createdAt).getUTCMonth();
+  if (month >= 2 && month <= 4) return 'spring';
+  if (month >= 5 && month <= 7) return 'summer';
+  if (month >= 8 && month <= 10) return 'autumn';
+  return 'winter';
+}
+
+function canonicalPhenotypes(phenotypes, habitat) {
+  if (!Array.isArray(phenotypes) || !phenotypes.length) {
+    throw new Error('Forest post projection requires registered phenotypes.');
+  }
+  const ordered = phenotypes.slice().sort((first, second) => first.id.localeCompare(second.id));
+  if (new Set(ordered.map(({ id }) => id)).size !== ordered.length) {
+    throw new Error('Forest post projection phenotype ids must be unique.');
+  }
+  for (const phenotype of ordered) {
+    if (typeof phenotype.id !== 'string' || !Number.isInteger(phenotype.assetVersion)
+      || !(phenotype.postTreeMeaning?.habitatWeights?.[habitat] > 0)) {
+      throw new Error(`Phenotype ${phenotype.id || '(unknown)'} has no bounded ${habitat} meaning.`);
+    }
+  }
+  return ordered;
+}
+
+export function selectForestPostTreePhenotype(postId, habitat, phenotypes = FOREST_PHENOTYPES) {
+  const ordered = canonicalPhenotypes(phenotypes, habitat);
+  const total = ordered.reduce((sum, phenotype) => (
+    sum + phenotype.postTreeMeaning.habitatWeights[habitat]
+  ), 0);
+  let choice = createRandom(hashSeed([
+    `forest-post-tree-mapping-v${FOREST_POST_TREE_MAPPING_VERSION}`,
+    'phenotype', postId, habitat
+  ].join(':')))() * total;
+  for (const phenotype of ordered) {
+    choice -= phenotype.postTreeMeaning.habitatWeights[habitat];
+    if (choice < 0) return phenotype;
+  }
+  return ordered.at(-1);
+}
+
+function explanationForSeason(season) {
+  if (season === 'unknown') {
+    return 'No creation timestamp was supplied, so the specimen kept its seed-selected natural tint.';
+  }
+  return `${season[0].toUpperCase()}${season.slice(1)} creation left a restrained permanent foliage tint.`;
+}
+
+function fingerprint(parts) {
+  return parts.join(':');
+}
+
+export function projectPostToForestTree(post, context) {
+  validatePost(post);
+  validateContext(context);
+  const phenotype = selectForestPostTreePhenotype(post.id, context.habitat);
+  const seed = hashSeed([
+    `forest-post-tree-mapping-v${FOREST_POST_TREE_MAPPING_VERSION}`, 'specimen', post.id
+  ].join(':'));
+  const season = creationSeason(post.createdAt);
+  const foliagePaletteId = season === 'unknown' ? null
+    : phenotype.postTreeMeaning.creationSeasonPaletteIds[season];
+  if (foliagePaletteId !== null
+    && !phenotype.foliagePalettes.some(({ id }) => id === foliagePaletteId)) {
+    throw new Error(`Phenotype ${phenotype.id} does not own palette ${foliagePaletteId}.`);
+  }
+  const visualFingerprint = fingerprint([
+    `mapping-v${FOREST_POST_TREE_MAPPING_VERSION}`,
+    foliagePaletteId ? `foliage-${foliagePaletteId}` : 'foliage-seed-selected'
+  ]);
+  const projectionFingerprint = fingerprint([
+    visualFingerprint, `seed-${seed}`, `${phenotype.id}@${phenotype.assetVersion}`,
+    `habitat-${context.habitat}`, `season-${season}`
+  ]);
+
+  return {
+    schemaVersion: FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION,
+    mappingVersion: FOREST_POST_TREE_MAPPING_VERSION,
+    specimen: { seed, source: 'stable-writing-identity' },
+    phenotype: { id: phenotype.id, version: phenotype.assetVersion },
+    habitat: { id: context.habitat, influence: 'soft-bias' },
+    permanentTraits: { creationSeason: season, foliagePaletteId },
+    surroundings: {},
+    explanations: [
+      {
+        token: 'stable-writing-identity',
+        text: 'Stable writing identity selected this specimen seed.'
+      },
+      {
+        token: 'habitat-soft-bias',
+        text: context.habitat === 'rocky-edge'
+          ? 'Rocky-edge habitat favored highland forms without requiring one species.'
+          : 'Neutral-grove habitat softly favored familiar grove forms without excluding any species.'
+      },
+      { token: 'creation-season-tint', text: explanationForSeason(season) }
+    ],
+    identity: { projectionFingerprint, visualFingerprint }
+  };
+}

--- a/server/services/forestProjectedScene.js
+++ b/server/services/forestProjectedScene.js
@@ -1,0 +1,65 @@
+import { FOREST_RENDERER_VERSION_V3 } from './forestTreeGeneratorV3.js';
+import { forestPostTreeFixtures } from './forestPostTreeFixtures.js';
+import { treeAssetCacheKey } from './forest/v3/treeAsset.js';
+
+function assetKeyForProjection(projection) {
+  return treeAssetCacheKey({
+    seed: projection.specimen.seed,
+    rendererVersion: FOREST_RENDERER_VERSION_V3,
+    phenotypeId: projection.phenotype.id,
+    phenotypeAssetVersion: projection.phenotype.version,
+    meaningProjection: {
+      version: projection.mappingVersion,
+      visualFingerprint: projection.identity.visualFingerprint
+    }
+  });
+}
+
+function writingFixture(fixture) {
+  const { projection } = fixture;
+  return {
+    id: fixture.fixtureId,
+    title: fixture.title,
+    roomName: fixture.roomName,
+    createdAt: fixture.post.createdAt.slice(0, 10),
+    excerpt: fixture.excerpt,
+    treeMeaning: {
+      mappingVersion: projection.mappingVersion,
+      specimenSeed: projection.specimen.seed,
+      phenotypeId: projection.phenotype.id,
+      habitat: projection.habitat.id,
+      creationSeason: projection.permanentTraits.creationSeason,
+      foliagePaletteId: projection.permanentTraits.foliagePaletteId,
+      explanations: projection.explanations.map(({ token, text }) => ({ token, text }))
+    }
+  };
+}
+
+export function composeProjectedForestScene(
+  baseLayout,
+  fixtures = forestPostTreeFixtures()
+) {
+  if (!baseLayout?.placements?.length || !Array.isArray(fixtures) || !fixtures.length) {
+    throw new Error('Projected forest scenes require placements and semantic fixtures.');
+  }
+  const assetProjections = new Map();
+  const placements = baseLayout.placements.map((placement, index) => {
+    const fixture = fixtures[index % fixtures.length];
+    const { projection } = fixture;
+    const assetKey = assetKeyForProjection(projection);
+    if (!assetProjections.has(assetKey)) assetProjections.set(assetKey, projection);
+    return {
+      ...placement,
+      phenotypeId: projection.phenotype.id,
+      treeSeed: projection.specimen.seed,
+      assetKey,
+      fixtureId: fixture.fixtureId
+    };
+  });
+
+  return {
+    layout: { ...baseLayout, placements },
+    assetProjections,
+    fixtures: fixtures.map(writingFixture)
+  };
+}

--- a/server/services/forestSceneAssetPool.js
+++ b/server/services/forestSceneAssetPool.js
@@ -1,6 +1,9 @@
 import { performance } from 'node:perf_hooks';
 
-import { generateForestTreeAssetV3 } from './forestTreeGeneratorV3.js';
+import {
+  generateForestTreeAssetV3,
+  generateProjectedForestTreeAssetV3
+} from './forestTreeGeneratorV3.js';
 import {
   resolveForestPhenotype
 } from './forest/v3/phenotype.js';
@@ -16,7 +19,7 @@ export function forestSceneAssetPoolSize() {
   return sceneAssetCache.size;
 }
 
-export function prepareForestSceneAssets(placements) {
+export function prepareForestSceneAssets(placements, assetProjections = new Map()) {
   const startedAt = performance.now();
   const assets = [];
   const required = new Map(placements.map((placement) => [placement.assetKey, placement]));
@@ -28,10 +31,13 @@ export function prepareForestSceneAssets(placements) {
       const generationStartedAt = performance.now();
       const phenotype = resolveForestPhenotype(placement.phenotypeId);
       if (!phenotype) throw new Error(`Unknown forest phenotype: ${placement.phenotypeId}`);
-      const asset = generateForestTreeAssetV3(
-        { id: `forest-scene-specimen-${placement.treeSeed}` },
-        { seed: placement.treeSeed, phenotype }
-      );
+      const projection = assetProjections.get(assetKey);
+      const asset = projection
+        ? generateProjectedForestTreeAssetV3(projection)
+        : generateForestTreeAssetV3(
+          { id: `forest-scene-specimen-${placement.treeSeed}` },
+          { seed: placement.treeSeed, phenotype }
+        );
       if (asset.cacheKey !== assetKey) throw new Error('Prepared tree asset identity mismatch.');
       sceneAssetCache.set(assetKey, asset);
       generatedAssetCount += 1;
@@ -52,9 +58,11 @@ export function prepareForestSceneAssets(placements) {
   };
 }
 
-export function prepareForestSceneWithDiagnostics(layout) {
+export function prepareForestSceneWithDiagnostics(layout, assetProjections = new Map()) {
   const startedAt = performance.now();
-  const { assets, diagnostics } = prepareForestSceneAssets(layout.placements);
+  const { assets, diagnostics } = prepareForestSceneAssets(
+    layout.placements, assetProjections
+  );
   const scene = JSON.parse(JSON.stringify({ ...layout, assets }));
   return {
     scene,
@@ -65,6 +73,6 @@ export function prepareForestSceneWithDiagnostics(layout) {
   };
 }
 
-export function prepareForestScene(layout) {
-  return prepareForestSceneWithDiagnostics(layout).scene;
+export function prepareForestScene(layout, assetProjections = new Map()) {
+  return prepareForestSceneWithDiagnostics(layout, assetProjections).scene;
 }

--- a/server/services/forestSceneExploration.js
+++ b/server/services/forestSceneExploration.js
@@ -29,7 +29,7 @@ export function forestPlacementCollisionRadius(placement) {
   return traits.collisionRadius * placement.scale;
 }
 
-export function createForestExploration(scene) {
+export function createForestExploration(scene, options = {}) {
   const spawn = {
     worldX: Math.round(forestCorridorCenter(scene.world.height - 180, scene.world.width)),
     worldY: scene.world.height - 180,
@@ -37,12 +37,21 @@ export function createForestExploration(scene) {
     facing: 'down',
     movementSpeed: FOREST_PLAYER_SPEED
   };
-  const fixtures = FIXTURES.map((fixture) => ({ ...fixture }));
+  const customFixtures = Array.isArray(options.fixtures);
+  const fixtures = customFixtures
+    ? JSON.parse(JSON.stringify(options.fixtures))
+    : FIXTURES.map((fixture) => ({ ...fixture }));
+  const fixtureIds = new Set(fixtures.map(({ id }) => id));
   const placements = scene.placements.map((placement) => ({
     ...placement,
     collisionRadius: forestPlacementCollisionRadius(placement),
-    fixtureId: fixtures[hashSeed(`forest-fixture:${placement.id}`) % fixtures.length].id
+    fixtureId: customFixtures
+      ? placement.fixtureId
+      : fixtures[hashSeed(`forest-fixture:${placement.id}`) % fixtures.length].id
   }));
+  if (!fixtures.length || placements.some(({ fixtureId }) => !fixtureIds.has(fixtureId))) {
+    throw new Error('Forest exploration placements require known fixture identities.');
+  }
 
   return {
     ...scene,

--- a/server/services/forestScenePressure.js
+++ b/server/services/forestScenePressure.js
@@ -28,6 +28,14 @@ export const FOREST_PRESSURE_PROFILES = Object.freeze([
     })
   }),
   Object.freeze({
+    id: 'post-tree-meaning',
+    label: 'Projected writing grove',
+    description: '180 placements cycle through the 24 meaning-contract fixtures and 23 assets.',
+    pressure: false,
+    projectedWriting: true,
+    layout: Object.freeze({ seed: 'projected-writing-grove', assetPoolSize: 24 })
+  }),
+  Object.freeze({
     id: 'asset-variety',
     label: 'Asset variety',
     description: '180 placements sharing 60 assets.',

--- a/server/services/forestTreeGeneratorV3.js
+++ b/server/services/forestTreeGeneratorV3.js
@@ -1,10 +1,14 @@
 import { growBranchGraph } from './forest/v3/growth.js';
 import { analyzeBranchGraph } from './forest/v3/graphDiagnostics.js';
-import { DECIDUOUS_PHENOTYPE } from './forest/v3/phenotype.js';
+import { DECIDUOUS_PHENOTYPE, resolveForestPhenotype } from './forest/v3/phenotype.js';
 import { hashSeed } from './forest/v3/random.js';
 import { rasterizeFoliage } from './forest/v3/rasterizeFoliage.js';
 import { rasterizeWood } from './forest/v3/rasterizeWood.js';
 import { buildForestTreeAsset } from './forest/v3/treeAsset.js';
+import {
+  FOREST_POST_TREE_MAPPING_VERSION,
+  FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION
+} from './forestPostTreeProjection.js';
 
 // Version 4 adds bounded height-density and foliage-shape vocabulary. Asset schema remains v2.
 export const FOREST_RENDERER_VERSION_V3 = 4;
@@ -18,6 +22,7 @@ export function generateForestTreeGraph(post, options = {}) {
     rendererVersion: FOREST_RENDERER_VERSION_V3,
     seed: seed >>> 0,
     phenotype,
+    meaningProjectionIdentity: options.meaningProjectionIdentity || null,
     ...graph,
     diagnostics: analyzeBranchGraph(graph, phenotype)
   };
@@ -28,10 +33,56 @@ export function generateForestTreeV3(post, options = {}) {
   return {
     ...graph,
     wood: rasterizeWood(graph, graph.phenotype, graph.seed),
-    foliage: rasterizeFoliage(graph, graph.phenotype, graph.seed)
+    foliage: rasterizeFoliage(graph, graph.phenotype, graph.seed, {
+      paletteId: options.foliagePaletteId
+    })
   };
 }
 
 export function generateForestTreeAssetV3(post, options = {}) {
   return buildForestTreeAsset(generateForestTreeV3(post, options));
+}
+
+function optionsForProjection(projection) {
+  if (projection?.schemaVersion !== FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION
+    || projection?.mappingVersion !== FOREST_POST_TREE_MAPPING_VERSION) {
+    throw new Error('Unsupported forest post-tree projection version.');
+  }
+  const phenotype = resolveForestPhenotype(projection.phenotype?.id);
+  if (!phenotype || phenotype.assetVersion !== projection.phenotype.version) {
+    throw new Error('Forest post-tree projection references an unknown phenotype identity.');
+  }
+  const paletteId = projection.permanentTraits?.foliagePaletteId;
+  if (paletteId !== null && !phenotype.foliagePalettes.some(({ id }) => id === paletteId)) {
+    throw new Error('Forest post-tree projection references an unknown foliage palette.');
+  }
+  const expectedVisualFingerprint = [
+    `mapping-v${projection.mappingVersion}`,
+    paletteId ? `foliage-${paletteId}` : 'foliage-seed-selected'
+  ].join(':');
+  if (!Number.isInteger(projection.specimen?.seed) || projection.specimen.seed < 0
+    || projection.specimen.seed > 0xFFFFFFFF
+    || projection.identity?.visualFingerprint !== expectedVisualFingerprint) {
+    throw new Error('Forest post-tree projection has an invalid visual identity.');
+  }
+  return {
+    seed: projection.specimen.seed,
+    phenotype,
+    foliagePaletteId: paletteId,
+    meaningProjectionIdentity: {
+      version: projection.mappingVersion,
+      visualFingerprint: projection.identity.visualFingerprint
+    }
+  };
+}
+
+export function generateProjectedForestTreeV3(projection) {
+  return generateForestTreeV3(
+    { id: `projected-specimen-${projection?.specimen?.seed}` },
+    optionsForProjection(projection)
+  );
+}
+
+export function generateProjectedForestTreeAssetV3(projection) {
+  return buildForestTreeAsset(generateProjectedForestTreeV3(projection));
 }

--- a/spec/forestPostTreeProjectionSpec.js
+++ b/spec/forestPostTreeProjectionSpec.js
@@ -1,0 +1,279 @@
+import {
+  FOREST_POST_TREE_MAPPING_VERSION,
+  FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION,
+  projectPostToForestTree,
+  selectForestPostTreePhenotype
+} from '../server/services/forestPostTreeProjection.js';
+import {
+  generateProjectedForestTreeAssetV3,
+  generateProjectedForestTreeV3
+} from '../server/services/forestTreeGeneratorV3.js';
+import { FOREST_PHENOTYPES } from '../server/services/forest/v3/phenotype.js';
+import {
+  FOREST_TREE_ASSET_SCHEMA_VERSION,
+  treeAssetCacheKey
+} from '../server/services/forest/v3/treeAsset.js';
+import {
+  clearForestLabTreeCache,
+  getForestLabProjectedTree
+} from '../server/services/forestLabTreeCache.js';
+import {
+  encodeForestSceneAssets,
+  FOREST_ASSET_TRANSPORT_RASTER,
+  FOREST_ASSET_TRANSPORT_RUNS
+} from '../server/services/forestSceneAssetTransport.js';
+import { forestFixtures, projectForestLabFixture } from '../server/routes/devViews.js';
+
+describe('forest post-to-tree meaning projection', () => {
+  const post = Object.freeze({
+    id: 'meaning-contract-post',
+    roomId: 'physics',
+    createdAt: '2025-10-12T00:00:00.000Z',
+    wordCount: 1200,
+    collaboratorCount: 2,
+    translationCount: 1,
+    commentCount: 6,
+    reactionCount: 8,
+    questApproved: true
+  });
+  const context = Object.freeze({ habitat: 'neutral-grove' });
+
+  beforeEach(() => clearForestLabTreeCache());
+
+  it('is explicit, deterministic, bounded, and exactly JSON serializable', () => {
+    const first = projectPostToForestTree(post, context);
+    const repeated = projectPostToForestTree({ ...post }, { ...context });
+
+    expect(first).toEqual(repeated);
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+    expect(first.schemaVersion).toBe(FOREST_POST_TREE_PROJECTION_SCHEMA_VERSION);
+    expect(first.mappingVersion).toBe(FOREST_POST_TREE_MAPPING_VERSION);
+    expect(first.specimen.seed).toEqual(jasmine.any(Number));
+    expect(first.phenotype).toEqual(jasmine.objectContaining({
+      id: jasmine.any(String), version: jasmine.any(Number)
+    }));
+    expect(first.permanentTraits).toEqual({
+      creationSeason: 'autumn', foliagePaletteId: jasmine.any(String)
+    });
+    expect(first.explanations.map(({ token }) => token)).toEqual([
+      'stable-writing-identity', 'habitat-soft-bias', 'creation-season-tint'
+    ]);
+    expect(JSON.stringify(first)).not.toContain(post.id);
+    expect(JSON.stringify(first)).not.toContain(post.roomId);
+    expect(JSON.stringify(first)).not.toContain('1200');
+  });
+
+  it('uses a deterministic documented fallback when creation metadata is missing', () => {
+    const projection = projectPostToForestTree({ id: post.id }, context);
+    const tree = generateProjectedForestTreeV3(projection);
+
+    expect(projection.permanentTraits).toEqual({
+      creationSeason: 'unknown', foliagePaletteId: null
+    });
+    expect(tree.foliage.paletteId).toEqual(jasmine.any(String));
+    expect(projection.explanations.at(-1).text).toContain('seed-selected natural tint');
+  });
+
+  it('rejects unknown fields, malformed values, unsafe numbers, and unknown context', () => {
+    for (const invalid of [
+      { ...post, title: 'Raw post content' },
+      { ...post, id: 'x'.repeat(129) },
+      { ...post, createdAt: 'October 12, 2025' },
+      { ...post, commentCount: -1 },
+      { ...post, reactionCount: Number.MAX_SAFE_INTEGER },
+      { ...post, questApproved: 1 }
+    ]) expect(() => projectPostToForestTree(invalid, context)).toThrow();
+    expect(() => projectPostToForestTree(post, { habitat: 'alpine-biome' })).toThrow();
+    expect(() => projectPostToForestTree(post, { habitat: 'neutral-grove', weather: 'rain' }))
+      .toThrow();
+    expect(() => projectPostToForestTree(post, {
+      habitat: 'neutral-grove', overlay: { marker: true }
+    })).toThrow();
+  });
+
+  it('derives specimen identity only from stable post identity and mapping version', () => {
+    const base = projectPostToForestTree(post, context);
+    const changedMetadata = projectPostToForestTree({
+      ...post,
+      roomId: 'history',
+      wordCount: 900000,
+      collaboratorCount: 100,
+      translationCount: 100,
+      commentCount: 1000000,
+      reactionCount: 1000000,
+      questApproved: false
+    }, context);
+    const otherPost = projectPostToForestTree({ ...post, id: 'meaning-contract-post-2' }, context);
+
+    expect(changedMetadata).toEqual(base);
+    expect(otherPost.specimen.seed).not.toBe(base.specimen.seed);
+    expect(generateProjectedForestTreeAssetV3(changedMetadata))
+      .toEqual(generateProjectedForestTreeAssetV3(base));
+  });
+
+  it('selects through the canonical registry independently of registry order', () => {
+    const selected = selectForestPostTreePhenotype(post.id, context.habitat);
+    const reversed = selectForestPostTreePhenotype(
+      post.id, context.habitat, FOREST_PHENOTYPES.slice().reverse()
+    );
+
+    expect(reversed).toBe(selected);
+    expect(FOREST_PHENOTYPES).toContain(selected);
+  });
+
+  it('softly biases habitats while retaining every registered phenotype', () => {
+    const ids = Array.from({ length: 1200 }, (_, index) => `distribution-post-${index}`);
+    const count = habitat => Object.fromEntries(FOREST_PHENOTYPES.map(phenotype => [
+      phenotype.id,
+      ids.filter(id => selectForestPostTreePhenotype(id, habitat).id === phenotype.id).length
+    ]));
+    const neutral = count('neutral-grove');
+    const rocky = count('rocky-edge');
+
+    expect(Object.values(neutral).every(value => value > 100)).toBeTrue();
+    expect(Object.values(rocky).every(value => value > 100)).toBeTrue();
+    expect(rocky['wind-shaped-highland-conifer'])
+      .toBeGreaterThan(neutral['wind-shaped-highland-conifer']);
+    expect(neutral['open-crown-deciduous']).toBeGreaterThan(rocky['open-crown-deciduous']);
+  });
+
+  it('keeps one controlled creation-season change inside phenotype-owned palette bounds', () => {
+    const spring = projectPostToForestTree({
+      ...post, createdAt: '2025-04-12T00:00:00.000Z'
+    }, context);
+    const autumn = projectPostToForestTree({
+      ...post, createdAt: '2025-10-12T00:00:00.000Z'
+    }, context);
+    const springTree = generateProjectedForestTreeV3(spring);
+    const autumnTree = generateProjectedForestTreeV3(autumn);
+    const phenotype = FOREST_PHENOTYPES.find(({ id }) => id === spring.phenotype.id);
+
+    expect(autumn.specimen).toEqual(spring.specimen);
+    expect(autumn.phenotype).toEqual(spring.phenotype);
+    expect(autumnTree.nodes).toEqual(springTree.nodes);
+    expect(autumnTree.architecture).toEqual(springTree.architecture);
+    expect(autumnTree.foliage.paletteId).not.toBe(springTree.foliage.paletteId);
+    expect(phenotype.foliagePalettes.map(({ id }) => id)).toContain(springTree.foliage.paletteId);
+    expect(phenotype.foliagePalettes.map(({ id }) => id)).toContain(autumnTree.foliage.paletteId);
+    expect(generateProjectedForestTreeAssetV3(autumn).cacheKey)
+      .not.toBe(generateProjectedForestTreeAssetV3(spring).cacheKey);
+  });
+
+  it('separates cache identity for visual decisions but not explanation-only differences', () => {
+    const neutral = projectPostToForestTree({
+      ...post, id: 'forest-pair-habitat'
+    }, { habitat: 'neutral-grove' });
+    const rocky = projectPostToForestTree({
+      ...post, id: 'forest-pair-habitat'
+    }, { habitat: 'rocky-edge' });
+    expect(rocky.phenotype).toEqual(neutral.phenotype);
+    expect(rocky.identity.projectionFingerprint).not.toBe(
+      neutral.identity.projectionFingerprint
+    );
+    expect(generateProjectedForestTreeAssetV3(rocky).cacheKey)
+      .toBe(generateProjectedForestTreeAssetV3(neutral).cacheKey);
+
+    const identity = {
+      seed: neutral.specimen.seed,
+      rendererVersion: 4,
+      phenotypeId: neutral.phenotype.id,
+      phenotypeAssetVersion: neutral.phenotype.version,
+      meaningProjection: { version: 1, visualFingerprint: 'mapping-v1:foliage-test' }
+    };
+    expect(treeAssetCacheKey({ ...identity, meaningProjection: {
+      ...identity.meaningProjection, version: 2
+    } })).not.toBe(treeAssetCacheKey(identity));
+  });
+
+  it('rejects a projected visual decision that does not match its fingerprint', () => {
+    const projection = projectPostToForestTree(post, context);
+    const phenotype = FOREST_PHENOTYPES.find(({ id }) => id === projection.phenotype.id);
+    const otherPalette = phenotype.foliagePalettes.find(
+      ({ id }) => id !== projection.permanentTraits.foliagePaletteId
+    ).id;
+    const tampered = {
+      ...projection,
+      permanentTraits: { ...projection.permanentTraits, foliagePaletteId: otherPalette }
+    };
+
+    expect(() => generateProjectedForestTreeAssetV3(tampered))
+      .toThrowError('Forest post-tree projection has an invalid visual identity.');
+  });
+
+  it('keeps projection details and raw post metadata out of runtime assets', () => {
+    const projection = projectPostToForestTree(post, context);
+    const asset = generateProjectedForestTreeAssetV3(projection);
+    const serialized = JSON.stringify(asset);
+
+    expect(asset.schemaVersion).toBe(FOREST_TREE_ASSET_SCHEMA_VERSION);
+    expect(asset.layers.map(({ id }) => id)).toEqual([
+      'rear-foliage', 'wood', 'front-foliage'
+    ]);
+    expect(serialized).not.toContain('explanations');
+    expect(serialized).not.toContain('roomId');
+    expect(serialized).not.toContain(post.id);
+    expect(serialized).not.toContain(post.roomId);
+    expect(asset.layers.filter(layer => layer.motionGroups)
+      .every(layer => layer.motionGroups.length <= 3)).toBeTrue();
+  });
+
+  it('reuses projected Lab assets by complete visual identity', () => {
+    const firstProjection = projectPostToForestTree(post, context);
+    const repeatedProjection = projectPostToForestTree({ ...post, reactionCount: 999 }, context);
+    const first = getForestLabProjectedTree(firstProjection);
+    const repeated = getForestLabProjectedTree(repeatedProjection);
+
+    expect(first.cacheHit).toBeFalse();
+    expect(repeated.cacheHit).toBeTrue();
+    expect(repeated.asset).toBe(first.asset);
+  });
+
+  it('preserves projected runtime identity through both transports', async () => {
+    const asset = generateProjectedForestTreeAssetV3(
+      projectPostToForestTree(post, context)
+    );
+    const runs = await encodeForestSceneAssets([asset], FOREST_ASSET_TRANSPORT_RUNS);
+    const raster = await encodeForestSceneAssets([asset], FOREST_ASSET_TRANSPORT_RASTER);
+
+    expect(runs.assets[0]).toEqual(asset);
+    expect(raster.assets[0].cacheKey).toBe(asset.cacheKey);
+    expect(raster.assets[0].phenotype).toEqual(asset.phenotype);
+    expect(raster.assets[0].layers.map(({ id }) => id)).toEqual(
+      asset.layers.map(({ id }) => id)
+    );
+  });
+
+  it('provides balanced explainable Lab fixtures and three controlled pairs', () => {
+    const fixtures = forestFixtures();
+    const counts = Object.fromEntries(FOREST_PHENOTYPES.map(phenotype => [
+      phenotype.id, fixtures.filter(item => item.projection.phenotype.id === phenotype.id).length
+    ]));
+    const paired = label => fixtures.filter(({ pair }) => pair?.startsWith(label));
+    const habitat = paired('Habitat pair');
+    const season = paired('Creation-season pair');
+    const activity = paired('Mutable-activity pair');
+
+    expect(counts).toEqual({
+      'open-crown-deciduous': 8,
+      'sunset-lanternwood': 8,
+      'wind-shaped-highland-conifer': 8
+    });
+    expect(fixtures.every(item => item.projection.explanations.length === 3)).toBeTrue();
+    expect(habitat[0].projection.specimen).toEqual(habitat[1].projection.specimen);
+    expect(habitat[0].projection.phenotype).not.toEqual(habitat[1].projection.phenotype);
+    expect(season[0].tree.nodes).toEqual(season[1].tree.nodes);
+    expect(season[0].tree.foliage.paletteId).not.toBe(season[1].tree.foliage.paletteId);
+    expect(activity[0].projection).toEqual(activity[1].projection);
+    expect(activity[0].asset).toBe(activity[1].asset);
+  });
+
+  it('retains bounded diagnostics for an invalid Lab fixture', () => {
+    const invalid = projectForestLabFixture(post, { habitat: 'unknown-habitat' });
+
+    expect(invalid.projection).toBeNull();
+    expect(invalid.tree).toBeNull();
+    expect(invalid.asset).toBeNull();
+    expect(invalid.projectionError).toContain('habitat must be one of');
+    expect(invalid.projectionError).not.toContain(post.id);
+  });
+});

--- a/spec/forestProjectedSceneSpec.js
+++ b/spec/forestProjectedSceneSpec.js
@@ -1,0 +1,158 @@
+import { forestPostTreeFixtures } from '../server/services/forestPostTreeFixtures.js';
+import { composeProjectedForestScene } from '../server/services/forestProjectedScene.js';
+import {
+  clearForestSceneAssetPool,
+  forestSceneAssetPoolSize,
+  prepareForestSceneAssets
+} from '../server/services/forestSceneAssetPool.js';
+import { createForestExploration } from '../server/services/forestSceneExploration.js';
+import { generateForestSceneLayout } from '../server/services/forestSceneLayout.js';
+import {
+  encodeForestSceneAssets,
+  FOREST_ASSET_TRANSPORT_RASTER,
+  FOREST_ASSET_TRANSPORT_RUNS
+} from '../server/services/forestSceneAssetTransport.js';
+import { resolveForestPressureProfile } from '../server/services/forestScenePressure.js';
+
+describe('projected-writing Activity Forest scene', () => {
+  function projectedScene() {
+    const profile = resolveForestPressureProfile('post-tree-meaning');
+    const projected = composeProjectedForestScene(generateForestSceneLayout(profile.layout));
+    return {
+      ...projected,
+      scene: createForestExploration(projected.layout, { fixtures: projected.fixtures })
+    };
+  }
+
+  beforeEach(() => clearForestSceneAssetPool());
+
+  it('defines an explicit semantic profile without changing default scene generation', () => {
+    const before = generateForestSceneLayout();
+    const profile = resolveForestPressureProfile('post-tree-meaning');
+    const projected = projectedScene();
+    const after = generateForestSceneLayout();
+
+    expect(profile.projectedWriting).toBeTrue();
+    expect(profile.pressure).toBeFalse();
+    expect(projected.scene.placements.length).toBe(180);
+    expect(after).toEqual(before);
+    expect(before.placements.some(({ assetKey }) => assetKey.includes('meaning-v'))).toBeFalse();
+  });
+
+  it('cycles 24 inspectable fixtures through a bounded 23-asset semantic pool', () => {
+    const { scene, assetProjections } = projectedScene();
+    const fixtureCounts = Object.fromEntries(scene.exploration.fixtures.map(({ id }) => [
+      id, scene.placements.filter(({ fixtureId }) => fixtureId === id).length
+    ]));
+
+    expect(scene.exploration.fixtures.length).toBe(24);
+    expect(assetProjections.size).toBe(23);
+    expect(new Set(scene.placements.map(({ assetKey }) => assetKey)).size).toBe(23);
+    expect(Math.min(...Object.values(fixtureCounts))).toBe(7);
+    expect(Math.max(...Object.values(fixtureCounts))).toBe(8);
+    expect(new Set(scene.placements.map(({ phenotypeId }) => phenotypeId))).toEqual(new Set([
+      'open-crown-deciduous',
+      'sunset-lanternwood',
+      'wind-shaped-highland-conifer'
+    ]));
+  });
+
+  it('keeps semantic fixture assignment aligned with projected asset identity', () => {
+    const fixtures = forestPostTreeFixtures();
+    const byId = new Map(fixtures.map(fixture => [fixture.fixtureId, fixture]));
+    const { scene } = projectedScene();
+
+    for (const placement of scene.placements) {
+      const projection = byId.get(placement.fixtureId).projection;
+      expect(placement.treeSeed).toBe(projection.specimen.seed);
+      expect(placement.phenotypeId).toBe(projection.phenotype.id);
+      expect(placement.assetKey).toContain(
+        `meaning-v${projection.mappingVersion}-${projection.identity.visualFingerprint}`
+      );
+    }
+  });
+
+  it('sends only placement identity and bounded inspection meaning, never projection inputs', () => {
+    const { scene } = projectedScene();
+    const serializedPlacements = JSON.stringify(scene.placements);
+    const serializedFixtures = JSON.stringify(scene.exploration.fixtures);
+    const meaning = scene.exploration.fixtures[0].treeMeaning;
+
+    for (const excluded of [
+      'habitat', 'createdAt', 'wordCount', 'collaboratorCount', 'translationCount',
+      'commentCount', 'reactionCount', 'questApproved', 'explanations'
+    ]) expect(serializedPlacements).not.toContain(`"${excluded}"`);
+    for (const excluded of [
+      'wordCount', 'collaboratorCount', 'translationCount', 'commentCount',
+      'reactionCount', 'questApproved', 'projectionFingerprint', 'visualFingerprint'
+    ]) expect(serializedFixtures).not.toContain(`"${excluded}"`);
+    expect(meaning).toEqual(jasmine.objectContaining({
+      mappingVersion: 1,
+      specimenSeed: jasmine.any(Number),
+      phenotypeId: jasmine.any(String),
+      habitat: jasmine.any(String),
+      creationSeason: jasmine.any(String),
+      explanations: jasmine.any(Array)
+    }));
+    expect(meaning.explanations.every(({ token, text }) => token && text)).toBeTrue();
+  });
+
+  it('prepares and reuses projected assets through the normal bounded scene pool', () => {
+    const { scene, assetProjections } = projectedScene();
+    const cold = prepareForestSceneAssets(scene.placements, assetProjections);
+    const warm = prepareForestSceneAssets(scene.placements, assetProjections);
+
+    expect(cold.assets.length).toBe(23);
+    expect(cold.diagnostics.generatedAssetCount).toBe(23);
+    expect(warm.diagnostics.generatedAssetCount).toBe(0);
+    expect(warm.diagnostics.reusedAssetCount).toBe(23);
+    expect(forestSceneAssetPoolSize()).toBe(23);
+    expect(cold.assets.every(asset => asset.cacheKey.includes('meaning-v1'))).toBeTrue();
+    expect(cold.assets.every(asset => asset.layers.map(({ id }) => id).join(',')
+      === 'rear-foliage,wood,front-foliage')).toBeTrue();
+    expect(cold.assets.every(asset => asset.layers.filter(layer => layer.motionGroups)
+      .every(layer => layer.motionGroups.length <= 3))).toBeTrue();
+  });
+
+  it('preserves projected identity through both scene transports', async () => {
+    const { scene, assetProjections } = projectedScene();
+    const assets = prepareForestSceneAssets(scene.placements.slice(0, 2), assetProjections).assets;
+    const runs = await encodeForestSceneAssets(assets, FOREST_ASSET_TRANSPORT_RUNS);
+    const rasters = await encodeForestSceneAssets(assets, FOREST_ASSET_TRANSPORT_RASTER);
+
+    expect(runs.assets).toEqual(assets);
+    expect(rasters.assets.map(({ cacheKey }) => cacheKey))
+      .toEqual(assets.map(({ cacheKey }) => cacheKey));
+    expect(rasters.assets.every(asset => asset.layers.map(({ id }) => id).join(',')
+      === 'rear-foliage,wood,front-foliage')).toBeTrue();
+  });
+
+  it('provides a bounded accessible inspection surface for tree meaning', () => {
+    const viewPath = 'views/dev/activity-forest.pug';
+    const view = fs.readFileSync(viewPath, 'utf8');
+    const script = fs.readFileSync('public/js/activity-forest.js', 'utf8');
+
+    expect(() => pug.compileFile(viewPath)).not.toThrow();
+    for (const field of [
+      'data-forest-tree-meaning', 'data-forest-meaning-phenotype',
+      'data-forest-meaning-seed', 'data-forest-meaning-habitat',
+      'data-forest-meaning-tint', 'data-forest-meaning-reasons'
+    ]) expect(view).toContain(field);
+    expect(script).toContain('meaningSurface.hidden = !meaning');
+    expect(script).toContain("meaning.habitat.replaceAll('-', ' ')");
+    expect(script).not.toContain("`${meaning.habitat} · soft bias`");
+    expect(script).toContain('item.textContent = explanation.text');
+    expect(script).not.toContain('explanation.innerHTML');
+  });
+
+  it('rejects custom exploration fixtures when placements do not reference them', () => {
+    const layout = generateForestSceneLayout({ placementCount: 1 });
+    expect(() => createForestExploration(layout, { fixtures: [{
+      id: 'semantic-only', title: 'Tree', roomName: 'Room',
+      createdAt: '2025-01-01', excerpt: 'Writing.'
+    }] })).toThrowError('Forest exploration placements require known fixture identities.');
+  });
+});
+import fs from 'node:fs';
+
+import pug from 'pug';

--- a/spec/forestSceneSpec.js
+++ b/spec/forestSceneSpec.js
@@ -126,7 +126,7 @@ describe('static Activity Forest scene', () => {
     const unique = resolveForestPressureProfile('unique-assets');
     const large = resolveForestPressureProfile('large-world');
 
-    expect(FOREST_PRESSURE_PROFILES.length).toBe(5);
+    expect(FOREST_PRESSURE_PROFILES.length).toBe(6);
     expect(representative.pressure).toBeFalse();
     expect(representative.layout).toEqual({});
     expect(resolveForestPressureProfile('unknown')).toBe(representative);

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -11,13 +11,15 @@ block content
   main.activity-forest
     header.activity-forest__header
       div
-        p.activity-forest__eyebrow= profile.pressure ? 'Development pressure test' : 'Development preview'
+        p.activity-forest__eyebrow= profile.pressure ? 'Development pressure test' : profile.projectedWriting ? 'Meaning-contract scene' : 'Development preview'
         h1 Activity Forest
-          if profile.pressure
+          if profile.pressure || profile.projectedWriting
             |  — #{profile.label}
         p.activity-forest__lede
           if profile.pressure
             | #{profile.description} This mode is development-only and does not change the default grove.
+          else if profile.projectedWriting
+            | #{profile.description} Inspect trees while walking to compare their bounded habitat and creation-season decisions.
           else
             | Walk the winding clearing, approach a tree, and rediscover a fixture piece of writing.
             | The grove remains deterministic and is composed from reusable procedural tree assets.
@@ -25,7 +27,7 @@ block content
         button.activity-forest__reset(type='button' data-forest-reset-overlay) Reset personal overlay
         button.activity-forest__reset(type='button' data-forest-reset) Return to entrance
 
-    nav.activity-forest__profiles(aria-label='Forest pressure configurations')
+    nav.activity-forest__profiles(aria-label='Forest development configurations')
       each availableProfile in pressureProfiles
         a(
           href=`/__dev/views/activity-forest?pressure=${availableProfile.id}&transport=${scene.assetLoading.transport}`
@@ -213,6 +215,22 @@ block content
         span(aria-hidden='true')  ·
         time(data-forest-post-date)
       p.activity-forest__dialog-excerpt(data-forest-post-excerpt)
+      section.activity-forest__tree-meaning(data-forest-tree-meaning hidden)
+        h3 Why this tree differs
+        dl
+          div
+            dt Phenotype
+            dd(data-forest-meaning-phenotype)
+          div
+            dt Specimen seed
+            dd(data-forest-meaning-seed)
+          div
+            dt Habitat
+            dd(data-forest-meaning-habitat)
+          div
+            dt Permanent tint
+            dd(data-forest-meaning-tint)
+        ul(data-forest-meaning-reasons)
       button(type='button' data-forest-dialog-close) Return to the forest
 
     dialog.activity-forest__dialog(data-forest-object-dialog aria-labelledby='forest-object-title')

--- a/views/dev/forest-lab.pug
+++ b/views/dev/forest-lab.pug
@@ -13,13 +13,16 @@ block content
       p.forest-lab__eyebrow Development preview
       h1 Activity Forest Lab
       p.forest-lab__lede
-        | Every registered procedural phenotype is shown as finished trees, leafless wood rasters, and
-        | its deterministic branch graph so structural and rendering changes remain diagnosable.
+        | Representative writing fixtures pass through the versioned post-to-tree meaning contract,
+        | then use the same finished-tree, leafless-wood, and branch-graph paths.
 
     section.forest-lab__legend(aria-labelledby='forest-lab-legend')
       h2#forest-lab-legend Current visual grammar
       ul
         li Post identity supplies the stable seed for every growth and rendering decision.
+        li Neutral-grove and rocky-edge habitat hints softly bias all three eligible phenotypes.
+        li Creation season selects one existing phenotype-owned foliage tint; size and complexity do not change.
+        li Mutable activity counts, room changes, and personal overlays do not restyle the core tree in this slice.
         li Three-dimensional radial growth is projected into a crisp two-dimensional tree.
         li Branch hierarchy and specimen architecture shape taper from the trunk through terminal twigs.
         li Broad leaves or needle sprays grow from eligible branches while preserving intentional crown gaps.
@@ -28,86 +31,107 @@ block content
     section.forest-gallery(aria-label='Generated post tree gallery')
       each item, treeIndex in trees
         article.forest-comparison
-          .forest-comparison__views
-            button.forest-grown-card(
-              type='button'
-              data-forest-tree
-              data-title=item.title
-              data-room=item.roomId
-              data-date=item.createdAt
-              data-excerpt=item.excerpt
-              data-url=item.url
-              aria-label=`Inspect procedural tree for ${item.title}`
-            )
-              span.forest-comparison__label Grown tree
-              .forest-grown-stage
-                canvas.forest-grown-canvas(
-                  width=item.asset.dimensions.width
-                  height=item.asset.dimensions.height
-                  data-forest-asset=treeIndex
-                  role='img'
-                  aria-label=`Procedural tree with supported foliage for ${item.title}`
-                )
-            figure.forest-wood-card
-              figcaption.forest-comparison__label Leafless wood
-              .forest-wood-stage
-                canvas.forest-wood-canvas(
-                  width=item.asset.dimensions.width
-                  height=item.asset.dimensions.height
-                  data-forest-asset=treeIndex
-                  role='img'
-                  aria-label=`Leafless wood raster for ${item.title}`
-                )
-            figure.forest-graph-card
-              figcaption.forest-comparison__label Branch graph
-              svg.forest-graph-svg(
-                viewBox=`0 0 ${item.tree.phenotype.width} ${item.tree.phenotype.height}`
-                role='img'
-                aria-label=`Branch graph for ${item.title}`
-                preserveAspectRatio='xMidYMax meet'
+          if item.projectionError
+            .forest-comparison__error(role='alert')
+              strong Projection failed
+              p= item.projectionError
+          else
+            .forest-comparison__views
+              button.forest-grown-card(
+                type='button'
+                data-forest-tree
+                data-title=item.title
+                data-room=item.roomId
+                data-date=item.createdAt
+                data-excerpt=item.excerpt
+                data-url=item.url
+                aria-label=`Inspect procedural tree for ${item.title}`
               )
-                title= `Deterministic branch graph for ${item.title}`
-                ellipse.forest-graph__crown(
-                  cx=item.tree.phenotype.crown.centerX
-                  cy=item.tree.phenotype.crown.centerY
-                  rx=item.tree.phenotype.crown.radiusX
-                  ry=item.tree.phenotype.crown.radiusY
-                )
-                each point in item.tree.attractionPoints
-                  circle.forest-graph__attraction(cx=point.x cy=point.y r='0.65')
-                each segment in item.tree.segments
-                  - const from = item.tree.nodes[segment.fromId]
-                  - const to = item.tree.nodes[segment.toId]
-                  line.forest-graph__segment(
-                    x1=from.x y1=from.y x2=to.x y2=to.y
-                    stroke-width=Math.max(0.55, segment.radius * 0.7)
+                span.forest-comparison__label Grown tree
+                .forest-grown-stage
+                  canvas.forest-grown-canvas(
+                    width=item.asset.dimensions.width
+                    height=item.asset.dimensions.height
+                    data-forest-asset=treeIndex
+                    role='img'
+                    aria-label=`Procedural tree with supported foliage for ${item.title}`
                   )
-                each node in item.tree.nodes
-                  circle.forest-graph__node(cx=node.x cy=node.y r='0.75')
-                each terminalId in item.tree.terminalNodeIds
-                  - const terminal = item.tree.nodes[terminalId]
-                  circle.forest-graph__terminal(cx=terminal.x cy=terminal.y r='1.65')
+              figure.forest-wood-card
+                figcaption.forest-comparison__label Leafless wood
+                .forest-wood-stage
+                  canvas.forest-wood-canvas(
+                    width=item.asset.dimensions.width
+                    height=item.asset.dimensions.height
+                    data-forest-asset=treeIndex
+                    role='img'
+                    aria-label=`Leafless wood raster for ${item.title}`
+                  )
+              figure.forest-graph-card
+                figcaption.forest-comparison__label Branch graph
+                svg.forest-graph-svg(
+                  viewBox=`0 0 ${item.tree.phenotype.width} ${item.tree.phenotype.height}`
+                  role='img'
+                  aria-label=`Branch graph for ${item.title}`
+                  preserveAspectRatio='xMidYMax meet'
+                )
+                  title= `Deterministic branch graph for ${item.title}`
+                  ellipse.forest-graph__crown(
+                    cx=item.tree.phenotype.crown.centerX
+                    cy=item.tree.phenotype.crown.centerY
+                    rx=item.tree.phenotype.crown.radiusX
+                    ry=item.tree.phenotype.crown.radiusY
+                  )
+                  each point in item.tree.attractionPoints
+                    circle.forest-graph__attraction(cx=point.x cy=point.y r='0.65')
+                  each segment in item.tree.segments
+                    - const from = item.tree.nodes[segment.fromId]
+                    - const to = item.tree.nodes[segment.toId]
+                    line.forest-graph__segment(
+                      x1=from.x y1=from.y x2=to.x y2=to.y
+                      stroke-width=Math.max(0.55, segment.radius * 0.7)
+                    )
+                  each node in item.tree.nodes
+                    circle.forest-graph__node(cx=node.x cy=node.y r='0.75')
+                  each terminalId in item.tree.terminalNodeIds
+                    - const terminal = item.tree.nodes[terminalId]
+                    circle.forest-graph__terminal(cx=terminal.x cy=terminal.y r='1.65')
           h2.forest-comparison__title= item.title
-          p.forest-comparison__meta
-            - const maximumOrder = Math.max(...item.tree.nodes.map(node => node.generation))
-            | #{item.tree.phenotype.name} · #{item.tree.foliage.paletteId} foliage ·
-            |  seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
-            |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
-            |  base radius #{item.tree.architecture.trunkBaseRadius.toFixed(2)} ·
-            |  taper #{item.tree.architecture.trunkTaper.toFixed(2)} ·
-            |  lean #{(item.tree.architecture.trunkLeanAngle * 180 / Math.PI).toFixed(1)}°
-            |  @ #{(item.tree.architecture.trunkLeanAzimuth * 180 / Math.PI).toFixed(0)}° ·
-            if item.tree.architecture.hasSplitTrunk
-              |  split #{item.tree.architecture.splitTrunkHeight.toFixed(1)} high
-              |  @ #{(item.tree.architecture.splitTrunkAngle * 180 / Math.PI).toFixed(1)}° ·
-              |  balance #{item.tree.architecture.leaderBalance.toFixed(3)}
-              |  (leader #{item.tree.architecture.dominantLeaderIndex + 1} stronger) ·
-            else
-              |  single trunk ·
-            |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·
-            |  #{item.tree.foliage.leaves.length} leaves ·
-            |  #{item.tree.diagnostics.crossingCount} projected overlaps ·
-            |  #{item.tree.stats.terminationReason}
+          if !item.projectionError && item.pair
+            p.forest-comparison__pair= item.pair
+          if !item.projectionError
+            .forest-comparison__meaning
+              p
+                strong #{item.projection.phenotype.id}
+                |  · #{item.projection.habitat.id} · #{item.projection.permanentTraits.creationSeason}
+                if item.projection.permanentTraits.foliagePaletteId
+                  |  · #{item.projection.permanentTraits.foliagePaletteId} tint
+                else
+                  |  · seed-selected tint
+              ul
+                each explanation in item.projection.explanations
+                  li(data-reason-token=explanation.token)= explanation.text
+              code= `projection v${item.projection.mappingVersion} · ${item.projection.identity.projectionFingerprint}`
+          if !item.projectionError
+            p.forest-comparison__meta
+              - const maximumOrder = Math.max(...item.tree.nodes.map(node => node.generation))
+              | #{item.tree.phenotype.name} · #{item.tree.foliage.paletteId} foliage ·
+              |  seed #{item.tree.seed} · #{item.tree.nodes.length} nodes ·
+              |  branch start #{item.tree.architecture.branchStartHeight.toFixed(1)} ·
+              |  base radius #{item.tree.architecture.trunkBaseRadius.toFixed(2)} ·
+              |  taper #{item.tree.architecture.trunkTaper.toFixed(2)} ·
+              |  lean #{(item.tree.architecture.trunkLeanAngle * 180 / Math.PI).toFixed(1)}°
+              |  @ #{(item.tree.architecture.trunkLeanAzimuth * 180 / Math.PI).toFixed(0)}° ·
+              if item.tree.architecture.hasSplitTrunk
+                |  split #{item.tree.architecture.splitTrunkHeight.toFixed(1)} high
+                |  @ #{(item.tree.architecture.splitTrunkAngle * 180 / Math.PI).toFixed(1)}° ·
+                |  balance #{item.tree.architecture.leaderBalance.toFixed(3)}
+                |  (leader #{item.tree.architecture.dominantLeaderIndex + 1} stronger) ·
+              else
+                |  single trunk ·
+              |  order #{maximumOrder} · #{item.tree.diagnostics.maximumTortuosity.toFixed(2)} tortuosity ·
+              |  #{item.tree.foliage.leaves.length} leaves ·
+              |  #{item.tree.diagnostics.crossingCount} projected overlaps ·
+              |  #{item.tree.stats.terminationReason}
 
     script#forest-tree-assets(type='application/json')!= JSON.stringify(trees.map(item => item.asset)).replace(/</g, '\\u003c')
 


### PR DESCRIPTION
## Summary

Implements Milestone 7 of the Activity Forest roadmap through two focused development slices:

- Defines a deterministic, versioned post-to-tree meaning contract.
- Adds a projected-writing grove for evaluating that contract at explorable scene scale.

The result connects bounded writing evidence to procedural-tree generation without turning mutable activity into visual status or beginning the biome system prematurely.

## Post-to-tree contract

- Derives stable specimen identity from post identity.
- Softly biases registered phenotype selection using bounded habitat context.
- Projects creation season into one restrained, phenotype-owned foliage palette.
- Explicitly leaves room changes, word count, collaborations, translations, comments, reactions, and quest state without a core-tree expression.
- Rejects unknown, malformed, oversized, or transient inputs.
- Preserves personal-overlay independence.

## Identity and caching

- Adds an explicit projection schema and mapping version.
- Includes every output-affecting projected decision in runtime asset identity.
- Allows explanation-only differences to reuse identical pixels.
- Rejects projections whose visual decision does not match their fingerprint.
- Keeps runtime tree-asset schema version 2 and renderer version 4 unchanged.
- Keeps raw post metadata, projection inputs, and explanations out of runtime assets and placement manifests.

## Forest Lab

- Runs all 24 representative fixtures through the meaning contract.
- Retains exactly eight fixtures per registered phenotype.
- Adds inspectable phenotype, seed, habitat, creation-season, palette, version, and reason diagnostics.
- Provides controlled habitat, creation-season, and mutable-activity comparison pairs.
- Retains final-tree, leafless-wood, and branch-graph views.
- Displays bounded diagnostics for invalid fixtures.

## Projected writing grove

Adds the development-only `post-tree-meaning` Activity Forest profile:

- 180 deterministic placements
- 24 inspectable writing fixtures
- 23 unique projected assets
- All three registered phenotypes
- Existing regional loading and bounded scene pooling
- Color-run and lossless-raster transports
- Existing collision, culling, ambient motion, inspection, nearby writing, touch controls, and overlay behavior

Tree inspection includes development diagnostics explaining the projected phenotype, specimen seed, habitat context, and permanent tint. These details are explicitly documented as diagnostic instrumentation rather than a proposed final player-facing interface.

The representative default and `botanical-range` profiles remain unchanged.

## Documentation

Documents:

- Projection schema and accepted inputs
- Input classification and mutation policy
- Habitat weights and creation-season mapping
- Cache and invalidation rules
- Forest Lab evidence
- Projected-grove composition and measurements
- Diagnostic versus player-facing explanation boundaries
- Remaining real-distribution and Milestone 8 biome questions

Historical renderer-v2 mappings are retained as research evidence and clarified as inactive.

## Validation

- Full repository suite: 655 specs, 0 failures
- Forest regression suite: 136 specs, 0 failures
- Projected-scene suite: 8 specs, 0 failures
- Full ESLint pass
- Pug compilation and `git diff --check`
- Both runtime transports verified