### PR TITLE
Fix homepage translation selection across age bands

### DIFF
--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -450,10 +450,48 @@ export async function getTopBlocksWithFallback(options = {}) {
     ? { type: 'all' }
     : { type: 'days', value: maxDaysUsed };
 
+  const preferredBlocks = await loadPreferredTranslationVariants(
+    collected,
+    preferredLang,
+    { lockedOnly }
+  );
+
   return {
-    blocks: mergePinnedHomeBlocks(pinnedBlocks, collected, { limit: target }),
+    blocks: mergePinnedHomeBlocks(pinnedBlocks, preferredBlocks, { limit: target }),
     period
   };
+}
+
+export function replaceWithPreferredTranslationVariants(blocks, preferredTranslations, preferredLang) {
+  const preferredByGroup = new Map(
+    (preferredTranslations || [])
+      .filter(block => block?.groupId && block?.lang === preferredLang)
+      .map(block => [String(block.groupId), block])
+  );
+
+  return (blocks || []).map(block => {
+    if (!block?.groupId || block.lang === preferredLang) return block;
+    return preferredByGroup.get(String(block.groupId)) || block;
+  });
+}
+
+async function loadPreferredTranslationVariants(blocks, preferredLang, { lockedOnly = false } = {}) {
+  const groupIds = [...new Set(
+    (blocks || [])
+      .filter(block => block?.groupId && block.lang !== preferredLang)
+      .map(block => block.groupId)
+  )];
+
+  if (groupIds.length === 0) return blocks;
+
+  const match = publiclyVisibleBlockMatch({
+    groupId: { $in: groupIds },
+    lang: preferredLang
+  });
+  if (lockedOnly) match.status = 'locked';
+
+  const preferredTranslations = await Block.find(match).lean().exec();
+  return replaceWithPreferredTranslationVariants(blocks, preferredTranslations, preferredLang);
 }
 
 export function mergePinnedHomeBlocks(pinnedBlocks, ordinaryBlocks, { limit = 20 } = {}) {

--- a/spec/homePinnedBlocksSpec.js
+++ b/spec/homePinnedBlocksSpec.js
@@ -1,4 +1,8 @@
-import { HOME_PINNED_BLOCK_LIMIT, mergePinnedHomeBlocks } from '../server/db/blockService.js';
+import {
+  HOME_PINNED_BLOCK_LIMIT,
+  mergePinnedHomeBlocks,
+  replaceWithPreferredTranslationVariants
+} from '../server/db/blockService.js';
 
 describe('home pinned blocks', () => {
   function block(id, overrides = {}) {
@@ -73,5 +77,26 @@ describe('home pinned blocks', () => {
     expect(result.slice(0, HOME_PINNED_BLOCK_LIMIT).map(b => b._id))
       .toEqual(['pinned-1', 'pinned-2', 'pinned-3']);
     expect(result.map(b => b._id)).not.toContain('pinned-4');
+  });
+
+  it('uses an older preferred-language translation after age-band deduplication', () => {
+    const newerRussian = block('newer-ru', {
+      groupId: 'translated-post',
+      lang: 'ru',
+      createdAt: new Date('2026-07-08T00:00:00.000Z')
+    });
+    const olderEnglish = block('older-en', {
+      groupId: 'translated-post',
+      lang: 'en',
+      createdAt: new Date('2026-07-01T00:00:00.000Z')
+    });
+
+    const result = replaceWithPreferredTranslationVariants(
+      [newerRussian, block('untranslated', { lang: 'ru' })],
+      [olderEnglish],
+      'en'
+    );
+
+    expect(result.map(b => b._id)).toEqual(['older-en', 'untranslated']);
   });
 });


### PR DESCRIPTION
## Summary

Fixes homepage translation deduplication when translations from the same group fall into different age bands.

Previously, a newer translation in another language could claim the group before an older preferred-language translation was processed. For example, a newer Russian translation could appear even when English was selected.

## Changes

- Preserve the translation group’s homepage ranking based on recent activity.
- Replace the selected variant with the user’s preferred-language translation when one is publicly available.
- Fall back to the originally selected translation when no preferred-language version exists.
- Respect the locked-only filter when resolving preferred translations.
- Add regression coverage for a newer Russian translation paired with an older English post.

## Testing

- `npm test` — 670 specs passing
- ESLint passes for the changed files
- `git diff --check` passes