### PR TITLE
Rework forest stream banks and bridge perspective

### DIFF
--- a/docs/forest/environment-region-contract.md
+++ b/docs/forest/environment-region-contract.md
@@ -100,11 +100,34 @@ pathfinder.
 
 The stream center is a seed-derived base Y plus two bounded sine waves with different wavelengths.
 It crosses the full finite world from west to east and is queryable analytically without a raster.
-Distance to that center classifies water, bank, or land. The fixed profile uses a 44-pixel water
-half-width and 22-pixel bank width. Water and bank shapes are painted in visible 16-pixel samples
-after the corridor, so the stream cuts across the route rather than appearing beneath it.
+Distance to that center classifies water, bank, or land. The gameplay profile retains its 44-pixel
+water half-width and 22-pixel bank classification so traversal and placement remain planar.
 
-Three broad, independently meandering tonal bands break the water into deep teal, middle blue-green,
+Presentation uses the registered `varied-incised-creek-bank` definition. Smooth deterministic
+anchors vary water depth from 5–14 pixels, each side's slope run from 20–42 pixels, and broad plus
+fine edge displacement independently along the creek. The generator samples those profiles into
+three-dimensional bank-face quads: the outer edge remains on the world ground at `z = 0`, while the
+irregular inner edge meets a recessed water surface at negative `z`. The shared forest projection
+maps those points to canvas space. The far bank is painted first, then the recessed water, then the
+near bank, giving the channel coherent occlusion without adding general terrain-elevation physics.
+
+Seeded 210-pixel composition anchors choose grassy, rocky, bare-dirt, or fallen-log-jam influence,
+then smoothstep-blend continuously toward the next anchor instead of changing material at a section
+line. Each bank face is divided into four irregular 3D strata with progressively darker values from
+the ground cap to the waterline, but broken cap shadows and material clusters keep those strata from
+reading as regular masonry courses. A highlighted grass overhang, dark waterline undercut, roots,
+clustered soil pixels, top-lit embedded rocks, dirt striations, and occasional multi-member fallen
+logs provide scale and slope cues. A translucent shallow shelf carries muted soil color and pebbles
+past the waterline so the bank appears to continue below the surface. Both geometry and material
+remain continuous at sample boundaries, and visible geometry is generated and cached in bounded
+world-X chunks rather than across the whole world every frame.
+
+Movement remains planar, but traversal tests the player's full collision circle against the same
+irregular water edge used by presentation. The original analytic half-width remains a conservative
+minimum. Only the rotated, radius-inset bridge deck may admit a player whose circle intersects water;
+this prevents visual edge displacement from making the character appear to wade beside a bridge.
+
+Three broad, independently meandering tonal bands break the recessed water into deep teal, middle blue-green,
 and lighter shallow regions without creating hard tile boundaries. Stable world-anchored clusters
 of two-tone pixels dapple those large shapes, while separate moss, soil, shallow-water, and shadow
 notches articulate both banks. Above them, four sparse flow lanes contain short two- or three-step
@@ -124,15 +147,23 @@ evaluated in local longitudinal/lateral coordinates,
 so its containment and traversal contract supports arbitrary world angles. Player collision remains
 two-dimensional: water rejects movement unless the player's collision circle is inside the rotated
 deck rectangle, and each visible side rail rejects circle overlap over both water and dry approaches.
-The open ends remain unobstructed. Presentation alone evaluates a sine-shaped elevation curve from zero at either
-approach to a 24-pixel crown whenever the bridge is not parallel to the viewport Y axis. A deep
-two-tone curved fascia, crown-lit plank palette, explicit transverse seams, uneven seed-stable plank
-widths and outer ends, restrained grain, iron nails, four
-bridge-aligned stone abutments, and irregular log posts and rails make the rustic arch readable.
-Adjacent planks share the same procedurally chosen seam endpoints, preventing gaps while retaining
-hand-built variation. Every lateral point at one longitudinal position—including fascia and rails
-outside the walkable rectangle—uses the centerline elevation. The deck, player, posts, and rails
-therefore share one structural arch, so walking appears to rise and descend while world position,
+The open ends remain unobstructed.
+
+Presentation is generated from the registered `rustic-timber-arch` bridge definition. That
+definition groups the circular-segment profile, deck and plank dimensions, fascia depth, rail and
+post spacing, abutments, and palette in one parameter object so another bridge form can be added by
+registering a different definition rather than retuning screen-space drawing commands. Each instance
+supplies only its world position, angle, footprint, span, and crown.
+
+The generator constructs plank surfaces, plank ends, curved fascia segments, posts, and handrail
+members as three-dimensional points in the bridge's rotated local coordinate system. A single
+orthographic world projection maps `(x, y, z)` to canvas `(x, y - z)`, matching the forest's planar
+ground and sprite convention. Depth values order surfaces and members before painting. The deck uses
+a true circular-segment arch from zero at either approach to its configured crown; vertical thickness,
+post height, and rail height are offsets on that same profile instead of canvas-Y approximations.
+Both differently angled instances therefore retain the same proportions. Crown-lit uneven planks,
+transverse seams, iron nails, two-tone curved fascia, bridge-aligned stone abutments, and log rails
+retain the rustic pixel-art treatment. The player uses the same profile height while world position,
 collision, focus, and camera remain planar.
 This is not general elevation physics, jumping, slopes, or a bridge-construction system.
 

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -58,10 +58,19 @@ import {
   renderNearbyForestWritingCandidates
 } from './forest-nearby-writing.js';
 import {
+  buildForestBridgeModel3d
+} from './forest-bridges.js';
+import { projectForestPoint3d } from './forest-projection.js';
+import {
+  buildForestStreamBankModel3d,
+  forestStreamBankEdgePoint3d,
+  forestStreamWaterDepthAt,
+  forestStreamWaterPoint3d
+} from './forest-stream-banks.js';
+import {
   FOREST_BOULDER_TYPE,
   FOREST_GROUND_DETAIL_CELL_SIZE,
   forestBridgeElevationAt,
-  forestBridgeWorldPosition,
   forestEnvironmentAt,
   forestGroundDetailAt,
   forestStreamCenterY,
@@ -77,12 +86,16 @@ if (payload && viewportElement && canvas) {
   const initialResponseDecodeStartedAt = window.performance.now();
   const scene = JSON.parse(payload.textContent);
   const crossings = scene.crossings || (scene.crossing ? [scene.crossing] : []);
+  const bridgeModels = new Map(crossings.map(bridge => (
+    [bridge.id, buildForestBridgeModel3d(bridge)]
+  )));
   const initialResponseDecodeDuration = window.performance.now() - initialResponseDecodeStartedAt;
   const assetsByKey = new Map();
   const fixturesById = new Map(scene.exploration.fixtures.map((fixture) => [fixture.id, fixture]));
   const context = canvas.getContext('2d');
   const spritesByKey = new Map();
   const camera = { x: 0, y: 0, width: 0, height: 0 };
+  let streamBankModelCache = null;
   const player = { ...scene.exploration.spawn };
   const overlayPersistence = createForestDevOverlayPersistence(window.localStorage);
   const persistedOverlay = overlayPersistence.load(scene.baseIdentity);
@@ -641,22 +654,149 @@ if (payload && viewportElement && canvas) {
     context.fill();
   }
 
-  function paintStreamRibbon(halfWidth, fillStyle) {
-    const firstX = Math.max(0, Math.floor(camera.x / 16) * 16);
-    const lastX = Math.min(scene.world.width, Math.ceil(
-      (camera.x + camera.width) / 16
-    ) * 16);
+  function streamQueryX(worldX) {
+    return Math.max(0, Math.min(scene.world.width, Math.round(worldX)));
+  }
+
+  function streamScreenPoint(worldX, lateral = 0) {
+    const queryX = streamQueryX(worldX);
+    return projectForestPoint3d(forestStreamWaterPoint3d(
+      scene.environment, worldX, lateral,
+      forestStreamCenterY(scene.environment, queryX)
+    ), camera);
+  }
+
+  function streamBankEdgeScreenPoint(worldX, side, position = 'inner') {
+    const queryX = streamQueryX(worldX);
+    visibleStreamBankModel();
+    const key = `${worldX}:${side}:${position}`;
+    let point = streamBankModelCache.edgePoints.get(key);
+    if (!point) {
+      point = forestStreamBankEdgePoint3d(
+        scene.environment, worldX, side,
+        forestStreamCenterY(scene.environment, queryX), position
+      );
+      streamBankModelCache.edgePoints.set(key, point);
+    }
+    return projectForestPoint3d(point, camera);
+  }
+
+  function visibleStreamBankModel() {
+    const chunk = 192;
+    const firstX = Math.max(0, Math.floor((camera.x - 96) / chunk) * chunk);
+    const lastX = Math.min(scene.world.width,
+      Math.ceil((camera.x + camera.width + 96) / chunk) * chunk);
+    if (!streamBankModelCache || streamBankModelCache.firstX !== firstX
+      || streamBankModelCache.lastX !== lastX) {
+      streamBankModelCache = {
+        firstX,
+        lastX,
+        edgePoints: new Map(),
+        model: buildForestStreamBankModel3d(scene.environment, { firstX, lastX },
+          worldX => forestStreamCenterY(scene.environment, streamQueryX(worldX)))
+      };
+    }
+    return streamBankModelCache.model;
+  }
+
+  function paintStreamBankDetail(detail) {
+    const from = projectForestPoint3d(detail.from, camera);
+    const to = projectForestPoint3d(detail.to, camera);
+    const stroke = (color, width, offsetX = 0, offsetY = 0) => {
+      context.beginPath();
+      context.moveTo(Math.round(from.x + offsetX), Math.round(from.y + offsetY));
+      context.lineTo(Math.round(to.x + offsetX), Math.round(to.y + offsetY));
+      context.strokeStyle = color;
+      context.lineWidth = width;
+      context.stroke();
+    };
+    context.lineCap = detail.role.startsWith('log') || detail.role === 'grass'
+      ? 'round' : 'butt';
+    if (detail.role === 'lip') {
+      stroke(detail.colors[0], detail.width + 2, 0, 1);
+      stroke(detail.colors[1], detail.width, 0, -1);
+    } else if (detail.role === 'grass') {
+      stroke(detail.colors[0], detail.width, 0, 1);
+      stroke(detail.colors[1], 1);
+      const direction = to.x >= from.x ? 1 : -1;
+      stroke(detail.colors[1], 1, -direction * 3, 1);
+      stroke(detail.colors[1], 1, direction * 3, 2);
+    } else {
+      stroke(detail.colors[0], detail.width);
+      stroke(detail.colors[1], Math.max(1, Math.floor(detail.width / 3)), 0,
+        detail.role === 'undercut' ? -1 : 0);
+    }
+    context.lineCap = 'butt';
+  }
+
+  function paintStreamBankMark(mark) {
+    const point = projectForestPoint3d(mark.point, camera);
+    const x = Math.round(point.x);
+    const y = Math.round(point.y);
+    const size = mark.size;
+    if (mark.role === 'rock') {
+      const half = Math.floor(size / 2);
+      const crown = 2 + (mark.variant % 2);
+      bridgePolygon([
+        { x: x - half - 1, y: y + 1 },
+        { x: x - half + crown, y: y - Math.floor(size * 0.35) },
+        { x: x + half - 1, y: y - Math.floor(size * 0.25) },
+        { x: x + half + 1, y: y + 1 },
+        { x: x + half - 2, y: y + 3 },
+        { x: x - half + 1, y: y + 3 }
+      ], mark.colors[0]);
+      context.fillStyle = mark.colors[1];
+      context.fillRect(x - half + crown - 1, y - Math.floor(size * 0.35),
+        Math.max(3, size - crown - 1), Math.max(2, Math.floor(size * 0.35)));
+      context.fillStyle = '#bcc3a4';
+      context.fillRect(x - half + crown, y - Math.floor(size * 0.35),
+        Math.max(2, Math.floor(size * 0.35)), 1);
+      if (size > 8) {
+        context.fillStyle = '#515b50';
+        context.fillRect(x + half - 2, y - 1, 2, 2);
+      }
+      return;
+    }
+    context.fillStyle = mark.colors[0];
+    context.fillRect(x - Math.floor(size / 2), y, size, 2);
+    context.fillStyle = mark.colors[1];
+    context.fillRect(x - Math.floor(size / 3), y - 1,
+      Math.max(2, Math.floor(size * 0.66)), 1 + (mark.variant % 2));
+  }
+
+  function paintStreamBank(side) {
+    const model = visibleStreamBankModel();
+    for (const surface of model.surfaces.filter(candidate => candidate.side === side)) {
+      bridgePolygon(surface.points.map(point => {
+        const projected = projectForestPoint3d(point, camera);
+        return { x: Math.round(projected.x), y: Math.round(projected.y) };
+      }), surface.fill);
+    }
+    model.details.filter(detail => detail.side === side).forEach(paintStreamBankDetail);
+    model.marks.filter(candidate => candidate.side === side).forEach(paintStreamBankMark);
+  }
+
+  function paintStreamWaterSurface(fillStyle) {
+    const surfaces = visibleStreamBankModel().surfaces;
+    const farBank = surfaces.filter(({ side, stratum }) => side === -1 && stratum === 3);
+    const nearBank = surfaces.filter(({ side, stratum }) => side === 1 && stratum === 3);
     context.beginPath();
-    for (let worldX = firstX; worldX <= lastX; worldX += 16) {
-      const screenX = worldX - camera.x;
-      const screenY = forestStreamCenterY(scene.environment, worldX) - camera.y - halfWidth;
-      if (worldX === firstX) context.moveTo(screenX, screenY);
-      else context.lineTo(screenX, screenY);
-    }
-    for (let worldX = lastX; worldX >= firstX; worldX -= 16) {
-      context.lineTo(worldX - camera.x,
-        forestStreamCenterY(scene.environment, worldX) - camera.y + halfWidth);
-    }
+    farBank.forEach((surface, index) => {
+      const points = index === 0 ? [surface.points[1], surface.points[2]] : [surface.points[2]];
+      for (const value of points) {
+        const point = projectForestPoint3d(value, camera);
+        if (index === 0 && value === points[0]) context.moveTo(point.x, point.y);
+        else context.lineTo(point.x, point.y);
+      }
+    });
+    [...nearBank].reverse().forEach((surface, index) => {
+      const values = index === 0 ? [surface.points[2], surface.points[1]]
+        : [surface.points[1]];
+      for (const value of values) {
+        const point = projectForestPoint3d(value, camera);
+        context.lineTo(point.x, point.y);
+      }
+    });
     context.closePath();
     context.fillStyle = fillStyle;
     context.fill();
@@ -682,13 +822,6 @@ if (payload && viewportElement && canvas) {
     return value - Math.floor(value);
   }
 
-  function bridgePresentationVariation(bridge, decision, ordinal = 0, side = 0) {
-    const value = Math.sin((bridge.worldX * 0.071)
-      + (bridge.worldY * 0.037) + (decision * 47.31)
-      + (ordinal * 91.73) + (side * 19.17)) * 43758.5453;
-    return value - Math.floor(value);
-  }
-
   function paintStreamColorBand(lane, halfWidth, fillStyle, wavelength, phase) {
     const firstX = Math.max(0, Math.floor(camera.x / 16) * 16);
     const lastX = Math.min(scene.world.width, Math.ceil(
@@ -697,18 +830,18 @@ if (payload && viewportElement && canvas) {
     const edge = (worldX, side) => {
       const meander = Math.sin((worldX / wavelength) + phase) * 4;
       const widthVariation = Math.sin((worldX / (wavelength * 0.57)) + phase + 1.7) * 2;
-      return forestStreamCenterY(scene.environment, worldX) + lane + meander
-        + (side * (halfWidth + widthVariation));
+      return streamScreenPoint(worldX, lane + meander
+        + (side * (halfWidth + widthVariation)));
     };
     context.beginPath();
     for (let worldX = firstX; worldX <= lastX; worldX += 16) {
-      const pointX = worldX - camera.x;
-      const pointY = edge(worldX, -1) - camera.y;
-      if (worldX === firstX) context.moveTo(pointX, pointY);
-      else context.lineTo(pointX, pointY);
+      const point = edge(worldX, -1);
+      if (worldX === firstX) context.moveTo(point.x, point.y);
+      else context.lineTo(point.x, point.y);
     }
     for (let worldX = lastX; worldX >= firstX; worldX -= 16) {
-      context.lineTo(worldX - camera.x, edge(worldX, 1) - camera.y);
+      const point = edge(worldX, 1);
+      context.lineTo(point.x, point.y);
     }
     context.closePath();
     context.fillStyle = fillStyle;
@@ -730,11 +863,9 @@ if (payload && viewportElement && canvas) {
         const lane = -stream.halfWidth + 7 + (laneIndex * 11)
           + Math.floor((streamFlowVariation(identity, laneIndex, 13) - 0.5) * 5);
         if (Math.abs(lane) >= stream.halfWidth - 3) continue;
-        const worldY = forestStreamCenterY(scene.environment, Math.max(0, Math.min(
-          scene.world.width, Math.round(worldX)
-        ))) + lane;
-        const x = Math.round(worldX - camera.x);
-        const y = Math.round(worldY - camera.y);
+        const point = streamScreenPoint(worldX, lane);
+        const x = Math.round(point.x);
+        const y = Math.round(point.y);
         const width = 2 + Math.floor(streamFlowVariation(identity, laneIndex, 14) * 7);
         const colorIndex = Math.floor(streamFlowVariation(identity, laneIndex, 15)
           * waterColors.length);
@@ -747,42 +878,74 @@ if (payload && viewportElement && canvas) {
     }
   }
 
-  function paintStreamEdgeTexture(stream) {
+  function paintStreamEdgeTexture() {
     const edgeSpacing = 14;
     const firstColumn = Math.floor((camera.x - edgeSpacing) / edgeSpacing);
     const lastColumn = Math.ceil((camera.x + camera.width + edgeSpacing) / edgeSpacing);
     for (let column = firstColumn; column <= lastColumn; column += 1) {
       const worldX = column * edgeSpacing;
       const queryX = Math.max(0, Math.min(scene.world.width, Math.round(worldX)));
-      const centerY = forestStreamCenterY(scene.environment, queryX);
       for (const side of [-1, 1]) {
         const identity = column + (side * 401);
-        const notch = Math.floor(streamFlowVariation(identity, side, 21) * 5);
         const width = 4 + Math.floor(streamFlowVariation(identity, side, 22) * 8);
-        const waterY = centerY + (side * (stream.halfWidth - 2 + notch));
+        const water = streamBankEdgeScreenPoint(queryX, side);
         context.fillStyle = side < 0 ? '#58a09a' : '#1d6577';
-        context.fillRect(Math.round(worldX - camera.x), Math.round(waterY - camera.y), width, 2);
-        if (streamFlowVariation(identity, side, 23) > 0.4) {
-          const bankY = centerY + (side * (stream.halfWidth + 5 + notch));
-          context.fillStyle = streamFlowVariation(identity, side, 24) > 0.5
-            ? '#527342' : '#789054';
-          context.fillRect(Math.round(worldX - camera.x) + 3,
-            Math.round(bankY - camera.y), Math.max(3, width - 3), 2);
-        }
+        context.fillRect(Math.round(water.x), Math.round(water.y), width, 2);
+      }
+    }
+  }
+
+  function paintStreamShallows() {
+    const surfaces = visibleStreamBankModel().surfaces;
+    for (const side of [-1, 1]) {
+      const edge = surfaces.filter(({ side: candidateSide, stratum }) => (
+        candidateSide === side && stratum === 3
+      ));
+      if (!edge.length) continue;
+      const inner = [edge[0].points[1], ...edge.map(surface => surface.points[2])];
+      const submerged = inner.map(point => ({ ...point, y: point.y - (side * 13) }));
+      context.beginPath();
+      [...inner, ...submerged.reverse()].forEach((value, index) => {
+        const point = projectForestPoint3d(value, camera);
+        if (index === 0) context.moveTo(point.x, point.y);
+        else context.lineTo(point.x, point.y);
+      });
+      context.closePath();
+      context.fillStyle = side < 0 ? 'rgba(151, 145, 91, 0.25)'
+        : 'rgba(105, 101, 69, 0.32)';
+      context.fill();
+    }
+    const spacing = 27;
+    const firstColumn = Math.floor((camera.x - spacing) / spacing);
+    const lastColumn = Math.ceil((camera.x + camera.width + spacing) / spacing);
+    for (let column = firstColumn; column <= lastColumn; column += 1) {
+      const worldX = column * spacing;
+      for (const side of [-1, 1]) {
+        const identity = column + (side * 613);
+        if (streamFlowVariation(identity, side, 31) < 0.38) continue;
+        const edge = streamBankEdgeScreenPoint(worldX, side);
+        const x = Math.round(edge.x + ((streamFlowVariation(identity, side, 32) - 0.5) * 8));
+        const y = Math.round(edge.y - (side * (4
+          + (streamFlowVariation(identity, side, 33) * 5))));
+        const width = 3 + Math.floor(streamFlowVariation(identity, side, 34) * 5);
+        context.fillStyle = 'rgba(43, 61, 56, 0.48)';
+        context.fillRect(x - 1, y + 1, width + 2, 2);
+        context.fillStyle = 'rgba(170, 177, 139, 0.44)';
+        context.fillRect(x, y, width, 2);
       }
     }
   }
 
   function paintStream(elapsedSeconds) {
     const stream = scene.environment.stream;
-    paintStreamRibbon(stream.halfWidth + stream.bankWidth, '#61794b');
-    paintStreamRibbon(stream.halfWidth + 6, '#336d67');
-    paintStreamRibbon(stream.halfWidth, '#247486');
+    paintStreamBank(-1);
+    paintStreamWaterSurface('#247486');
     paintStreamColorBand(7, 20, '#2f8190', 176, 0.4);
     paintStreamColorBand(-22, 7, '#4b9b9b', 127, 2.1);
     paintStreamColorBand(27, 5, '#1d687d', 151, 4.6);
+    paintStreamShallows();
     paintStreamSurfaceTexture(stream);
-    paintStreamEdgeTexture(stream);
+    paintStreamEdgeTexture();
     const spacing = 76;
     const firstMark = Math.floor((camera.x - spacing) / spacing);
     const lastMark = Math.ceil((camera.x + camera.width + spacing) / spacing);
@@ -808,9 +971,10 @@ if (payload && viewportElement && canvas) {
           const streamQueryX = Math.round(worldX);
           const laneStep = segment === 1 ? stepDirection * 2 : 0;
           const baseY = forestStreamCenterY(scene.environment, streamQueryX) + lane + laneStep;
-          const worldY = baseY + streamFlowDeflection(worldX, baseY);
-          const screenX = Math.round(worldX - camera.x);
-          const screenY = Math.round(worldY - camera.y);
+          const deflection = streamFlowDeflection(worldX, baseY);
+          const point = streamScreenPoint(worldX, lane + laneStep + deflection);
+          const screenX = Math.round(point.x);
+          const screenY = Math.round(point.y);
           const segmentWidth = Math.max(5,
             Math.ceil(length / segmentCount) + (segment === 1 ? 2 : 0));
           context.fillStyle = lane === -9 || lane === 28 ? '#a1d0bd' : '#79c3bb';
@@ -827,17 +991,12 @@ if (payload && viewportElement && canvas) {
         }
       }
     }
+    paintStreamBank(1);
   }
 
-  function bridgeScreenPoint(bridge, longitudinal, lateral = 0, elevated = true) {
-    const world = forestBridgeWorldPosition(bridge, longitudinal, lateral);
-    const elevationPosition = forestBridgeWorldPosition(bridge, longitudinal, 0);
-    const elevation = elevated
-      ? forestBridgeElevationAt(bridge, elevationPosition) : 0;
-    return {
-      x: Math.round(world.worldX - camera.x),
-      y: Math.round(world.worldY - camera.y - elevation)
-    };
+  function bridgeScreenPoint(point) {
+    const projected = projectForestPoint3d(point, camera);
+    return { x: Math.round(projected.x), y: Math.round(projected.y) };
   }
 
   function bridgePolygon(points, fillStyle) {
@@ -851,192 +1010,74 @@ if (payload && viewportElement && canvas) {
     context.fill();
   }
 
+  function bridgeSurfaceDepth(surface) {
+    return surface.points.reduce((sum, point) => (
+      sum + projectForestPoint3d(point, camera).depth
+    ), 0) / surface.points.length;
+  }
+
   function paintBridgeDeck(bridge) {
-    const sideDrop = 11;
-
-    for (const endSign of [-1, 1]) {
-      for (const side of [-1, 1]) {
-        const inner = endSign * (bridge.halfLength - 8);
-        const outer = endSign * (bridge.halfLength + 7);
-        const nearSide = side * (bridge.halfWidth - 4);
-        const farSide = side * (bridge.halfWidth + 10);
-        bridgePolygon([
-          bridgeScreenPoint(bridge, inner, nearSide, false),
-          bridgeScreenPoint(bridge, inner, farSide, false),
-          bridgeScreenPoint(bridge, outer, farSide, false),
-          bridgeScreenPoint(bridge, outer, nearSide, false)
-        ], '#555344');
-        bridgePolygon([
-          bridgeScreenPoint(bridge, inner + (endSign * 2), nearSide, false),
-          bridgeScreenPoint(bridge, inner + (endSign * 2),
-            side * (bridge.halfWidth + 6), false),
-          bridgeScreenPoint(bridge, outer - (endSign * 2),
-            side * (bridge.halfWidth + 6), false),
-          bridgeScreenPoint(bridge, outer - (endSign * 2), nearSide, false)
-        ], '#85806a');
-      }
-    }
-
-    bridgePolygon([
-      bridgeScreenPoint(bridge, -bridge.halfLength, -bridge.halfWidth - 6, false),
-      bridgeScreenPoint(bridge, -bridge.halfLength, bridge.halfWidth + 6, false),
-      bridgeScreenPoint(bridge, bridge.halfLength, bridge.halfWidth + 6, false),
-      bridgeScreenPoint(bridge, bridge.halfLength, -bridge.halfWidth - 6, false)
-    ].map(point => ({ x: point.x + 3, y: point.y + 7 })), 'rgba(27, 39, 37, 0.34)');
-
-    for (const side of [-1, 1]) {
-      const archEdge = [];
-      for (let longitudinal = -bridge.halfLength; longitudinal < bridge.halfLength;
-        longitudinal += 12) {
-        const next = Math.min(bridge.halfLength, longitudinal + 12);
-        const start = bridgeScreenPoint(bridge, longitudinal, side * (bridge.halfWidth + 1));
-        const end = bridgeScreenPoint(bridge, next, side * (bridge.halfWidth + 1));
-        if (!archEdge.length) archEdge.push(start);
-        archEdge.push(end);
-        bridgePolygon([start, end, { x: end.x, y: end.y + sideDrop },
-          { x: start.x, y: start.y + sideDrop }], side < 0 ? '#493225' : '#392a22');
-      }
+    const model = bridgeModels.get(bridge.id);
+    const roleOrder = { shadow: 0, abutment: 1, fascia: 2, 'plank-end': 3, plank: 4 };
+    const surfaces = [...model.surfaces].sort((left, right) => (
+      roleOrder[left.role] - roleOrder[right.role]
+      || bridgeSurfaceDepth(left) - bridgeSurfaceDepth(right)
+      || left.ordinal - right.ordinal
+    ));
+    for (const surface of surfaces) {
+      const points = surface.points.map(bridgeScreenPoint);
+      bridgePolygon(points, surface.fill);
+      if (surface.role !== 'plank') continue;
       context.beginPath();
-      archEdge.forEach((point, index) => {
-        if (index === 0) context.moveTo(point.x, point.y + sideDrop);
-        else context.lineTo(point.x, point.y + sideDrop);
-      });
-      context.strokeStyle = '#2f2924';
-      context.lineWidth = 3;
-      context.lineJoin = 'round';
-      context.stroke();
-      context.beginPath();
-      archEdge.forEach((point, index) => {
-        if (index === 0) context.moveTo(point.x, point.y + 2);
-        else context.lineTo(point.x, point.y + 2);
-      });
-      context.strokeStyle = '#805536';
-      context.lineWidth = 2;
-      context.stroke();
-    }
-
-    bridgePolygon([
-      bridgeScreenPoint(bridge, -bridge.halfLength, -bridge.halfWidth),
-      bridgeScreenPoint(bridge, -bridge.halfLength, bridge.halfWidth),
-      bridgeScreenPoint(bridge, bridge.halfLength, bridge.halfWidth),
-      bridgeScreenPoint(bridge, bridge.halfLength, -bridge.halfWidth)
-    ], '#563a29');
-
-    let longitudinal = -bridge.halfLength;
-    let plankOrdinal = 0;
-    while (longitudinal < bridge.halfLength) {
-      const plankWidth = 6 + Math.floor(bridgePresentationVariation(
-        bridge, 1, plankOrdinal
-      ) * 5);
-      const next = Math.min(bridge.halfLength, longitudinal + plankWidth);
-      const startLeftInset = Math.floor(bridgePresentationVariation(
-        bridge, 2, plankOrdinal
-      ) * 3);
-      const startRightInset = Math.floor(bridgePresentationVariation(
-        bridge, 3, plankOrdinal
-      ) * 3);
-      const endLeftInset = Math.floor(bridgePresentationVariation(
-        bridge, 2, plankOrdinal + 1
-      ) * 3);
-      const endRightInset = Math.floor(bridgePresentationVariation(
-        bridge, 3, plankOrdinal + 1
-      ) * 3);
-      const plank = [
-        bridgeScreenPoint(bridge, longitudinal, -bridge.halfWidth + startLeftInset),
-        bridgeScreenPoint(bridge, longitudinal, bridge.halfWidth - startRightInset),
-        bridgeScreenPoint(bridge, next, bridge.halfWidth - endRightInset),
-        bridgeScreenPoint(bridge, next, -bridge.halfWidth + endLeftInset)
-      ];
-      const plankCenter = forestBridgeWorldPosition(bridge,
-        longitudinal + (plankWidth * 0.5), 0);
-      const elevationRatio = forestBridgeElevationAt(bridge, plankCenter)
-        / bridge.maximumElevationPixels;
-      const plankColors = elevationRatio > 0.72
-        ? ['#b87f49', '#c08a52', '#a87243', '#b7804c']
-        : elevationRatio > 0.34
-          ? ['#a66f42', '#b57d49', '#96613b', '#aa7243']
-          : ['#925f3c', '#a36c41', '#835536', '#98623c'];
-      const colorIndex = Math.floor(bridgePresentationVariation(bridge, 4, plankOrdinal)
-        * plankColors.length);
-      bridgePolygon(plank, plankColors[colorIndex]);
-      context.beginPath();
-      const seamStart = bridgeScreenPoint(bridge, longitudinal,
-        -bridge.halfWidth + startLeftInset + 2);
-      const seamEnd = bridgeScreenPoint(bridge, longitudinal,
-        bridge.halfWidth - startRightInset - 2);
-      context.moveTo(seamStart.x, seamStart.y);
-      context.lineTo(seamEnd.x, seamEnd.y);
-      context.strokeStyle = elevationRatio > 0.72 ? '#795033' : '#65452f';
+      context.moveTo(points[0].x, points[0].y);
+      context.lineTo(points[1].x, points[1].y);
+      context.strokeStyle = surface.points[0].z > bridge.maximumElevationPixels * 0.72
+        ? model.palette.seamHigh : model.palette.seam;
       context.lineWidth = 1;
       context.stroke();
-      const grainCenter = -bridge.halfWidth + 12
-        + (bridgePresentationVariation(bridge, 5, plankOrdinal) * (bridge.halfWidth * 1.25));
-      const grainLength = 5 + Math.floor(bridgePresentationVariation(
-        bridge, 6, plankOrdinal
-      ) * 7);
-      bridgePolygon([
-        bridgeScreenPoint(bridge, longitudinal + (plankWidth * 0.52),
-          grainCenter - grainLength),
-        bridgeScreenPoint(bridge, longitudinal + (plankWidth * 0.52),
-          grainCenter + grainLength),
-        bridgeScreenPoint(bridge, longitudinal + (plankWidth * 0.52) + 1,
-          grainCenter + grainLength),
-        bridgeScreenPoint(bridge, longitudinal + (plankWidth * 0.52) + 1,
-          grainCenter - grainLength)
-      ], bridgePresentationVariation(bridge, 6, plankOrdinal) > 0.72
-        ? '#5b3b2a' : '#c0874f');
-      if (plankOrdinal % 3 !== 1) {
-        for (const side of [-1, 1]) {
-          const nail = bridgeScreenPoint(bridge, longitudinal + 2,
-            side * (bridge.halfWidth - 6));
-          context.fillStyle = '#3d342d';
-          context.fillRect(nail.x, nail.y, 2, 2);
-        }
+    }
+    for (const detail of model.details) {
+      const from = bridgeScreenPoint(detail.from);
+      const to = bridgeScreenPoint(detail.to);
+      context.strokeStyle = detail.color;
+      context.fillStyle = detail.color;
+      if (detail.role === 'nail') {
+        context.fillRect(from.x - 1, from.y - 1, detail.width, detail.width);
+        continue;
       }
-      longitudinal = next;
-      plankOrdinal += 1;
+      context.beginPath();
+      context.moveTo(from.x, from.y);
+      context.lineTo(to.x, to.y);
+      context.lineWidth = detail.width;
+      context.stroke();
     }
   }
 
+  function paintBridgeMember(member) {
+    const from = bridgeScreenPoint(member.from);
+    const to = bridgeScreenPoint(member.to);
+    context.beginPath();
+    context.moveTo(from.x, from.y);
+    context.lineTo(to.x, to.y);
+    context.strokeStyle = member.colors[0];
+    context.lineWidth = member.width;
+    context.lineCap = 'round';
+    context.lineJoin = 'round';
+    context.stroke();
+    context.strokeStyle = member.colors[1];
+    context.lineWidth = Math.max(1, Math.floor(member.width / 3));
+    context.stroke();
+  }
+
   function paintBridgeRails(bridge) {
-    for (const side of [-1, 1]) {
-      const railPoints = [];
-      let longitudinal = -bridge.halfLength;
-      let postOrdinal = 0;
-      while (longitudinal <= bridge.halfLength) {
-        const point = bridgeScreenPoint(bridge, longitudinal, side * (bridge.halfWidth + 2));
-        const postHeight = 10 + Math.floor(bridgePresentationVariation(
-          bridge, 7, postOrdinal, side
-        ) * 5);
-        railPoints.push({ x: point.x, y: point.y - postHeight + 2 });
-        context.fillStyle = '#493325';
-        context.fillRect(point.x - 3, point.y - postHeight, 6, postHeight + 5);
-        context.fillStyle = '#9e6b40';
-        context.fillRect(point.x - 1, point.y - postHeight + 1, 2, postHeight - 1);
-        context.fillStyle = '#c08a55';
-        context.fillRect(point.x - 1, point.y - postHeight - 1, 3, 2);
-        longitudinal += 19 + Math.floor(bridgePresentationVariation(
-          bridge, 8, postOrdinal, side
-        ) * 7);
-        postOrdinal += 1;
-      }
-      const end = bridgeScreenPoint(bridge, bridge.halfLength,
-        side * (bridge.halfWidth + 2));
-      railPoints.push({ x: end.x, y: end.y - 9 });
-      context.beginPath();
-      railPoints.forEach((point, index) => {
-        if (index === 0) context.moveTo(point.x, point.y);
-        else context.lineTo(point.x, point.y);
-      });
-      context.strokeStyle = '#473126';
-      context.lineWidth = 6;
-      context.lineCap = 'round';
-      context.lineJoin = 'round';
-      context.stroke();
-      context.strokeStyle = '#9f6b3e';
-      context.lineWidth = 2;
-      context.stroke();
-    }
+    const model = bridgeModels.get(bridge.id);
+    [...model.members].sort((left, right) => {
+      const leftDepth = (projectForestPoint3d(left.from, camera).depth
+        + projectForestPoint3d(left.to, camera).depth) / 2;
+      const rightDepth = (projectForestPoint3d(right.from, camera).depth
+        + projectForestPoint3d(right.to, camera).depth) / 2;
+      return leftDepth - rightDepth || left.ordinal - right.ordinal;
+    }).forEach(paintBridgeMember);
   }
 
   function paintTree(placement, elapsedSeconds) {
@@ -1073,7 +1114,9 @@ if (payload && viewportElement && canvas) {
 
   function paintBoulder(boulder) {
     const x = Math.round(boulder.worldX - camera.x);
-    const y = Math.round(boulder.worldY - camera.y);
+    const waterDepth = boulder.terrainRole === 'stream-boulder'
+      ? forestStreamWaterDepthAt(scene.environment, boulder.worldX) : 0;
+    const y = Math.round(boulder.worldY - camera.y + waterDepth);
     const width = boulder.width;
     const height = boulder.height;
     const left = x - Math.floor(width / 2);

--- a/public/js/forest-bridges.js
+++ b/public/js/forest-bridges.js
@@ -1,0 +1,228 @@
+export { projectForestPoint3d } from './forest-projection.js';
+export const FOREST_BRIDGE_TYPE = 'arched-footbridge';
+export const FOREST_BRIDGE_DEFINITION_ID = 'rustic-timber-arch';
+
+export const FOREST_BRIDGE_DEFINITIONS = Object.freeze([
+  Object.freeze({
+    id: FOREST_BRIDGE_DEFINITION_ID,
+    type: FOREST_BRIDGE_TYPE,
+    profile: Object.freeze({ shape: 'circular-segment' }),
+    deck: Object.freeze({
+      thickness: 8,
+      plankLength: Object.freeze([7, 11]),
+      edgeInset: 1,
+      nailInset: 6
+    }),
+    fascia: Object.freeze({ lateralOffset: 1, thickness: 9 }),
+    rail: Object.freeze({
+      lateralOffset: 3,
+      height: 19,
+      postSpacing: 22,
+      postWidth: 5,
+      handrailWidth: 6
+    }),
+    abutment: Object.freeze({ length: 14, lateralExtension: 8 }),
+    palette: Object.freeze({
+      shadow: 'rgba(27, 39, 37, 0.34)',
+      abutmentDark: '#555344',
+      abutmentLight: '#85806a',
+      underside: '#34271f',
+      fasciaDark: '#493225',
+      fasciaLight: '#805536',
+      plankLow: Object.freeze(['#925f3c', '#a36c41', '#835536', '#98623c']),
+      plankMid: Object.freeze(['#a66f42', '#b57d49', '#96613b', '#aa7243']),
+      plankHigh: Object.freeze(['#b87f49', '#c08a52', '#a87243', '#b7804c']),
+      seam: '#65452f',
+      seamHigh: '#795033',
+      grainDark: '#5b3b2a',
+      grainLight: '#c0874f',
+      nail: '#3d342d',
+      railDark: '#473126',
+      railMid: '#9f6b3e',
+      railLight: '#c08a55'
+    })
+  })
+]);
+
+export function resolveForestBridgeDefinition(id) {
+  return FOREST_BRIDGE_DEFINITIONS.find(definition => definition.id === id) || null;
+}
+
+function bridgeVariation(bridge, decision, ordinal = 0, side = 0) {
+  const value = Math.sin((bridge.worldX * 0.071)
+    + (bridge.worldY * 0.037) + (decision * 47.31)
+    + (ordinal * 91.73) + (side * 19.17)) * 43758.5453;
+  return value - Math.floor(value);
+}
+
+export function forestBridgeProfileHeight(bridge, longitudinal) {
+  const definition = resolveForestBridgeDefinition(bridge.definitionId);
+  if (!definition || definition.profile.shape !== 'circular-segment') return 0;
+  const halfLength = bridge.halfLength;
+  const rise = bridge.maximumElevationPixels;
+  const bounded = Math.max(-halfLength, Math.min(halfLength, longitudinal));
+  const radius = ((halfLength * halfLength) + (rise * rise)) / (2 * rise);
+  const springHeight = Math.sqrt(Math.max(0, (radius * radius)
+    - (halfLength * halfLength)));
+  return Math.max(0, Math.sqrt(Math.max(0, (radius * radius) - (bounded * bounded)))
+    - springHeight);
+}
+
+export function forestBridgePoint3d(bridge, longitudinal, lateral = 0, heightOffset = 0) {
+  const angle = bridge.angleMilliradians / 1000;
+  return {
+    x: bridge.worldX + (Math.cos(angle) * longitudinal) - (Math.sin(angle) * lateral),
+    y: bridge.worldY + (Math.sin(angle) * longitudinal) + (Math.cos(angle) * lateral),
+    z: forestBridgeProfileHeight(bridge, longitudinal) + heightOffset
+  };
+}
+
+function surface(id, role, points, fill, ordinal = 0) {
+  return Object.freeze({ id, role, points: Object.freeze(points), fill, ordinal });
+}
+
+function member(id, role, from, to, width, colors, ordinal = 0) {
+  return Object.freeze({ id, role, from, to, width, colors, ordinal });
+}
+
+function detail(id, role, from, to, width, color, ordinal = 0) {
+  return Object.freeze({ id, role, from, to, width, color, ordinal });
+}
+
+export function buildForestBridgeModel3d(bridge) {
+  const definition = resolveForestBridgeDefinition(bridge.definitionId);
+  if (!definition) throw new Error('Cannot build an unknown forest bridge definition.');
+  const { deck, fascia, rail, abutment, palette } = definition;
+  const surfaces = [];
+  const members = [];
+  const details = [];
+
+  surfaces.push(surface('ground-shadow', 'shadow', [
+    forestBridgePoint3d(bridge, -bridge.halfLength - 4, -bridge.halfWidth - 5,
+      -forestBridgeProfileHeight(bridge, -bridge.halfLength - 4)),
+    forestBridgePoint3d(bridge, -bridge.halfLength - 4, bridge.halfWidth + 5,
+      -forestBridgeProfileHeight(bridge, -bridge.halfLength - 4)),
+    forestBridgePoint3d(bridge, bridge.halfLength + 4, bridge.halfWidth + 5,
+      -forestBridgeProfileHeight(bridge, bridge.halfLength + 4)),
+    forestBridgePoint3d(bridge, bridge.halfLength + 4, -bridge.halfWidth - 5,
+      -forestBridgeProfileHeight(bridge, bridge.halfLength + 4))
+  ], palette.shadow));
+
+  for (const endSign of [-1, 1]) {
+    const inner = endSign * (bridge.halfLength - 7);
+    const outer = endSign * (bridge.halfLength + abutment.length);
+    surfaces.push(surface(`abutment-${endSign}`, 'abutment', [
+      forestBridgePoint3d(bridge, inner, -bridge.halfWidth + 4,
+        -forestBridgeProfileHeight(bridge, inner)),
+      forestBridgePoint3d(bridge, inner, bridge.halfWidth - 4,
+        -forestBridgeProfileHeight(bridge, inner)),
+      forestBridgePoint3d(bridge, outer, bridge.halfWidth + abutment.lateralExtension,
+        -forestBridgeProfileHeight(bridge, outer)),
+      forestBridgePoint3d(bridge, outer, -bridge.halfWidth - abutment.lateralExtension,
+        -forestBridgeProfileHeight(bridge, outer))
+    ], endSign < 0 ? palette.abutmentDark : palette.abutmentLight));
+  }
+
+  for (const side of [-1, 1]) {
+    const lateral = side * (bridge.halfWidth + fascia.lateralOffset);
+    for (let start = -bridge.halfLength, ordinal = 0; start < bridge.halfLength;
+      start += 10, ordinal += 1) {
+      const end = Math.min(bridge.halfLength, start + 10);
+      surfaces.push(surface(`fascia-${side}-${ordinal}`, 'fascia', [
+        forestBridgePoint3d(bridge, start, lateral, -1),
+        forestBridgePoint3d(bridge, end, lateral, -1),
+        forestBridgePoint3d(bridge, end, lateral, -1 - fascia.thickness),
+        forestBridgePoint3d(bridge, start, lateral, -1 - fascia.thickness)
+      ], side < 0 ? palette.fasciaLight : palette.fasciaDark, ordinal));
+    }
+  }
+
+  let start = -bridge.halfLength;
+  let plankOrdinal = 0;
+  while (start < bridge.halfLength) {
+    const plankLength = deck.plankLength[0] + Math.floor(bridgeVariation(
+      bridge, 1, plankOrdinal
+    ) * ((deck.plankLength[1] - deck.plankLength[0]) + 1));
+    const end = Math.min(bridge.halfLength, start + plankLength);
+    const startLeftInset = deck.edgeInset + Math.floor(bridgeVariation(
+      bridge, 2, plankOrdinal
+    ) * 2);
+    const startRightInset = deck.edgeInset + Math.floor(bridgeVariation(
+      bridge, 3, plankOrdinal
+    ) * 2);
+    const endLeftInset = deck.edgeInset + Math.floor(bridgeVariation(
+      bridge, 2, plankOrdinal + 1
+    ) * 2);
+    const endRightInset = deck.edgeInset + Math.floor(bridgeVariation(
+      bridge, 3, plankOrdinal + 1
+    ) * 2);
+    const elevationRatio = forestBridgeProfileHeight(bridge, (start + end) / 2)
+      / bridge.maximumElevationPixels;
+    const plankPalette = elevationRatio > 0.72 ? palette.plankHigh
+      : elevationRatio > 0.34 ? palette.plankMid : palette.plankLow;
+    const fill = plankPalette[Math.floor(bridgeVariation(bridge, 4, plankOrdinal)
+      * plankPalette.length)];
+    const top = [
+      forestBridgePoint3d(bridge, start, -bridge.halfWidth + startLeftInset),
+      forestBridgePoint3d(bridge, start, bridge.halfWidth - startRightInset),
+      forestBridgePoint3d(bridge, end, bridge.halfWidth - endRightInset),
+      forestBridgePoint3d(bridge, end, -bridge.halfWidth + endLeftInset)
+    ];
+    surfaces.push(surface(`plank-${plankOrdinal}`, 'plank', top, fill, plankOrdinal));
+    surfaces.push(surface(`plank-end-${plankOrdinal}`, 'plank-end', [
+      top[0], top[1],
+      forestBridgePoint3d(bridge, start, bridge.halfWidth - startRightInset,
+        -deck.thickness),
+      forestBridgePoint3d(bridge, start, -bridge.halfWidth + startLeftInset,
+        -deck.thickness)
+    ], palette.underside, plankOrdinal));
+    const grainCenter = -bridge.halfWidth + 12
+      + (bridgeVariation(bridge, 5, plankOrdinal) * (bridge.halfWidth * 1.25));
+    const grainLength = 5 + Math.floor(bridgeVariation(bridge, 6, plankOrdinal) * 7);
+    const grainLongitudinal = start + ((end - start) * 0.52);
+    details.push(detail(`grain-${plankOrdinal}`, 'grain',
+      forestBridgePoint3d(bridge, grainLongitudinal, grainCenter - grainLength, 0.2),
+      forestBridgePoint3d(bridge, grainLongitudinal, grainCenter + grainLength, 0.2),
+      1, bridgeVariation(bridge, 6, plankOrdinal) > 0.72
+        ? palette.grainDark : palette.grainLight, plankOrdinal));
+    if (plankOrdinal % 3 !== 1) {
+      for (const side of [-1, 1]) {
+        const nail = forestBridgePoint3d(
+          bridge, Math.min(end - 1, start + 2), side * (bridge.halfWidth - deck.nailInset), 0.4
+        );
+        details.push(detail(`nail-${side}-${plankOrdinal}`, 'nail', nail, nail,
+          2, palette.nail, plankOrdinal));
+      }
+    }
+    start = end;
+    plankOrdinal += 1;
+  }
+
+  const postLongitudes = [];
+  for (let longitudinal = -bridge.halfLength; longitudinal < bridge.halfLength;
+    longitudinal += rail.postSpacing) postLongitudes.push(longitudinal);
+  if (postLongitudes.at(-1) !== bridge.halfLength) postLongitudes.push(bridge.halfLength);
+  for (const side of [-1, 1]) {
+    const lateral = side * (bridge.halfWidth + rail.lateralOffset);
+    postLongitudes.forEach((longitudinal, ordinal) => {
+      members.push(member(`post-${side}-${ordinal}`, 'post',
+        forestBridgePoint3d(bridge, longitudinal, lateral, -2),
+        forestBridgePoint3d(bridge, longitudinal, lateral, rail.height),
+        rail.postWidth, [palette.railDark, palette.railLight], ordinal));
+      if (ordinal > 0) {
+        members.push(member(`rail-${side}-${ordinal}`, 'rail',
+          forestBridgePoint3d(bridge, postLongitudes[ordinal - 1], lateral, rail.height),
+          forestBridgePoint3d(bridge, longitudinal, lateral, rail.height),
+          rail.handrailWidth, [palette.railDark, palette.railMid], ordinal));
+      }
+    });
+  }
+
+  return Object.freeze({
+    definitionId: definition.id,
+    surfaces: Object.freeze(surfaces),
+    details: Object.freeze(details),
+    members: Object.freeze(members),
+    palette
+  });
+}

--- a/public/js/forest-environment.js
+++ b/public/js/forest-environment.js
@@ -1,13 +1,20 @@
+import {
+  FOREST_BRIDGE_TYPE,
+  forestBridgeProfileHeight,
+  resolveForestBridgeDefinition
+} from './forest-bridges.js';
+import { forestStreamBankProfileAt } from './forest-stream-banks.js';
+
 export const FOREST_ENVIRONMENT_SCHEMA_VERSION = 2;
 export const FOREST_WORLD_GENERATION_VERSION = 2;
-export const FOREST_GROUND_PRESENTATION_VERSION = 11;
+export const FOREST_GROUND_PRESENTATION_VERSION = 13;
 export const FOREST_ENVIRONMENT_GRAMMAR_ID = 'grove-rocky-rise-and-stream';
 export const FOREST_GROUND_DETAIL_VERSION = 1;
 export const FOREST_GROUND_DETAIL_CELL_SIZE = 48;
 export const FOREST_BOULDER_TYPE = 'generated-boulder';
-export const FOREST_BRIDGE_TYPE = 'arched-footbridge';
-export const FOREST_CROSSING_SCHEMA_VERSION = 2;
-export const FOREST_CROSSING_GENERATION_VERSION = 5;
+export { FOREST_BRIDGE_TYPE } from './forest-bridges.js';
+export const FOREST_CROSSING_SCHEMA_VERSION = 3;
+export const FOREST_CROSSING_GENERATION_VERSION = 6;
 export const FOREST_ROCK_PALETTES = Object.freeze([
   Object.freeze({
     id: 'mossed-green', weight: 40,
@@ -65,7 +72,7 @@ const POSITION_KEYS = Object.freeze(['worldX', 'worldY']);
 const CELL_KEYS = Object.freeze(['column', 'row']);
 const CROSSING_KEYS = Object.freeze([
   'schemaVersion', 'generationVersion', 'id', 'type', 'worldX', 'worldY', 'orientation',
-  'angleMilliradians', 'halfWidth', 'halfLength', 'maximumElevationPixels'
+  'angleMilliradians', 'definitionId', 'halfWidth', 'halfLength', 'maximumElevationPixels'
 ]);
 
 function exactKeys(value, expected) {
@@ -208,6 +215,19 @@ export function forestStreamCenterY(manifest, worldX) {
   return Math.round(streamCenterY(manifest, worldX));
 }
 
+export function forestStreamWaterContains(manifest, position, padding = 0) {
+  if (!Number.isFinite(position?.worldX) || !Number.isFinite(position?.worldY)
+    || !Number.isFinite(padding) || padding < 0
+    || position.worldX < 0 || position.worldX > manifest.world.width) return false;
+  const centerY = streamCenterY(manifest, position.worldX);
+  const farProfile = forestStreamBankProfileAt(manifest, position.worldX, -1);
+  const nearProfile = forestStreamBankProfileAt(manifest, position.worldX, 1);
+  const farHalfWidth = manifest.stream.halfWidth + Math.max(0, farProfile.innerOffset);
+  const nearHalfWidth = manifest.stream.halfWidth + Math.max(0, nearProfile.innerOffset);
+  return position.worldY + padding >= centerY - farHalfWidth
+    && position.worldY - padding <= centerY + nearHalfWidth;
+}
+
 export function forestEnvironmentAt(manifest, position) {
   validateForestEnvironmentManifest(manifest);
   if (!exactKeys(position, POSITION_KEYS)
@@ -328,14 +348,15 @@ export function validateForestStreamCrossing(crossing, world) {
     || crossing.schemaVersion !== FOREST_CROSSING_SCHEMA_VERSION
     || crossing.generationVersion !== FOREST_CROSSING_GENERATION_VERSION
     || ![
-      'forest-crossing-v5-stream-footbridge-primary',
-      'forest-crossing-v5-stream-footbridge-secondary'
+      'forest-crossing-v6-stream-footbridge-primary',
+      'forest-crossing-v6-stream-footbridge-secondary'
     ].includes(crossing.id)
     || crossing.type !== FOREST_BRIDGE_TYPE
     || !boundedInteger(crossing.worldX, 0, world.width)
     || !boundedInteger(crossing.worldY, 0, world.height)
     || crossing.orientation !== 'world-angle'
     || !boundedInteger(crossing.angleMilliradians, -6283, 6283)
+    || resolveForestBridgeDefinition(crossing.definitionId)?.type !== crossing.type
     || !boundedInteger(crossing.halfWidth, 20, 60)
     || !boundedInteger(crossing.halfLength, 70, 160)
     || !boundedInteger(crossing.maximumElevationPixels, 4, 24)) {
@@ -392,11 +413,6 @@ export function forestBridgeWorldPosition(crossing, longitudinal, lateral = 0) {
 
 export function forestBridgeElevationAt(crossing, position) {
   if (!forestBridgeContains(crossing, position)) return 0;
-  const angle = crossing.angleMilliradians / 1000;
-  if (Math.abs(Math.cos(angle)) < 0.001) return 0;
   const { longitudinal } = forestBridgeLocalCoordinates(crossing, position);
-  const progress = Math.max(0, 1 - (Math.abs(longitudinal) / crossing.halfLength));
-  if (progress < 0.001) return 0;
-  const easedRamp = Math.sin(progress * Math.PI / 2);
-  return Math.max(1, Math.round(easedRamp * crossing.maximumElevationPixels));
+  return Math.round(forestBridgeProfileHeight(crossing, longitudinal));
 }

--- a/public/js/forest-projection.js
+++ b/public/js/forest-projection.js
@@ -1,0 +1,7 @@
+export function projectForestPoint3d(point, camera = { x: 0, y: 0 }) {
+  return {
+    x: point.x - camera.x,
+    y: point.y - camera.y - point.z,
+    depth: point.y + point.z
+  };
+}

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -17,7 +17,7 @@ import {
   FOREST_BOULDER_TYPE,
   forestBridgeContains,
   forestBridgeRailCollides,
-  forestEnvironmentAt
+  forestStreamWaterContains
 } from './forest-environment.js';
 
 export function placementVisualRect(placement, asset) {
@@ -260,10 +260,7 @@ export function forestTerrainTraversableAt(scene, position) {
   if (crossings.some(crossing => forestBridgeRailCollides(
     crossing, position, position.radius || 0
   ))) return false;
-  const environment = forestEnvironmentAt(scene.environment, {
-    worldX: Math.round(position.worldX), worldY: Math.round(position.worldY)
-  });
-  if (environment.hydrology.state !== 'water') return true;
+  if (!forestStreamWaterContains(scene.environment, position, position.radius || 0)) return true;
   return crossings.some(crossing => forestBridgeContains(
     crossing, position, -(position.radius || 0)
   ));

--- a/public/js/forest-stream-banks.js
+++ b/public/js/forest-stream-banks.js
@@ -374,8 +374,8 @@ export function buildForestStreamBankModel3d(manifest, range, centerYAt) {
     * definition.sampleStep);
   const model = { definitionId: definition.id, surfaces: [], details: [], marks: [] };
   for (const side of [-1, 1]) {
-    let ordinal = 0;
     for (let startX = firstX; startX < lastX; startX += definition.sampleStep) {
+      const ordinal = Math.floor(startX / definition.sampleStep);
       const endX = Math.min(lastX, startX + definition.sampleStep);
       const startProfile = forestStreamBankProfileAt(manifest, startX, side);
       const endProfile = forestStreamBankProfileAt(manifest, endX, side);
@@ -399,7 +399,6 @@ export function buildForestStreamBankModel3d(manifest, range, centerYAt) {
       }
       appendSegmentDetails(model, manifest, startProfile, endProfile,
         startCenterY, endCenterY, ordinal);
-      ordinal += 1;
     }
     const firstSection = Math.floor(firstX / definition.compositionSectionLength) - 1;
     const lastSection = Math.ceil(lastX / definition.compositionSectionLength) + 1;

--- a/public/js/forest-stream-banks.js
+++ b/public/js/forest-stream-banks.js
@@ -1,0 +1,416 @@
+export const FOREST_STREAM_BANK_DEFINITION_ID = 'varied-incised-creek-bank';
+export const FOREST_STREAM_BANK_MODEL_VERSION = 3;
+export const FOREST_STREAM_BANK_SAMPLE_STEP = 16;
+
+export const FOREST_STREAM_BANK_COMPOSITIONS = Object.freeze([
+  Object.freeze({
+    id: 'grassy', weight: 42,
+    strata: Object.freeze({
+      far: Object.freeze(['#68764d', '#716044', '#5e4e3d', '#403a33']),
+      near: Object.freeze(['#596b46', '#66543e', '#524438', '#37322e'])
+    }),
+    lip: '#89ad5c', shadow: '#314936', detail: '#acd36d'
+  }),
+  Object.freeze({
+    id: 'rocky', weight: 25,
+    strata: Object.freeze({
+      far: Object.freeze(['#737763', '#686555', '#55524a', '#383e3a']),
+      near: Object.freeze(['#626b58', '#5c594f', '#494741', '#313633'])
+    }),
+    lip: '#879273', shadow: '#343f3d', detail: '#abb09a'
+  }),
+  Object.freeze({
+    id: 'bare-dirt', weight: 23,
+    strata: Object.freeze({
+      far: Object.freeze(['#876e4c', '#775b3e', '#604838', '#3d312b']),
+      near: Object.freeze(['#765f44', '#694e39', '#513d33', '#342b27'])
+    }),
+    lip: '#98764e', shadow: '#49372d', detail: '#b18a59'
+  }),
+  Object.freeze({
+    id: 'fallen-log-jam', weight: 10,
+    strata: Object.freeze({
+      far: Object.freeze(['#657048', '#685039', '#503d31', '#352d28']),
+      near: Object.freeze(['#56613f', '#584333', '#44352d', '#2d2724'])
+    }),
+    lip: '#74834d', shadow: '#352d28', detail: '#9a6a42'
+  })
+]);
+
+export const FOREST_STREAM_BANK_DEFINITIONS = Object.freeze([
+  Object.freeze({
+    id: FOREST_STREAM_BANK_DEFINITION_ID,
+    modelVersion: FOREST_STREAM_BANK_MODEL_VERSION,
+    waterDepth: Object.freeze({ minimum: 5, maximum: 14, anchorSpacing: 168 }),
+    slopeRun: Object.freeze({ minimum: 20, maximum: 42, anchorSpacing: 156 }),
+    edge: Object.freeze({
+      broadAmplitude: 5,
+      detailAmplitude: 4,
+      broadSpacing: 96,
+      detailSpacing: 36
+    }),
+    compositionSectionLength: 210,
+    stratumCount: 4,
+    sampleStep: FOREST_STREAM_BANK_SAMPLE_STEP
+  })
+]);
+
+export function resolveForestStreamBankDefinition(id) {
+  return FOREST_STREAM_BANK_DEFINITIONS.find(definition => definition.id === id) || null;
+}
+
+export function resolveForestStreamBankComposition(id) {
+  return FOREST_STREAM_BANK_COMPOSITIONS.find(composition => composition.id === id) || null;
+}
+
+function hash(value) {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    result ^= value.charCodeAt(index);
+    result = Math.imul(result, 16777619);
+  }
+  result += result << 13;
+  result ^= result >>> 7;
+  result += result << 3;
+  result ^= result >>> 17;
+  result += result << 5;
+  return result >>> 0;
+}
+
+function unit(value) {
+  return hash(value) / 4294967296;
+}
+
+function smoothstep(value) {
+  const bounded = Math.max(0, Math.min(1, value));
+  return bounded * bounded * (3 - (2 * bounded));
+}
+
+function interpolateAnchors(manifest, worldX, spacing, decision, minimum, maximum,
+  side = 0) {
+  const firstIndex = Math.floor(worldX / spacing);
+  const progress = smoothstep((worldX - (firstIndex * spacing)) / spacing);
+  const valueAt = index => minimum + (unit([
+    manifest.seed, `stream-bank-v${FOREST_STREAM_BANK_MODEL_VERSION}`,
+    decision, side, index
+  ].join(':')) * (maximum - minimum));
+  const first = valueAt(firstIndex);
+  const second = valueAt(firstIndex + 1);
+  return first + ((second - first) * progress);
+}
+
+function compositionForSection(manifest, section, side) {
+  const totalWeight = FOREST_STREAM_BANK_COMPOSITIONS.reduce(
+    (total, composition) => total + composition.weight, 0
+  );
+  let selection = unit([
+    manifest.seed, `stream-bank-v${FOREST_STREAM_BANK_MODEL_VERSION}`,
+    'composition', side, section
+  ].join(':')) * totalWeight;
+  return FOREST_STREAM_BANK_COMPOSITIONS.find((composition) => {
+    selection -= composition.weight;
+    return selection < 0;
+  }) || FOREST_STREAM_BANK_COMPOSITIONS[0];
+}
+
+function compositionBlendAt(manifest, worldX, side, definition) {
+  const section = Math.floor(worldX / definition.compositionSectionLength);
+  const progress = smoothstep((worldX - (section * definition.compositionSectionLength))
+    / definition.compositionSectionLength);
+  return {
+    primary: compositionForSection(manifest, section, side),
+    secondary: compositionForSection(manifest, section + 1, side),
+    mix: progress
+  };
+}
+
+function colorChannels(color) {
+  return [1, 3, 5].map(index => Number.parseInt(color.slice(index, index + 2), 16));
+}
+
+function mixColor(first, second, progress) {
+  const from = colorChannels(first);
+  const to = colorChannels(second);
+  return `#${from.map((channel, index) => Math.round(
+    channel + ((to[index] - channel) * progress)
+  ).toString(16).padStart(2, '0')).join('')}`;
+}
+
+function compositionInfluence(profile, compositionId) {
+  let influence = 0;
+  if (profile.compositionId === compositionId) influence += 1 - profile.compositionMix;
+  if (profile.nextCompositionId === compositionId) influence += profile.compositionMix;
+  return influence;
+}
+
+export function forestStreamWaterDepthAt(manifest, worldX) {
+  const definition = FOREST_STREAM_BANK_DEFINITIONS[0];
+  return interpolateAnchors(manifest, worldX, definition.waterDepth.anchorSpacing,
+    'water-depth', definition.waterDepth.minimum, definition.waterDepth.maximum);
+}
+
+export function forestStreamBankProfileAt(manifest, worldX, side) {
+  const definition = FOREST_STREAM_BANK_DEFINITIONS[0];
+  if (![-1, 1].includes(side) || !Number.isFinite(worldX)) {
+    throw new Error('A stream bank profile requires a finite position and side.');
+  }
+  const broadOffset = interpolateAnchors(manifest, worldX, definition.edge.broadSpacing,
+    'broad-edge', -definition.edge.broadAmplitude, definition.edge.broadAmplitude, side);
+  const detailOffset = interpolateAnchors(manifest, worldX, definition.edge.detailSpacing,
+    'detail-edge', -definition.edge.detailAmplitude, definition.edge.detailAmplitude, side);
+  const outerOffset = interpolateAnchors(manifest, worldX,
+    definition.edge.detailSpacing * 2, 'outer-edge', -3, 3, side);
+  const innerOffset = broadOffset + detailOffset;
+  const sampledSlopeRun = interpolateAnchors(manifest, worldX,
+    definition.slopeRun.anchorSpacing,
+    'slope-run', definition.slopeRun.minimum, definition.slopeRun.maximum, side);
+  const waterDepth = forestStreamWaterDepthAt(manifest, worldX);
+  const slopeRun = Math.max(sampledSlopeRun,
+    waterDepth + innerOffset - outerOffset + 6);
+  const composition = compositionBlendAt(manifest, worldX, side, definition);
+  return Object.freeze({
+    definitionId: definition.id,
+    modelVersion: definition.modelVersion,
+    side,
+    worldX,
+    waterDepth,
+    slopeRun,
+    innerOffset,
+    outerOffset,
+    compositionId: composition.primary.id,
+    nextCompositionId: composition.secondary.id,
+    compositionMix: composition.mix
+  });
+}
+
+export function forestStreamWaterPoint3d(manifest, worldX, lateral, centerY) {
+  return {
+    x: worldX,
+    y: centerY + lateral,
+    z: -forestStreamWaterDepthAt(manifest, worldX)
+  };
+}
+
+function bankPoint3d(manifest, profile, centerY, position) {
+  const stream = manifest.stream;
+  if (position === 'inner') {
+    return {
+      x: profile.worldX,
+      y: centerY + (profile.side * (stream.halfWidth + profile.innerOffset)),
+      z: -profile.waterDepth
+    };
+  }
+  return {
+    x: profile.worldX,
+    y: centerY + (profile.side * (stream.halfWidth + profile.slopeRun
+      + profile.outerOffset)),
+    z: 0
+  };
+}
+
+export function forestStreamBankEdgePoint3d(manifest, worldX, side, centerY,
+  position = 'inner') {
+  return bankPoint3d(
+    manifest, forestStreamBankProfileAt(manifest, worldX, side), centerY, position
+  );
+}
+
+function pointBetween(first, second, progress) {
+  return {
+    x: first.x + ((second.x - first.x) * progress),
+    y: first.y + ((second.y - first.y) * progress),
+    z: first.z + ((second.z - first.z) * progress)
+  };
+}
+
+function stratumColor(profile, stratum) {
+  const primary = resolveForestStreamBankComposition(profile.compositionId);
+  const secondary = resolveForestStreamBankComposition(profile.nextCompositionId);
+  const view = profile.side < 0 ? 'far' : 'near';
+  return mixColor(primary.strata[view][stratum], secondary.strata[view][stratum],
+    profile.compositionMix);
+}
+
+function stratumProgressAt(manifest, profile, boundary) {
+  if (boundary === 0) return 0;
+  if (boundary === 4) return 1;
+  const bases = [0, 0.2, 0.48, 0.76, 1];
+  return bases[boundary] + interpolateAnchors(
+    manifest, profile.worldX, 48, `stratum-${boundary}`, -0.045, 0.045, profile.side
+  );
+}
+
+function bankSurface(side, ordinal, stratum, points, startProfile, endProfile) {
+  return Object.freeze({
+    id: `bank-surface-${side}-${ordinal}-${stratum}`,
+    role: 'bank-stratum',
+    side,
+    ordinal,
+    stratum,
+    compositionId: startProfile.compositionId,
+    nextCompositionId: startProfile.nextCompositionId,
+    compositionMix: startProfile.compositionMix,
+    points: Object.freeze(points),
+    fill: mixColor(stratumColor(startProfile, stratum), stratumColor(endProfile, stratum), 0.5)
+  });
+}
+
+function bankDetail(id, role, side, from, to, width, colors) {
+  return Object.freeze({ id, role, side, from, to, width, colors });
+}
+
+function bankMark(id, role, side, point, size, colors, variant = 0) {
+  return Object.freeze({ id, role, side, point, size, colors, variant });
+}
+
+function appendSegmentDetails(model, manifest, startProfile, endProfile,
+  startCenterY, endCenterY, ordinal) {
+  const primary = resolveForestStreamBankComposition(startProfile.compositionId);
+  const secondary = resolveForestStreamBankComposition(startProfile.nextCompositionId);
+  const mixed = property => mixColor(
+    primary[property], secondary[property], startProfile.compositionMix
+  );
+  const startInner = bankPoint3d(manifest, startProfile, startCenterY, 'inner');
+  const startOuter = bankPoint3d(manifest, startProfile, startCenterY, 'outer');
+  const endInner = bankPoint3d(manifest, endProfile, endCenterY, 'inner');
+  const endOuter = bankPoint3d(manifest, endProfile, endCenterY, 'outer');
+  const side = startProfile.side;
+  const identity = [manifest.seed, side, Math.floor(startProfile.worldX), ordinal].join(':');
+  const grassyInfluence = compositionInfluence(startProfile, 'grassy');
+  const rockyInfluence = compositionInfluence(startProfile, 'rocky');
+  const dirtInfluence = compositionInfluence(startProfile, 'bare-dirt');
+
+  model.details.push(bankDetail(`bank-lip-${side}-${ordinal}`, 'lip', side,
+    startOuter, endOuter, grassyInfluence > 0.45 ? 3 : 2,
+    [mixed('shadow'), mixed('lip')]));
+  const startCapEdge = pointBetween(startOuter, startInner,
+    stratumProgressAt(manifest, startProfile, 1));
+  const endCapEdge = pointBetween(endOuter, endInner,
+    stratumProgressAt(manifest, endProfile, 1));
+  if (unit(`${identity}:cap-shadow`) > 0.24) {
+    model.details.push(bankDetail(`bank-cap-shadow-${side}-${ordinal}`, 'cap-shadow', side,
+      startCapEdge, endCapEdge, 2, ['#302d29', mixed('shadow')]));
+  }
+  model.details.push(bankDetail(`bank-undercut-${side}-${ordinal}`, 'undercut', side,
+    startInner, endInner, 3, ['#26312f', mixed('shadow')]));
+
+  if (unit(`${identity}:grass`) > 0.58 - (grassyInfluence * 0.46)) {
+    const base = pointBetween(startOuter, endOuter, unit(`${identity}:grass-x`));
+    model.details.push(bankDetail(`bank-grass-${side}-${ordinal}`, 'grass', side,
+      base, { ...base, x: base.x + (unit(`${identity}:grass-lean`) > 0.5 ? 2 : -2),
+        y: base.y - (side * 2), z: base.z + 5 + Math.floor(grassyInfluence * 3) }, 3,
+      [mixed('shadow'), mixed('detail')]));
+  }
+  if (unit(`${identity}:rock`) > 0.7 - (rockyInfluence * 0.55)) {
+    const along = unit(`${identity}:rock-x`);
+    const slope = 0.28 + (unit(`${identity}:rock-slope`) * 0.5);
+    const inner = pointBetween(startInner, endInner, along);
+    const outer = pointBetween(startOuter, endOuter, along);
+    model.marks.push(bankMark(`bank-rock-${side}-${ordinal}`, 'rock', side,
+      pointBetween(inner, outer, slope), 5 + Math.floor(unit(`${identity}:rock-size`) * 6),
+      [side < 0 ? '#38423d' : '#303936', side < 0 ? '#89917b' : '#747d6b'],
+      Math.floor(unit(`${identity}:rock-shape`) * 4)));
+  }
+  if (unit(`${identity}:dirt`) > 0.78 - (dirtInfluence * 0.48)) {
+    const along = unit(`${identity}:dirt-x`);
+    const inner = pointBetween(startInner, endInner, along);
+    const outer = pointBetween(startOuter, endOuter, along);
+    const from = pointBetween(inner, outer, 0.32 + (unit(`${identity}:dirt-slope`) * 0.35));
+    model.details.push(bankDetail(`bank-dirt-${side}-${ordinal}`, 'dirt', side,
+      from, { ...from, x: from.x + 5 + Math.floor(unit(`${identity}:dirt-length`) * 6) },
+      1, [mixed('shadow'), mixed('detail')]));
+  }
+  if (unit(`${identity}:soil`) > 0.38) {
+    const along = unit(`${identity}:soil-x`);
+    const inner = pointBetween(startInner, endInner, along);
+    const outer = pointBetween(startOuter, endOuter, along);
+    const slope = 0.16 + (unit(`${identity}:soil-slope`) * 0.7);
+    model.marks.push(bankMark(`bank-soil-${side}-${ordinal}`, 'soil', side,
+      pointBetween(outer, inner, slope), 2 + Math.floor(unit(`${identity}:soil-size`) * 3),
+      [mixed('shadow'), mixed('detail')], Math.floor(unit(`${identity}:soil-shape`) * 3)));
+  }
+  if (unit(`${identity}:root`) > 0.58) {
+    const along = unit(`${identity}:root-x`);
+    const inner = pointBetween(startInner, endInner, along);
+    const outer = pointBetween(startOuter, endOuter, along);
+    const from = pointBetween(outer, inner, 0.12 + (unit(`${identity}:root-top`) * 0.2));
+    const to = pointBetween(outer, inner, 0.48 + (unit(`${identity}:root-bottom`) * 0.34));
+    model.details.push(bankDetail(`bank-root-${side}-${ordinal}`, 'root', side,
+      from, { ...to, x: to.x + (unit(`${identity}:root-bend`) > 0.5 ? 2 : -2) },
+      1, [mixed('shadow'), '#806044']));
+  }
+}
+
+function appendLogJam(model, manifest, section, side, centerYAt, definition) {
+  const centerX = Math.round((section + 0.5) * definition.compositionSectionLength);
+  if (centerX < 0 || centerX > manifest.world.width) return;
+  if (compositionForSection(manifest, section, side).id !== 'fallen-log-jam') return;
+  const profile = forestStreamBankProfileAt(manifest, centerX, side);
+  const centerY = centerYAt(centerX);
+  const inner = bankPoint3d(manifest, profile, centerY, 'inner');
+  const direction = unit(`${manifest.seed}:log-jam:${side}:${section}:direction`) < 0.5 ? -1 : 1;
+  const length = 36 + Math.floor(unit(`${manifest.seed}:log-jam:${side}:${section}:length`) * 28);
+  const fromX = Math.max(0, centerX - (length / 2));
+  const toX = Math.min(manifest.world.width, centerX + (length / 2));
+  const from = { ...inner, x: fromX, y: inner.y - (direction * 5), z: inner.z + 4 };
+  const to = { ...inner, x: toX, y: inner.y + (direction * 5), z: inner.z + 6 };
+  model.details.push(bankDetail(`bank-log-${side}-${section}`, 'log', side,
+    from, to, 7, ['#3b2a23', '#95613b']));
+  const branchStart = pointBetween(from, to, 0.64);
+  model.details.push(bankDetail(`bank-log-branch-${side}-${section}`, 'log-branch', side,
+    branchStart, { ...branchStart, y: branchStart.y + (side * 15), z: branchStart.z + 3 },
+    3, ['#3b2a23', '#855536']));
+}
+
+export function buildForestStreamBankModel3d(manifest, range, centerYAt) {
+  const definition = FOREST_STREAM_BANK_DEFINITIONS[0];
+  if (!Number.isFinite(range?.firstX) || !Number.isFinite(range?.lastX)
+    || range.firstX > range.lastX || typeof centerYAt !== 'function') {
+    throw new Error('A stream bank model requires a finite ordered range and center query.');
+  }
+  const firstX = Math.max(0, Math.floor(range.firstX / definition.sampleStep)
+    * definition.sampleStep);
+  const lastX = Math.min(manifest.world.width, Math.ceil(range.lastX / definition.sampleStep)
+    * definition.sampleStep);
+  const model = { definitionId: definition.id, surfaces: [], details: [], marks: [] };
+  for (const side of [-1, 1]) {
+    let ordinal = 0;
+    for (let startX = firstX; startX < lastX; startX += definition.sampleStep) {
+      const endX = Math.min(lastX, startX + definition.sampleStep);
+      const startProfile = forestStreamBankProfileAt(manifest, startX, side);
+      const endProfile = forestStreamBankProfileAt(manifest, endX, side);
+      const startCenterY = centerYAt(startX);
+      const endCenterY = centerYAt(endX);
+      const startInner = bankPoint3d(manifest, startProfile, startCenterY, 'inner');
+      const startOuter = bankPoint3d(manifest, startProfile, startCenterY, 'outer');
+      const endInner = bankPoint3d(manifest, endProfile, endCenterY, 'inner');
+      const endOuter = bankPoint3d(manifest, endProfile, endCenterY, 'outer');
+      for (let stratum = 0; stratum < definition.stratumCount; stratum += 1) {
+        const startFrom = stratumProgressAt(manifest, startProfile, stratum);
+        const startTo = stratumProgressAt(manifest, startProfile, stratum + 1);
+        const endFrom = stratumProgressAt(manifest, endProfile, stratum);
+        const endTo = stratumProgressAt(manifest, endProfile, stratum + 1);
+        model.surfaces.push(bankSurface(side, ordinal, stratum, [
+          pointBetween(startOuter, startInner, startFrom),
+          pointBetween(startOuter, startInner, startTo),
+          pointBetween(endOuter, endInner, endTo),
+          pointBetween(endOuter, endInner, endFrom)
+        ], startProfile, endProfile));
+      }
+      appendSegmentDetails(model, manifest, startProfile, endProfile,
+        startCenterY, endCenterY, ordinal);
+      ordinal += 1;
+    }
+    const firstSection = Math.floor(firstX / definition.compositionSectionLength) - 1;
+    const lastSection = Math.ceil(lastX / definition.compositionSectionLength) + 1;
+    for (let section = firstSection; section <= lastSection; section += 1) {
+      appendLogJam(model, manifest, section, side, centerYAt, definition);
+    }
+  }
+  return Object.freeze({
+    definitionId: model.definitionId,
+    surfaces: Object.freeze(model.surfaces),
+    details: Object.freeze(model.details),
+    marks: Object.freeze(model.marks)
+  });
+}

--- a/server/routes/devViews.js
+++ b/server/routes/devViews.js
@@ -35,6 +35,11 @@ import {
   forestSceneCellIdsForViewport,
   forestScenePlacementCellId
 } from '../../public/js/forest-scene-math.js';
+import {
+  FOREST_STREAM_BANK_COMPOSITIONS,
+  FOREST_STREAM_BANK_DEFINITION_ID,
+  FOREST_STREAM_BANK_MODEL_VERSION
+} from '../../public/js/forest-stream-banks.js';
 
 const router = express.Router();
 
@@ -139,7 +144,12 @@ function forestEnvironmentSummary(scene) {
     ))].sort().map(value => [value, scene.terrainFeatures.filter(
       feature => feature.terrainRole === value
     ).length])),
-    crossing: scene.crossing,
+    streamBank: {
+      definitionId: FOREST_STREAM_BANK_DEFINITION_ID,
+      modelVersion: FOREST_STREAM_BANK_MODEL_VERSION,
+      compositionIds: FOREST_STREAM_BANK_COMPOSITIONS.map(({ id }) => id)
+    },
+    crossings: scene.crossings,
     placement: scene.environmentPlacementDiagnostics
   };
 }

--- a/server/services/forestTerrainFeatures.js
+++ b/server/services/forestTerrainFeatures.js
@@ -10,6 +10,7 @@ import {
   validateForestStreamCrossing
 } from '../../public/js/forest-environment.js';
 import { createRandom, hashSeed } from './forest/v3/random.js';
+import { FOREST_BRIDGE_DEFINITION_ID } from '../../public/js/forest-bridges.js';
 
 export { FOREST_CROSSING_GENERATION_VERSION, FOREST_CROSSING_SCHEMA_VERSION };
 
@@ -57,7 +58,7 @@ export function generateForestStreamCrossing(scene, corridorCenterAt) {
   return validateForestStreamCrossing({
     schemaVersion: FOREST_CROSSING_SCHEMA_VERSION,
     generationVersion: FOREST_CROSSING_GENERATION_VERSION,
-    id: 'forest-crossing-v5-stream-footbridge-primary',
+    id: 'forest-crossing-v6-stream-footbridge-primary',
     type: FOREST_BRIDGE_TYPE,
     worldX: best.worldX,
     worldY: best.worldY,
@@ -65,6 +66,7 @@ export function generateForestStreamCrossing(scene, corridorCenterAt) {
     angleMilliradians: 1100 + Math.floor(decisionUnit(
       scene.environment.seed, best.worldX, best.worldY, 'bridge-angle'
     ) * 100),
+    definitionId: FOREST_BRIDGE_DEFINITION_ID,
     halfWidth: 31,
     halfLength,
     maximumElevationPixels: 24
@@ -88,12 +90,13 @@ export function generateForestStreamCrossings(scene, corridorCenterAt) {
     const candidate = validateForestStreamCrossing({
       schemaVersion: FOREST_CROSSING_SCHEMA_VERSION,
       generationVersion: FOREST_CROSSING_GENERATION_VERSION,
-      id: 'forest-crossing-v5-stream-footbridge-secondary',
+      id: 'forest-crossing-v6-stream-footbridge-secondary',
       type: FOREST_BRIDGE_TYPE,
       worldX,
       worldY: forestStreamCenterY(scene.environment, worldX),
       orientation: 'world-angle',
       angleMilliradians,
+      definitionId: FOREST_BRIDGE_DEFINITION_ID,
       halfWidth: 29,
       halfLength,
       maximumElevationPixels: 20

--- a/spec/forestEnvironmentSpec.js
+++ b/spec/forestEnvironmentSpec.js
@@ -284,6 +284,27 @@ describe('first Activity Forest environment grammar', () => {
     expect(() => forestStreamBankProfileAt(environment, 20, 0)).toThrow();
   });
 
+  it('keeps creek-bank geometry and decoration stable across viewport cache ranges', () => {
+    const environment = manifest();
+    const centerYAt = worldX => forestStreamCenterY(environment, Math.round(worldX));
+    const first = buildForestStreamBankModel3d(environment, {
+      firstX: 0, lastX: 384
+    }, centerYAt);
+    const shifted = buildForestStreamBankModel3d(environment, {
+      firstX: 192, lastX: 576
+    }, centerYAt);
+    const inOverlap = value => value >= 192 && value < 384;
+    const overlapping = model => ({
+      surfaces: model.surfaces.filter(surface => inOverlap(surface.points[0].x)),
+      details: model.details.filter(detail => (
+        !detail.role.startsWith('log') && inOverlap(detail.from.x)
+      )),
+      marks: model.marks.filter(mark => inOverlap(mark.point.x))
+    });
+
+    expect(overlapping(first)).toEqual(overlapping(shifted));
+  });
+
   it('keeps the player collision circle out of the projected water edge', () => {
     const environment = manifest();
     const worldX = 100;

--- a/spec/forestEnvironmentSpec.js
+++ b/spec/forestEnvironmentSpec.js
@@ -1,4 +1,18 @@
 import {
+  buildForestBridgeModel3d,
+  FOREST_BRIDGE_DEFINITIONS,
+  forestBridgePoint3d,
+  projectForestPoint3d,
+  resolveForestBridgeDefinition
+} from '../public/js/forest-bridges.js';
+import {
+  buildForestStreamBankModel3d,
+  FOREST_STREAM_BANK_COMPOSITIONS,
+  forestStreamBankProfileAt,
+  forestStreamWaterDepthAt,
+  forestStreamWaterPoint3d
+} from '../public/js/forest-stream-banks.js';
+import {
   createForestEnvironmentManifest,
   FOREST_BOULDER_TYPE,
   FOREST_BRIDGE_TYPE,
@@ -15,6 +29,7 @@ import {
   forestEnvironmentAt,
   forestGroundDetailAt,
   forestStreamCenterY,
+  forestStreamWaterContains,
   resolveForestRockPalette,
   validateForestEnvironmentManifest,
   validateForestStreamCrossing
@@ -194,6 +209,107 @@ describe('first Activity Forest environment grammar', () => {
     expect(() => forestGroundDetailAt(environment, {
       column: 0, row: 0, viewport: 'ignored'
     })).toThrow();
+  });
+
+  it('constructs varied continuous creek banks and recessed water from bounded 3D profiles', () => {
+    const environment = manifest();
+    const profiles = [];
+    for (let worldX = 0; worldX <= world.width; worldX += 17) {
+      for (const side of [-1, 1]) {
+        const profile = forestStreamBankProfileAt(environment, worldX, side);
+        profiles.push(profile);
+        expect(profile).toEqual(forestStreamBankProfileAt(environment, worldX, side));
+        expect(profile.waterDepth).toBeGreaterThanOrEqual(5);
+        expect(profile.waterDepth).toBeLessThanOrEqual(14);
+        expect(profile.slopeRun).toBeGreaterThanOrEqual(20);
+        expect(profile.slopeRun).toBeLessThanOrEqual(42);
+        expect(Math.abs(profile.innerOffset)).toBeLessThanOrEqual(9);
+      }
+    }
+    expect(new Set(profiles.map(({ compositionId }) => compositionId))).toEqual(
+      new Set(FOREST_STREAM_BANK_COMPOSITIONS.map(({ id }) => id))
+    );
+    expect(Math.max(...profiles.map(({ waterDepth }) => waterDepth))
+      - Math.min(...profiles.map(({ waterDepth }) => waterDepth))).toBeGreaterThan(5);
+    expect(Math.max(...profiles.map(({ slopeRun }) => slopeRun))
+      - Math.min(...profiles.map(({ slopeRun }) => slopeRun))).toBeGreaterThan(12);
+    expect(Math.max(...profiles.map(({ innerOffset }) => innerOffset))
+      - Math.min(...profiles.map(({ innerOffset }) => innerOffset))).toBeGreaterThan(10);
+    for (let worldX = 1; worldX < world.width; worldX += 31) {
+      expect(Math.abs(forestStreamWaterDepthAt(environment, worldX)
+        - forestStreamWaterDepthAt(environment, worldX - 1))).toBeLessThan(0.2);
+    }
+
+    const model = buildForestStreamBankModel3d(environment, {
+      firstX: 0, lastX: world.width
+    }, worldX => forestStreamCenterY(environment, Math.round(worldX)));
+    expect(model.surfaces.length).toBeGreaterThan(1400);
+    expect(new Set(model.surfaces.map(({ side }) => side))).toEqual(new Set([-1, 1]));
+    expect(model.surfaces.every(({ points }) => points.every(point => (
+      point.z <= 0 && point.z >= -14
+    )))).toBeTrue();
+    expect(new Set(model.surfaces.map(({ stratum }) => stratum)))
+      .toEqual(new Set([0, 1, 2, 3]));
+    const colorChannels = color => [1, 3, 5].map(index => (
+      Number.parseInt(color.slice(index, index + 2), 16)
+    ));
+    for (const side of [-1, 1]) {
+      for (const stratum of [0, 1, 2, 3]) {
+        const surfaces = model.surfaces.filter(surface => (
+          surface.side === side && surface.stratum === stratum
+        ));
+        for (let index = 1; index < surfaces.length; index += 1) {
+          const previous = colorChannels(surfaces[index - 1].fill);
+          const current = colorChannels(surfaces[index].fill);
+          expect(Math.hypot(...previous.map((channel, channelIndex) => (
+            channel - current[channelIndex]
+          )))).toBeLessThan(6);
+        }
+      }
+    }
+    expect(new Set(model.details.map(({ role }) => role))).toEqual(new Set([
+      'lip', 'cap-shadow', 'undercut', 'grass', 'dirt', 'root', 'log', 'log-branch'
+    ]));
+    expect(new Set(model.marks.map(({ role }) => role))).toEqual(new Set(['rock', 'soil']));
+    const water = forestStreamWaterPoint3d(environment, 500, 0,
+      forestStreamCenterY(environment, 500));
+    expect(water.z).toBeLessThan(0);
+    expect(projectForestPoint3d(water).y).toBeGreaterThan(water.y);
+    const boundaryX = 210;
+    const beforeBoundary = forestStreamBankProfileAt(environment, boundaryX - 0.01, -1);
+    const afterBoundary = forestStreamBankProfileAt(environment, boundaryX + 0.01, -1);
+    expect(beforeBoundary.nextCompositionId).toBe(afterBoundary.compositionId);
+    expect(beforeBoundary.compositionMix).toBeGreaterThan(0.999);
+    expect(afterBoundary.compositionMix).toBeLessThan(0.001);
+    expect(() => forestStreamBankProfileAt(environment, 20, 0)).toThrow();
+  });
+
+  it('keeps the player collision circle out of the projected water edge', () => {
+    const environment = manifest();
+    const worldX = 100;
+    const centerY = forestStreamCenterY(environment, worldX);
+    const profile = forestStreamBankProfileAt(environment, worldX, -1);
+    const waterEdgeY = centerY - (environment.stream.halfWidth
+      + Math.max(0, profile.innerOffset));
+    expect(forestStreamWaterContains(environment, {
+      worldX, worldY: waterEdgeY - 9
+    }, 10)).toBeTrue();
+    expect(forestStreamWaterContains(environment, {
+      worldX, worldY: waterEdgeY - 11
+    }, 10)).toBeFalse();
+
+    const scene = generateForestSceneLayout(resolveForestPressureProfile('first-regions').layout);
+    const safeX = 100;
+    const safeCenterY = forestStreamCenterY(scene.environment, safeX);
+    const safeProfile = forestStreamBankProfileAt(scene.environment, safeX, -1);
+    const safeEdgeY = safeCenterY - (scene.environment.stream.halfWidth
+      + Math.max(0, safeProfile.innerOffset));
+    expect(forestTerrainTraversableAt(scene, {
+      worldX: safeX, worldY: safeEdgeY - 9, radius: 10
+    })).toBeFalse();
+    expect(forestTerrainTraversableAt(scene, {
+      worldX: safeX, worldY: safeEdgeY - 11, radius: 10
+    })).toBeTrue();
   });
 
   it('invalidates generated-base identity when environment seed or grammar inputs change', () => {
@@ -428,7 +544,7 @@ describe('first Activity Forest environment grammar', () => {
     const verticalBridge = { ...bridge, angleMilliradians: 1571 };
     expect(forestBridgeElevationAt(verticalBridge, {
       worldX: verticalBridge.worldX, worldY: verticalBridge.worldY
-    })).toBe(0);
+    })).toBe(verticalBridge.maximumElevationPixels);
     const almostVerticalBridge = { ...bridge, angleMilliradians: 1560 };
     expect(forestBridgeElevationAt(almostVerticalBridge, {
       worldX: almostVerticalBridge.worldX, worldY: almostVerticalBridge.worldY
@@ -461,6 +577,44 @@ describe('first Activity Forest environment grammar', () => {
       .toBeLessThan(-bridge.halfLength + 5);
     expect(forestBridgeLocalCoordinates(secondBridge, walk(secondBridge)).longitudinal)
       .toBeLessThan(-secondBridge.halfLength + 5);
+  });
+
+  it('builds each bridge as parameterized 3D geometry before projecting it to the canvas', () => {
+    const scene = generateForestSceneLayout(resolveForestPressureProfile('first-regions').layout);
+    expect(FOREST_BRIDGE_DEFINITIONS.length).toBeGreaterThan(0);
+    for (const bridge of scene.crossings) {
+      const definition = resolveForestBridgeDefinition(bridge.definitionId);
+      const model = buildForestBridgeModel3d(bridge);
+      expect(definition).not.toBeNull();
+      expect(model.definitionId).toBe(definition.id);
+      expect(model.surfaces.filter(({ role }) => role === 'plank').length)
+        .toBeGreaterThan(15);
+      expect(model.surfaces.some(({ points }) => points.some(point => point.z < 0))).toBeTrue();
+      expect(model.details.filter(({ role }) => role === 'grain').length).toBeGreaterThan(15);
+      expect(model.details.filter(({ role }) => role === 'nail').length).toBeGreaterThan(20);
+      expect(model.members.filter(({ role }) => role === 'post').length).toBeGreaterThan(10);
+      expect(model.members.filter(({ role }) => role === 'rail').length).toBeGreaterThan(8);
+
+      const center = forestBridgePoint3d(bridge, 0, 0);
+      const end = forestBridgePoint3d(bridge, bridge.halfLength, 0);
+      expect(center.z).toBeCloseTo(bridge.maximumElevationPixels, 6);
+      expect(end.z).toBeCloseTo(0, 6);
+      const centerProjection = projectForestPoint3d(center, { x: 25, y: 40 });
+      expect(centerProjection.x).toBeCloseTo(center.x - 25, 6);
+      expect(centerProjection.y).toBeCloseTo(center.y - 40 - center.z, 6);
+    }
+
+    const firstModel = buildForestBridgeModel3d(scene.crossings[0]);
+    const secondModel = buildForestBridgeModel3d(scene.crossings[1]);
+    const firstPlank = firstModel.surfaces.find(({ role }) => role === 'plank');
+    const secondPlank = secondModel.surfaces.find(({ role }) => role === 'plank');
+    const projectedDirection = (plank) => {
+      const from = projectForestPoint3d(plank.points[1]);
+      const to = projectForestPoint3d(plank.points[2]);
+      return Math.atan2(to.y - from.y, to.x - from.x);
+    };
+    expect(Math.abs(projectedDirection(firstPlank) - projectedDirection(secondPlank)))
+      .toBeGreaterThan(0.7);
   });
 
   it('keeps the environment-profile discovery offering finite and out of water', () => {
@@ -509,6 +663,7 @@ describe('first Activity Forest environment grammar', () => {
   it('keeps painting viewport-bounded and applies explicit water suitability', async () => {
     const fs = await import('node:fs');
     const painter = fs.readFileSync('public/js/activity-forest.js', 'utf8');
+    const bridgeGeometry = fs.readFileSync('public/js/forest-bridges.js', 'utf8');
     const overlay = fs.readFileSync('public/js/forest-world-overlay.js', 'utf8');
     expect(painter).toContain('forestEnvironmentAt(scene.environment');
     expect(painter).toContain('forestGroundDetailAt(scene.environment');
@@ -519,21 +674,24 @@ describe('first Activity Forest environment grammar', () => {
     expect(painter).toContain('streamFlowVariation(markIndex, lane');
     expect(painter).toContain('paintStreamColorBand(7, 20');
     expect(painter).toContain('const grove = [82, 132, 76]');
-    expect(painter).toContain("paintStreamRibbon(stream.halfWidth, '#247486')");
+    expect(painter).toContain("paintStreamWaterSurface('#247486')");
     expect(painter).toContain('paintStreamSurfaceTexture(stream)');
-    expect(painter).toContain('paintStreamEdgeTexture(stream)');
+    expect(painter).toContain('paintStreamEdgeTexture()');
+    expect(painter).toContain('paintStreamBank(-1)');
+    expect(painter).toContain('paintStreamBank(1)');
     expect(painter).toContain("terrainRole === 'bank-boulder'");
     expect(painter).toContain('ambientMotionActive ? Math.floor(elapsedSeconds * 6) : 0');
     expect(painter).toContain('const flowIdentity = markIndex - flowCycle');
     expect(painter).toContain('forestStreamCenterY(scene.environment, streamQueryX)');
-    expect(painter).toContain('forestBridgeWorldPosition(bridge');
-    expect(painter).toContain('forestBridgeWorldPosition(bridge, longitudinal, 0)');
+    expect(painter).toContain('buildForestBridgeModel3d(bridge)');
+    expect(painter).toContain('projectForestPoint3d(point, camera)');
     expect(painter).toContain('crossings.forEach(paintBridgeDeck)');
     expect(painter).toContain('crossings.forEach(paintBridgeRails)');
-    expect(painter).toContain('bridge, 1, plankOrdinal');
-    expect(painter).toContain('bridge, 2, plankOrdinal + 1');
-    expect(painter).toContain("context.strokeStyle = '#2f2924'");
-    expect(painter).toContain('const elevationRatio = forestBridgeElevationAt');
+    expect(bridgeGeometry).toContain("shape: 'circular-segment'");
+    expect(bridgeGeometry).toContain('forestBridgePoint3d(bridge');
+    expect(bridgeGeometry).toContain('surfaces: Object.freeze(surfaces)');
+    expect(bridgeGeometry).toContain('details: Object.freeze(details)');
+    expect(bridgeGeometry).toContain('members: Object.freeze(members)');
     expect(overlay).toContain('forestEnvironmentAt');
     const grove = forestEnvironmentAt(manifest(), { worldX: 100, worldY: 100 });
     const rockyManifest = manifest();

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -150,8 +150,12 @@ block content
           dt Terrain roles
           dd= Object.entries(environmentSummary.terrainRoles).map(([id, count]) => `${id} ${count}`).join(' · ')
         div
-          dt Stream crossing
-          dd #{environmentSummary.crossing.type} · #{environmentSummary.crossing.worldX}, #{environmentSummary.crossing.worldY} · #{environmentSummary.crossing.halfWidth * 2} × #{environmentSummary.crossing.halfLength * 2} · #{(environmentSummary.crossing.angleMilliradians / 1000 * 180 / Math.PI).toFixed(1)}° · +#{environmentSummary.crossing.maximumElevationPixels}px crown
+          dt Stream-bank model
+          dd #{environmentSummary.streamBank.definitionId} v#{environmentSummary.streamBank.modelVersion} · #{environmentSummary.streamBank.compositionIds.join(' · ')}
+        each crossing, crossingIndex in environmentSummary.crossings
+          div
+            dt Stream crossing #{crossingIndex + 1}
+            dd #{crossing.definitionId} · #{crossing.worldX}, #{crossing.worldY} · #{crossing.halfWidth * 2} × #{crossing.halfLength * 2} · #{(crossing.angleMilliradians / 1000 * 180 / Math.PI).toFixed(1)}° · +#{crossing.maximumElevationPixels}px crown
         div
           dt Placement attempts
           dd #{environmentSummary.placement.acceptedPlacementCount} accepted / #{environmentSummary.placement.attemptedCandidateCount} attempted · #{environmentSummary.placement.densityRejectionCount} density · #{environmentSummary.placement.corridorRejectionCount} corridor · #{environmentSummary.placement.spacingRejectionCount} spacing · #{environmentSummary.placement.termination}


### PR DESCRIPTION
## Summary

Reworks the forest stream and bridge rendering around a shared 3D projection model, improving perspective consistency and giving the creek banks a more natural, dimensional appearance.

## What changed

- Generates stream banks from deterministic 3D profiles with varying depth, slope, and edge shape
- Blends grassy, rocky, bare-dirt, and fallen-log bank compositions
- Adds grass overhangs, shaded embedded rocks, roots, soil details, and broken cap shadows
- Extends bank materials beneath the water with translucent shallow shelves and submerged pebbles
- Generates bridge planks, fascia, abutments, posts, and rails as projected 3D geometry
- Uses a shared projection for the stream, bridges, boulders, and player elevation
- Aligns stream collision and traversal with the irregular rendered water edge
- Keeps generation deterministic and viewport-bounded

## Result

The stream banks now read as eroded natural terrain instead of flat bands or constructed retaining walls. Bridge geometry also retains consistent proportions and perspective across different crossing angles.

## Testing

- ESLint passes for the updated forest renderer and stream-bank model
- 673 specs pass with 0 failures