### PR TITLE
Milestone 9B: Add Tansy Rook and expressive humanoid movement

### DIFF
--- a/docs/forest/transient-life-contract.md
+++ b/docs/forest/transient-life-contract.md
@@ -1,13 +1,14 @@
 # Activity Forest Transient-Life Contract
 
-## Milestone 9 Pass 2 checkpoint
+## Milestone 9 Pass 3 checkpoint
 
 This contract owns disposable, page-lifetime actors that make the forest feel inhabited without
 adding rewards, tasks, persistence, or a generalized agent system. Pass 1 proves the boundary with
 one small bird family. Pass 2 adds genuine branch hops, one ground-foraging pair, player startle,
-and a bounded return lifecycle. The visiting hiker remains the separate Pass 3 slice.
+and a bounded return lifecycle. Pass 3 adds one original older visiting hiker and a compact,
+non-consequential conversation.
 
-The pure browser boundary is `public/js/forest-transient-life.js`. Version **2** supports the actor
+The pure browser boundary is `public/js/forest-transient-life.js`. Version **3** supports the bird
 states `perched`, `branch-hop`, `ground-forage`, `ground-wander`, and `flight`, actor schema version
 **2**, three
 code-owned palette variants, and a maximum cast of four birds. Two begin in trees and two form the
@@ -18,6 +19,13 @@ ids. Its behavior record separately owns current state, route and anchor indices
 hop count, transition count, optional ground contact, and optional motion points.
 Ground actors additionally retain a capped retreat-attempt count used only while resolving a
 temporarily unavailable perch asset.
+
+The same boundary owns one visitor record with visitor schema version **1**. The visitor is not part
+of the bird actor array: her stable identity, two-point local route, disposable position, rest/walk
+state, humanoid motion, and page-lifetime conversation completion remain a separate discriminated
+record. `public/js/forest-humanoid.js` presentation version **3** is shared by the player and visitor.
+It projects a continuously eased world-facing angle into a pixel silhouette and derives planted-foot
+walking and capped running cadence from actual travel rather than key-down time.
 
 The scene seed reproduces the initial cast, variants, tree routes, and anchor choices. The page owns
 the clock: reload restarts the transient scene and its quiet intervals. No actor record is written
@@ -122,22 +130,49 @@ wing animation are suppressed. An already airborne bird freezes at its current p
 repeatedly teleporting. Interaction with trees, discoveries, objects, editors, dialogs,
 keyboard movement, and touch movement remains unchanged.
 
+## One quiet wayfarer
+
+Tansy Rook is an original fictional older traveler rather than a depiction of any historical hiker.
+She wears patched moss and bark colors, gray hair, a pointed weathered hood, and carries a walking
+staff. A bounded selector first tries dry ground near a bridge approach and otherwise tries points
+210–440 pixels from the entrance. Both endpoints of her 34-pixel local route must pass the same dry,
+bounded, bridge-, tree-, terrain-, and authored-object-clear suitability query used by ground life.
+She is also kept clear of the initial ground flock.
+
+Tansy rests for 12–22 seconds and occasionally walks her route at 32 pixels per second. She is
+non-solid and joins ordinary ground-Y depth ordering. Simulation stops outside the existing margin,
+while dialogs, the forest menu, and clearing or trail editors pause her locally. Reduced motion
+preserves her current position as a stable resting presentation. Her restrained idle lift is purely
+visual and stops with ambient motion.
+
+At 58 pixels she enters the existing nearest-focus competition and uses the same E/Enter and touch
+prompt as other interactions. Her dialog has five bounded nodes and two reply moments. Each offers
+two short responses, then immediately reconverges on the same next topic; this small braided shape
+is code-owned conversation copy, not a generalized choice graph. It has no quest, schedule, gift,
+reward, inventory effect, relationship state, or database write. Conversation completion is a
+page-lifetime boolean used only to replace repeats with one farewell observation. Both endings lead
+into her eccentric hymn to “Good Gourd, the Pumpkin Lord”; neither produces a lore ledger or
+gameplay effect.
+She remains quietly present after the conversation.
+
 ## Diagnostics and measured boundary
 
-Development diagnostics report total birds, counts for all five states, branch hops, autonomous and
-player-startled transitions, ground-group lifecycle, destination-selection exhaustion,
-reduced-motion suppression, and transient update duration separately from total rendering.
+Development diagnostics report total birds, counts for all five bird states, branch hops,
+autonomous and player-startled transitions, visitor state and transitions, ground-group lifecycle,
+destination-selection exhaustion, reduced-motion suppression, and transient update duration
+separately from total rendering.
 
-On Node 24.15.0, the final Pass 2 `first-regions` harness ran five all-actors-active samples of
-100,000 update calls against the production 60-placement scene. The sorted samples were 1,241.16,
-1,258.01, 1,524.87, 1,658.53, and 2,390.97 ms. The median was **1,524.87 ms**, or **0.015249 ms per
-call**, with four actors and no viewport culling. This is a deliberately stricter bounded
+On Node 24.15.0, the final Pass 3 `first-regions` harness ran five all-actors-active samples of
+100,000 update calls against the production 60-placement scene. The sorted samples were 1,249.62,
+1,276.15, 1,308.82, 1,603.93, and 2,285.63 ms. The median was **1,308.82 ms**, or **0.013088 ms per
+call**, with four birds, one visitor, and no viewport culling. This is a deliberately stricter bounded
 implementation measurement, not a browser frame-time claim. The ground point resolved on the first
 bounded attempt at `(1699, 1698)`; focused evidence covers staggered retreat, bounded unavailable
-perches, return recovery, free wandering, reduced-motion suppression, and bridge/stream depth
-classification. Human review accepted bird scale, coasting motion, natural canopy occlusion,
-individual peck timing, and the loose-flock walking behavior in the composed scene.
+perches, return recovery, free wandering, visitor selection, walk/rest transitions, dialog pausing,
+focus, conversation completion, reduced-motion suppression, and bridge/stream depth classification.
+Human review accepted the bird presentation and the shared continuously oriented humanoid scale,
+gait, palette, and silhouette before the visitor reused that boundary.
 
 This boundary is intentionally not an NPC framework, behavior tree, ecology simulation, navmesh,
-or persistence model. Adding the visiting hiker must reuse the ownership/update/render separation
-without generalizing it prematurely.
+or persistence model. The visitor reuses the ownership/update/render separation without introducing
+an extensible agent framework, real-user presence, schedules, needs, or persistence.

--- a/public/css/activity-forest.css
+++ b/public/css/activity-forest.css
@@ -493,6 +493,20 @@ html[data-theme='dark'] .activity-forest .activity-forest__prompt {
 }
 .activity-forest__dialog-context { margin: 0.3rem 0 1.2rem; color: #5f6a61; }
 .activity-forest__dialog-excerpt { font-size: 1.08rem; line-height: 1.65; }
+.activity-forest__visitor-text { white-space: pre-line; }
+.activity-forest__visitor-replies { margin-top: 1.25rem; }
+.activity-forest__visitor-reply-label {
+  margin: 0 0 0.5rem;
+  color: #6d705f;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.activity-forest__visitor-reply-buttons {
+  display: grid;
+  gap: 0.55rem;
+}
+.activity-forest__visitor-reply-buttons button { width: 100%; text-align: left; }
 .activity-forest__tree-meaning {
   margin: 1rem 0;
   padding: 0.85rem;

--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -78,14 +78,25 @@ import {
 } from './forest-environment.js';
 import {
   advanceForestTransientLife,
+  completeForestTransientVisitorConversation,
   createForestTransientLife,
   FOREST_BIRD_VARIANTS,
+  FOREST_TRANSIENT_VISITOR_AFTER_DIALOGUE,
+  FOREST_TRANSIENT_VISITOR_DIALOGUE,
   forestBirdForagePecking,
   forestBirdPerchPoint,
   forestTransientBirdsForTree,
   forestTransientDepthItems,
-  forestTransientLifeDiagnostic
+  forestTransientLifeDiagnostic,
+  forestTransientVisitorDialogueNode,
+  forestTransientVisitorFocus
 } from './forest-transient-life.js';
+import {
+  advanceForestHumanoidMotion,
+  createForestHumanoidMotion,
+  FOREST_HUMANOID_PROFILES,
+  paintForestHumanoid
+} from './forest-humanoid.js';
 
 const payload = document.getElementById('activity-forest-scene');
 const viewportElement = document.querySelector('[data-forest-viewport]');
@@ -107,6 +118,7 @@ if (payload && viewportElement && canvas) {
   const camera = { x: 0, y: 0, width: 0, height: 0 };
   let streamBankModelCache = null;
   const player = { ...scene.exploration.spawn };
+  const playerMotion = createForestHumanoidMotion(player.facing);
   const overlayPersistence = createForestDevOverlayPersistence(window.localStorage);
   const persistedOverlay = overlayPersistence.load(scene.baseIdentity);
   let overlay = persistedOverlay.overlay;
@@ -131,6 +143,14 @@ if (payload && viewportElement && canvas) {
     pointerId: null, originX: 0, originY: 0, x: 0, y: 0, maximumDistance: 0
   };
   const dialog = document.querySelector('[data-forest-dialog]');
+  const visitorDialog = document.querySelector('[data-forest-visitor-dialog]');
+  const visitorDialogueText = visitorDialog.querySelector('[data-forest-visitor-text]');
+  const visitorDialogueNext = visitorDialog.querySelector('[data-forest-visitor-next]');
+  const visitorDialogueReplies = visitorDialog.querySelector('[data-forest-visitor-replies]');
+  const visitorDialogueChoices = [
+    ...visitorDialog.querySelectorAll('[data-forest-visitor-choice]')
+  ];
+  let visitorDialogueNodeId = FOREST_TRANSIENT_VISITOR_DIALOGUE.start;
   const prompt = document.querySelector('[data-forest-prompt]');
   const joystick = document.querySelector('[data-forest-joystick]');
   const joystickStick = joystick.querySelector('[data-forest-joystick-stick]');
@@ -1394,25 +1414,40 @@ if (payload && viewportElement && canvas) {
       maximum, forestBridgeElevationAt(bridge, player)
     ), 0);
     const y = Math.round(player.worldY - camera.y - elevation);
-    context.fillStyle = 'rgba(22, 35, 31, 0.28)';
-    context.fillRect(x - 8, y - 3, 16, 5);
-    context.fillStyle = '#ead9b6';
-    context.fillRect(x - 4, y - 19, 8, 8);
-    context.fillStyle = '#263b3b';
-    context.fillRect(x - 6, y - 12, 12, 11);
-    context.fillStyle = '#b96045';
-    context.fillRect(x - 7, y - 21, 14, 4);
-    context.fillRect(x - 5, y - 24, 10, 3);
+    paintForestHumanoid(context, x, y, {
+      profile: FOREST_HUMANOID_PROFILES.player,
+      motion: playerMotion,
+      reducedMotion: reducedMotionQuery.matches
+    });
+  }
+
+  function paintVisitor(visitor, elapsedSeconds) {
+    const x = Math.round(visitor.position.worldX - camera.x);
+    const idleLift = ambientMotionActive && visitor.state === 'resting'
+      && Math.sin(elapsedSeconds * 0.9) > 0.92 ? 1 : 0;
+    const y = Math.round(visitor.position.worldY - camera.y - idleLift);
+    paintForestHumanoid(context, x, y, {
+      profile: FOREST_HUMANOID_PROFILES.visitor,
+      motion: visitor.humanoidMotion,
+      reducedMotion: reducedMotionQuery.matches,
+      resting: visitor.state === 'resting'
+    });
   }
 
   function updateFocus() {
-    focusedItem = focusedForestSceneItem(player, scene.placements.filter(
+    const sceneFocus = focusedForestSceneItem(player, scene.placements.filter(
       ({ assetKey }) => assetsByKey.has(assetKey)
     ), placedObjects, scene.exploration.interactionRadius, availableDiscoveries);
+    const visitorFocus = forestTransientVisitorFocus(transientLife, player);
+    focusedItem = [sceneFocus, visitorFocus].filter(Boolean).sort((left, right) => (
+      left.distance - right.distance || left.kind.localeCompare(right.kind)
+        || left.id.localeCompare(right.id)
+    ))[0] || null;
     prompt.hidden = !focusedItem || trailEditor.active || clearingEditor.active;
     const action = focusedItem?.kind === FOREST_DISCOVERY_TYPE
       ? `gather ${forestDiscoveryMaterial(focusedItem.value.material).label.toLowerCase()}`
-      : focusedItem?.kind === 'marker' ? 'inspect marker' : 'inspect';
+      : focusedItem?.kind === 'marker' ? 'inspect marker'
+        : focusedItem?.kind === 'visitor' ? `talk with ${focusedItem.value.name}` : 'inspect';
     prompt.querySelector('[data-forest-prompt-keyboard]').textContent =
       `Press E or Enter to ${action}`;
     prompt.querySelector('[data-forest-prompt-touch]').textContent = `Tap to ${action}`;
@@ -1437,6 +1472,7 @@ if (payload && viewportElement && canvas) {
     )) : visibility.depthOrder;
     for (const item of depthOrder) {
       if (item.kind === 'player') paintPlayer();
+      else if (item.kind === 'transient-visitor') paintVisitor(item.visitor, elapsedSeconds);
       else if (item.kind === 'transient-flight') paintFlyingBird(item.actor);
       else if (item.kind === 'transient-ground-bird') paintGroundBird(item.actor);
       else if (item.kind === 'marker') paintMarker(item.object);
@@ -1477,7 +1513,8 @@ if (payload && viewportElement && canvas) {
       transientDiagnostic.playerStartledTransitions} startled · ${
       transientDiagnostic.selectionExhaustions} exhausted${
       transientDiagnostic.suppressedByReducedMotion ? ' · reduced-motion frozen' : ''} · ${
-      transientDiagnostic.groundGroup}`;
+      transientDiagnostic.groundGroup} · ${transientDiagnostic.visitor} · ${
+      transientDiagnostic.visitorTransitions} visitor transitions`;
     if (scene.environment && diagnostics.environmentPlayer) {
       const environment = forestEnvironmentAt(scene.environment, {
         worldX: Math.round(player.worldX), worldY: Math.round(player.worldY)
@@ -1553,6 +1590,10 @@ if (payload && viewportElement && canvas) {
     const elapsed = Math.min(0.05, (timestamp - lastFrameTime) / 1000);
     lastFrameTime = timestamp;
     const transientStartedAt = window.performance.now();
+    const previousVisitorPosition = transientLife.visitor ? {
+      worldX: transientLife.visitor.position.worldX,
+      worldY: transientLife.visitor.position.worldY
+    } : null;
     advanceForestTransientLife(transientLife, {
       elapsedMilliseconds: elapsed * 1000,
       scene,
@@ -1562,20 +1603,36 @@ if (payload && viewportElement && canvas) {
       viewport: camera,
       player,
       documentHidden: document.hidden,
-      reducedMotion: reducedMotionQuery.matches
+      reducedMotion: reducedMotionQuery.matches,
+      visitorPaused: visitorDialog.open || dialog.open || objectDialog.open || forestMenu.open
+        || trailEditor.active || clearingEditor.active
     });
     const transientDuration = window.performance.now() - transientStartedAt;
+    const visitorMoved = previousVisitorPosition && transientLife.visitor
+      && (previousVisitorPosition.worldX !== transientLife.visitor.position.worldX
+        || previousVisitorPosition.worldY !== transientLife.visitor.position.worldY);
     transientUpdates.count += 1;
     transientUpdates.total += transientDuration;
     transientUpdates.maximum = Math.max(transientUpdates.maximum, transientDuration);
     diagnostics.transientDuration.textContent = `${transientDuration.toFixed(2)} ms last / ${
       (transientUpdates.total / transientUpdates.count).toFixed(2)} ms avg / ${
       transientUpdates.maximum.toFixed(2)} ms max`;
-    const moving = hasMovement() && !dialog.open && !objectDialog.open && !forestMenu.open;
+    const moving = hasMovement() && !visitorDialog.open && !dialog.open
+      && !objectDialog.open && !forestMenu.open;
     if (moving) {
-      Object.assign(player, moveForestPlayer(player, movementDirection(), elapsed,
+      const previousPlayer = { ...player };
+      const direction = movementDirection();
+      const nextPlayer = moveForestPlayer(player, direction, elapsed,
         scene.world, [...scene.placements, ...terrainFeatures,
-          ...forestSolidClearingPlacements(placedObjects)], scene));
+          ...forestSolidClearingPlacements(placedObjects)], scene);
+      Object.assign(player, nextPlayer);
+      Object.assign(playerMotion, advanceForestHumanoidMotion(playerMotion, {
+        from: previousPlayer,
+        to: nextPlayer,
+        direction,
+        elapsedSeconds: elapsed,
+        reducedMotion: reducedMotionQuery.matches
+      }));
       followPlayer();
       updateFocus();
       if (trailEditor.active && trailEditor.tool !== 'remove') {
@@ -1584,6 +1641,14 @@ if (payload && viewportElement && canvas) {
       if (clearingEditor.active) {
         previewClearingAt(player.worldX, player.worldY - 56, false);
       }
+    } else {
+      Object.assign(playerMotion, advanceForestHumanoidMotion(playerMotion, {
+        from: player,
+        to: player,
+        elapsedSeconds: elapsed,
+        reducedMotion: reducedMotionQuery.matches
+      }));
+      if (visitorMoved) updateFocus();
     }
     render(timestamp / 1000, moving, frameGap);
     if (moving || ambientMotionActive) scheduledFrame = requestAnimationFrame(frame);
@@ -1796,6 +1861,32 @@ if (payload && viewportElement && canvas) {
     openFixtureWriting(fixture, 'A writing remembered here');
   }
 
+  function renderVisitorDialogue() {
+    const completed = transientLife.visitor?.conversationCompleted;
+    const node = forestTransientVisitorDialogueNode(visitorDialogueNodeId);
+    const choices = completed ? [] : node.choices;
+    visitorDialogueText.textContent = completed
+      ? FOREST_TRANSIENT_VISITOR_AFTER_DIALOGUE
+      : node.text;
+    visitorDialogueReplies.hidden = choices.length === 0;
+    visitorDialogueChoices.forEach((button, index) => {
+      const choice = choices[index];
+      button.hidden = !choice;
+      button.textContent = choice?.label || '';
+    });
+    visitorDialogueNext.hidden = choices.length > 0;
+    return choices.length > 0 ? visitorDialogueChoices[0] : visitorDialogueNext;
+  }
+
+  function openVisitorConversation() {
+    if (!transientLife.visitor || visitorDialog.open) return;
+    clearMovement();
+    visitorDialogueNodeId = FOREST_TRANSIENT_VISITOR_DIALOGUE.start;
+    const firstControl = renderVisitorDialogue();
+    visitorDialog.showModal();
+    firstControl.focus();
+  }
+
   function openFixtureWriting(fixture, eyebrow) {
     if (!fixture) return;
     dialog.querySelector('[data-forest-dialog-eyebrow]').textContent = eyebrow;
@@ -1847,6 +1938,7 @@ if (payload && viewportElement && canvas) {
 
   function activateFocusedItem() {
     if (focusedItem?.kind === FOREST_DISCOVERY_TYPE) collectDiscovery(focusedItem.value);
+    else if (focusedItem?.kind === 'visitor') openVisitorConversation();
     else openInspection();
   }
 
@@ -2217,6 +2309,7 @@ if (payload && viewportElement && canvas) {
   function resetPlayer() {
     clearMovement();
     Object.assign(player, scene.exploration.spawn);
+    Object.assign(playerMotion, createForestHumanoidMotion(player.facing));
     followPlayer();
     updateFocus();
     requestRender();
@@ -2290,7 +2383,7 @@ if (payload && viewportElement && canvas) {
   });
   viewportElement.addEventListener('pointerdown', (event) => {
     if (event.pointerType === 'mouse' && clearingEditor.active
-      && !event.target.closest('button') && !dialog.open
+      && !event.target.closest('button') && !visitorDialog.open && !dialog.open
       && !objectDialog.open && !forestMenu.open) {
       event.preventDefault();
       const viewportRect = viewportElement.getBoundingClientRect();
@@ -2300,7 +2393,8 @@ if (payload && viewportElement && canvas) {
       return;
     }
     if (event.pointerType === 'mouse' && trailEditor.active
-      && !event.target.closest('button') && !dialog.open && !forestMenu.open) {
+      && !event.target.closest('button') && !visitorDialog.open && !dialog.open
+      && !forestMenu.open) {
       event.preventDefault();
       const viewportRect = viewportElement.getBoundingClientRect();
       commitTrailAt(camera.x + event.clientX - viewportRect.left,
@@ -2308,7 +2402,8 @@ if (payload && viewportElement && canvas) {
       viewportElement.focus();
       return;
     }
-    if (event.pointerType === 'mouse' || event.target.closest('button') || dialog.open
+    if (event.pointerType === 'mouse' || event.target.closest('button') || visitorDialog.open
+      || dialog.open
       || forestMenu.open) return;
     event.preventDefault();
     touch.pointerId = event.pointerId;
@@ -2364,6 +2459,25 @@ if (payload && viewportElement && canvas) {
     requestRender();
   });
   dialog.querySelector('[data-forest-dialog-close]').addEventListener('click', () => dialog.close());
+  visitorDialogueChoices.forEach((button, index) => {
+    button.addEventListener('click', () => {
+      const node = forestTransientVisitorDialogueNode(visitorDialogueNodeId);
+      const choice = node.choices[index];
+      if (!choice) return;
+      visitorDialogueNodeId = choice.next;
+      renderVisitorDialogue().focus();
+    });
+  });
+  visitorDialogueNext.addEventListener('click', () => {
+    completeForestTransientVisitorConversation(transientLife);
+    visitorDialog.close();
+  });
+  visitorDialog.addEventListener('close', () => {
+    clearMovement();
+    viewportElement.focus();
+    updateFocus();
+    requestRender();
+  });
   prompt.addEventListener('click', () => {
     if (!trailEditor.active) activateFocusedItem();
   });

--- a/public/js/forest-humanoid.js
+++ b/public/js/forest-humanoid.js
@@ -1,0 +1,295 @@
+export const FOREST_HUMANOID_PRESENTATION_VERSION = 3;
+export const FOREST_HUMANOID_RUN_THRESHOLD = 112;
+export const FOREST_HUMANOID_MAX_RUN_CYCLES_PER_SECOND = 2.8;
+
+export const FOREST_HUMANOID_PROFILES = Object.freeze({
+  player: Object.freeze({
+    id: 'player', skin: '#e3b98c', skinShadow: '#b9785d', hair: '#63412f',
+    hairHighlight: '#87583a', headwear: '#dc793c', headwearShadow: '#a94e31',
+    headwearHighlight: '#f09a4a', torso: '#39749b', torsoShadow: '#28526f',
+    torsoHighlight: '#5593b7', legs: '#25282d', legHighlight: '#3b3e46',
+    shoes: '#a63f38', shoeHighlight: '#d05a45', patch: null
+  }),
+  visitor: Object.freeze({
+    id: 'visitor', skin: '#c99572', skinShadow: '#98624f', hair: '#b8afa0',
+    hairHighlight: '#d0c8ba', headwear: '#536947', headwearShadow: '#344938',
+    headwearHighlight: '#70835d', torso: '#69784b', torsoShadow: '#485638',
+    torsoHighlight: '#879563', legs: '#4b4037', legHighlight: '#66584a',
+    shoes: '#59402f', shoeHighlight: '#78563c', patch: '#a9824f', staff: '#6b4b32'
+  })
+});
+
+const FACINGS = Object.freeze(['up', 'right', 'down', 'left']);
+
+export function createForestHumanoidMotion(facing = 'down') {
+  const facingRadians = facing === 'right' ? 0 : facing === 'up' ? -Math.PI / 2
+    : facing === 'left' ? Math.PI : Math.PI / 2;
+  return {
+    facingRadians: FACINGS.includes(facing) ? facingRadians : Math.PI / 2,
+    targetFacingRadians: FACINGS.includes(facing) ? facingRadians : Math.PI / 2,
+    speed: 0,
+    distance: 0,
+    stepPhase: 0
+  };
+}
+
+function normalizeAngle(angle) {
+  return Math.atan2(Math.sin(angle), Math.cos(angle));
+}
+
+function turnToward(current, target, maximumTurn) {
+  const difference = normalizeAngle(target - current);
+  if (Math.abs(difference) <= maximumTurn) return target;
+  return normalizeAngle(current + (Math.sign(difference) * maximumTurn));
+}
+
+export function forestHumanoidCadence(speed) {
+  if (!Number.isFinite(speed) || speed <= 1) return 0;
+  if (speed < FOREST_HUMANOID_RUN_THRESHOLD) {
+    return Math.min(2.4, 0.7 + (Math.sqrt(speed / FOREST_HUMANOID_RUN_THRESHOLD) * 1.75));
+  }
+  return Math.min(
+    FOREST_HUMANOID_MAX_RUN_CYCLES_PER_SECOND,
+    2.4 + ((speed - FOREST_HUMANOID_RUN_THRESHOLD) / 95)
+  );
+}
+
+export function forestHumanoidFootTravel(stepPhase) {
+  const cycle = ((stepPhase / (Math.PI * 2)) % 1 + 1) % 1;
+  const plantedFraction = 0.62;
+  if (cycle < plantedFraction) return 1 - ((cycle / plantedFraction) * 2);
+  const recovery = (cycle - plantedFraction) / (1 - plantedFraction);
+  const eased = recovery * recovery * (3 - (2 * recovery));
+  return -1 + (eased * 2);
+}
+
+export function advanceForestHumanoidMotion(motion, {
+  from, to, direction = null, elapsedSeconds, reducedMotion = false
+}) {
+  const deltaX = Number(to?.worldX) - Number(from?.worldX);
+  const deltaY = Number(to?.worldY) - Number(from?.worldY);
+  const travelled = Number.isFinite(deltaX) && Number.isFinite(deltaY)
+    ? Math.hypot(deltaX, deltaY) : 0;
+  const elapsed = Number.isFinite(elapsedSeconds) && elapsedSeconds > 0 ? elapsedSeconds : 0;
+  const speed = elapsed ? travelled / elapsed : 0;
+  const distance = motion.distance + travelled;
+  const cadence = forestHumanoidCadence(speed);
+  const intendedX = Number(direction?.x);
+  const intendedY = Number(direction?.y);
+  const hasIntendedDirection = Number.isFinite(intendedX) && Number.isFinite(intendedY)
+    && Math.hypot(intendedX, intendedY) > 0.01;
+  const hasTravelDirection = travelled > 0.01;
+  const targetFacingRadians = hasIntendedDirection ? Math.atan2(intendedY, intendedX)
+    : hasTravelDirection ? Math.atan2(deltaY, deltaX) : motion.targetFacingRadians;
+  const maximumTurn = elapsed * (speed >= FOREST_HUMANOID_RUN_THRESHOLD ? 11 : 8);
+  return {
+    facingRadians: reducedMotion ? targetFacingRadians
+      : turnToward(motion.facingRadians, targetFacingRadians, maximumTurn),
+    targetFacingRadians,
+    speed: reducedMotion ? 0 : speed,
+    distance,
+    stepPhase: reducedMotion ? 0
+      : motion.stepPhase + (elapsed * cadence * Math.PI * 2)
+  };
+}
+
+export function forestHumanoidGait(motion, reducedMotion = false) {
+  const moving = !reducedMotion && motion.speed > 1;
+  const running = moving && motion.speed >= FOREST_HUMANOID_RUN_THRESHOLD;
+  const signal = moving ? Math.sin(motion.stepPhase) : 0;
+  const stride = running ? 4 : 3;
+  return {
+    moving,
+    running,
+    bob: moving && Math.abs(Math.cos(motion.stepPhase)) > 0.72 ? 1 : 0,
+    leftForward: moving ? forestHumanoidFootTravel(motion.stepPhase) * stride : 0,
+    rightForward: moving
+      ? forestHumanoidFootTravel(motion.stepPhase + Math.PI) * stride : 0,
+    leftArm: -signal * (running ? 3 : 2),
+    rightArm: signal * (running ? 3 : 2)
+  };
+}
+
+function paintPixelLimb(context, fromX, fromY, toX, toY, color, thickness = 3) {
+  context.fillStyle = color;
+  for (let step = 0; step <= 3; step += 1) {
+    const progress = step / 3;
+    const x = Math.round(fromX + ((toX - fromX) * progress));
+    const y = Math.round(fromY + ((toY - fromY) * progress));
+    context.fillRect(x - Math.floor(thickness / 2), y - 1, thickness, 3);
+  }
+}
+
+function paintPixelJointedLeg(context, hip, knee, foot, color) {
+  paintPixelLimb(context, hip.x, hip.y, knee.x, knee.y, color, 4);
+  paintPixelLimb(context, knee.x, knee.y, foot.x, foot.y, color, 4);
+  context.fillStyle = color;
+  context.fillRect(Math.round(knee.x) - 2, Math.round(knee.y) - 1, 4, 3);
+}
+
+export function paintForestHumanoid(context, x, y, {
+  profile = FOREST_HUMANOID_PROFILES.player,
+  motion = createForestHumanoidMotion(),
+  reducedMotion = false,
+  resting = false
+} = {}) {
+  const gait = forestHumanoidGait(motion, reducedMotion || resting);
+  const bob = resting ? 0 : gait.bob;
+  const forwardX = Math.cos(motion.facingRadians);
+  const forwardY = Math.sin(motion.facingRadians);
+  const lateralX = -forwardY;
+  const lateralY = forwardX;
+  const frontness = Math.abs(forwardY);
+  const rearFacing = forwardY < -0.45;
+  const sideFacing = Math.abs(forwardX) > 0.55;
+  const bodyWidth = 11 + Math.round(frontness * 3);
+  const headWidth = 10 + Math.round(frontness * 3);
+  const footY = y - bob;
+
+  context.fillStyle = 'rgba(22, 35, 31, 0.27)';
+  context.fillRect(x - (resting ? 8 : 9), y - 3, resting ? 16 : 18, 4);
+
+  const legs = [
+    { side: -3.2, forward: gait.leftForward },
+    { side: 3.2, forward: gait.rightForward }
+  ].map(leg => ({
+    hipX: x + (lateralX * leg.side),
+    hipY: footY - 10 + (lateralY * leg.side * 0.25),
+    footX: x + (lateralX * leg.side) + (forwardX * leg.forward),
+    footY: footY - 2 + (lateralY * leg.side * 0.3) + (forwardY * leg.forward * 0.55),
+    rearBend: Math.min(1.6, Math.abs(leg.forward) * 0.4)
+  })).sort((left, right) => left.footY - right.footY);
+  legs.forEach((leg) => {
+    const knee = {
+      x: ((leg.hipX + leg.footX) / 2) - (forwardX * leg.rearBend),
+      y: ((leg.hipY + leg.footY) / 2) - (forwardY * leg.rearBend * 0.55)
+    };
+    paintPixelJointedLeg(context, { x: leg.hipX, y: leg.hipY }, knee, {
+      x: leg.footX, y: leg.footY
+    }, profile.legs);
+    context.fillStyle = profile.legHighlight;
+    context.fillRect(Math.round(knee.x) - 1, Math.round(knee.y) - 1, 2, 2);
+    const shoeX = Math.round(leg.footX);
+    const shoeY = Math.round(leg.footY);
+    context.fillStyle = profile.shoes;
+    context.fillRect(shoeX - 2, shoeY - 2, 4, 1);
+    context.fillRect(shoeX - 3, shoeY - 1, 6, 2);
+    context.fillRect(shoeX - 2, shoeY + 1, 5, 1);
+    context.fillStyle = profile.shoeHighlight;
+    context.fillRect(Math.round(leg.footX + (forwardX * 2)) - 1, shoeY - 1, 2, 1);
+  });
+
+  const arms = [
+    { side: -1, forward: gait.leftArm },
+    { side: 1, forward: gait.rightArm }
+  ];
+  if (profile.staff) {
+    const staffSide = 7;
+    const staffX = x + (lateralX * staffSide) + (forwardX * 1.5);
+    const staffTopY = footY - 21 + (lateralY * staffSide * 0.25);
+    paintPixelLimb(context, staffX, staffTopY, staffX + (forwardX * 2), footY - 1,
+      profile.staff, 2);
+  }
+  arms.forEach((arm) => {
+    const shoulderX = x + (lateralX * arm.side * ((bodyWidth / 2) + 1));
+    const shoulderY = footY - 20 + (lateralY * arm.side * 0.4);
+    const handX = shoulderX + (forwardX * arm.forward);
+    const handY = footY - 13 + (forwardY * arm.forward * 0.45);
+    const elbowX = shoulderX + ((handX - shoulderX) * 0.52);
+    const elbowY = shoulderY + ((handY - shoulderY) * 0.52);
+    paintPixelLimb(context, shoulderX, shoulderY, elbowX, elbowY, profile.torsoShadow, 4);
+    paintPixelLimb(context, elbowX, elbowY, handX, handY, profile.skinShadow, 3);
+    context.fillStyle = profile.skin;
+    context.fillRect(Math.round(handX) - 1, Math.round(handY) - 2, 3, 5);
+    context.fillRect(Math.round(handX) - 2, Math.round(handY) - 1, 5, 3);
+    context.fillStyle = profile.skinShadow;
+    context.fillRect(Math.round(handX) - 2, Math.round(handY) + 1, 1, 1);
+  });
+
+  const torsoLeft = x - Math.ceil(bodyWidth / 2);
+  context.fillStyle = profile.torsoShadow;
+  context.fillRect(torsoLeft + 1, footY - 22, bodyWidth - 2, 1);
+  context.fillRect(torsoLeft, footY - 21, bodyWidth, 3);
+  context.fillRect(torsoLeft + 1, footY - 18, bodyWidth - 2, 9);
+  context.fillStyle = profile.torso;
+  context.fillRect(torsoLeft + 2, footY - 21, bodyWidth - 4, 3);
+  context.fillRect(torsoLeft + 2, footY - 18, bodyWidth - 4, 8);
+  context.fillStyle = profile.torsoHighlight;
+  context.fillRect(torsoLeft + 3, footY - 20, 2, 7);
+  context.fillStyle = profile.skinShadow;
+  context.fillRect(x - 2, footY - 24, 4, 4);
+  context.fillStyle = profile.skin;
+  context.fillRect(x - 1, footY - 24, 2, 4);
+  context.fillStyle = profile.torsoShadow;
+  context.fillRect(x - 3, footY - 22, 2, 2);
+  context.fillRect(x + 1, footY - 22, 2, 2);
+  context.fillStyle = profile.legs;
+  context.fillRect(x - 4, footY - 11, 8, 2);
+
+  if (profile.patch) {
+    context.fillStyle = profile.patch;
+    context.fillRect(x + 1, footY - 15, 3, 3);
+    context.fillStyle = profile.torsoShadow;
+    context.fillRect(x - 6, footY - 10, 3, 2);
+    context.fillRect(x + 3, footY - 10, 4, 2);
+  }
+
+  const headLeft = x - Math.ceil(headWidth / 2);
+  context.fillStyle = profile.hair;
+  context.fillRect(headLeft + 1, footY - 32, headWidth - 2, 1);
+  context.fillRect(headLeft, footY - 31, headWidth, 10);
+  context.fillRect(headLeft - 1, footY - 28, 3, 9);
+  context.fillRect(headLeft + headWidth - 2, footY - 28, 3, 9);
+  context.fillStyle = profile.hairHighlight;
+  context.fillRect(headLeft + 2, footY - 31, 4, 2);
+  context.fillRect(headLeft + headWidth - 3, footY - 26, 2, 4);
+  const faceWidth = headWidth - 2;
+  const faceLeft = x - Math.floor(faceWidth / 2) + Math.round(forwardX);
+  context.fillStyle = rearFacing ? profile.hair : profile.skinShadow;
+  context.fillRect(faceLeft + 1, footY - 30, faceWidth - 2, 1);
+  context.fillRect(faceLeft, footY - 29, faceWidth, 6);
+  context.fillRect(faceLeft + 1, footY - 23, faceWidth - 2, 1);
+  if (!rearFacing) {
+    context.fillStyle = profile.skin;
+    context.fillRect(faceLeft + 1, footY - 29, faceWidth - 2, 5);
+  }
+  if (!rearFacing) {
+    if (sideFacing) {
+      const eyeX = x + Math.round(forwardX * ((headWidth / 2) - 2));
+      context.fillStyle = '#f2ead8';
+      context.fillRect(eyeX - (forwardX < 0 ? 1 : 0), footY - 28, 2, 2);
+      context.fillStyle = '#27302e';
+      context.fillRect(eyeX, footY - 28, 1, 2);
+      context.fillStyle = profile.skinShadow;
+      context.fillRect(x + Math.round(forwardX * (headWidth / 2)), footY - 25, 2, 2);
+    } else {
+      context.fillStyle = '#f2ead8';
+      context.fillRect(x - 4, footY - 28, 3, 2);
+      context.fillRect(x + 2, footY - 28, 3, 2);
+      context.fillStyle = '#27302e';
+      context.fillRect(x - 2, footY - 28, 1, 2);
+      context.fillRect(x + 2, footY - 28, 1, 2);
+      context.fillStyle = profile.skinShadow;
+      context.fillRect(x, footY - 26, 1, 2);
+      context.fillRect(x - 1, footY - 23, 3, 1);
+    }
+  }
+
+  context.fillStyle = profile.headwearShadow;
+  context.fillRect(x - Math.ceil((headWidth + 2) / 2), footY - 34, headWidth + 2, 4);
+  context.fillStyle = profile.headwear;
+  context.fillRect(x - Math.ceil(headWidth / 2), footY - 37, headWidth, 4);
+  if (profile.id === 'visitor') {
+    context.fillRect(x - Math.ceil((headWidth - 4) / 2), footY - 40, headWidth - 4, 3);
+    context.fillRect(x - 2 - Math.round(forwardX), footY - 42, 5, 2);
+    context.fillRect(x - 2 - Math.round(forwardX * 2), footY - 44, 3, 2);
+  } else {
+    context.fillRect(x - Math.ceil((headWidth - 4) / 2), footY - 39, headWidth - 4, 2);
+  }
+  context.fillStyle = profile.headwearHighlight;
+  context.fillRect(x - Math.floor(headWidth / 2) + 1, footY - 37, 4, 1);
+  context.fillRect(x - Math.round(forwardX * 2) - 1,
+    footY - (profile.id === 'visitor' ? 40 : 39), 3, 1);
+
+  return gait;
+}

--- a/public/js/forest-transient-life.js
+++ b/public/js/forest-transient-life.js
@@ -1,10 +1,16 @@
 import {
   forestBridgeContains,
+  forestBridgeWorldPosition,
   forestEnvironmentAt
 } from './forest-environment.js';
+import {
+  advanceForestHumanoidMotion,
+  createForestHumanoidMotion
+} from './forest-humanoid.js';
 
-export const FOREST_TRANSIENT_LIFE_VERSION = 2;
+export const FOREST_TRANSIENT_LIFE_VERSION = 3;
 export const FOREST_TRANSIENT_ACTOR_SCHEMA_VERSION = 2;
+export const FOREST_TRANSIENT_VISITOR_SCHEMA_VERSION = 1;
 export const FOREST_TRANSIENT_BIRD_LIMIT = 4;
 export const FOREST_TRANSIENT_GROUND_BIRD_COUNT = 2;
 export const FOREST_TRANSIENT_VISIBLE_REDUCED_MOTION_LIMIT = 2;
@@ -15,6 +21,80 @@ export const FOREST_TRANSIENT_STARTLE_RADIUS = 88;
 export const FOREST_TRANSIENT_STARTLE_RESET_RADIUS = 142;
 export const FOREST_TRANSIENT_GROUND_RADIUS = 9;
 export const FOREST_TRANSIENT_MAX_RETREAT_ATTEMPTS = 4;
+export const FOREST_TRANSIENT_VISITOR_INTERACTION_RADIUS = 58;
+
+const GOOD_GOURD_HYMN = [
+  'Good Gourd, the Pumpkin Lord, mercy’s growing on the vine,',
+  'Good Gourd, the Pumpkin Lord, come scoop his seeds divine,',
+  'Good Gourd, the Pumpkin Lord, he’ll squash your every sin,',
+  'As a pure purée, as a pious pie, or as a good old carved-out grin.'
+].join('\n');
+
+function visitorDialogueNode(id, text, choices = []) {
+  return Object.freeze({
+    id,
+    text,
+    choices: Object.freeze(choices.map(choice => Object.freeze(choice)))
+  });
+}
+
+export const FOREST_TRANSIENT_VISITOR_DIALOGUE = Object.freeze({
+  start: 'meeting',
+  nodes: Object.freeze([
+    visitorDialogueNode(
+      'meeting',
+      '“Name’s Tansy Rook. I’ve buried more boots than kin.”',
+      [
+        { label: '“That’s a lot of walking.”', next: 'long-road' },
+        { label: '“More boots than kin?”', next: 'buried-boots' }
+      ]
+    ),
+    visitorDialogueNode(
+      'long-road',
+      [
+        '“Walking’s the easy part. Stopping somewhere that expects explanations—that wears the soles.',
+        'These days I stop among trees. Decent company. They remember what you meant, not merely what you managed to say.”'
+      ].join('\n\n'),
+      [
+        { label: '“Don’t you get lonely?”', next: 'loneliness' },
+        { label: '“What keeps you going?”', next: 'keeps-going' }
+      ]
+    ),
+    visitorDialogueNode(
+      'buried-boots',
+      [
+        '“Kin complain when buried. Boots have manners.',
+        'These days I stop among trees. Decent company. They remember what you meant, not merely what you managed to say.”'
+      ].join('\n\n'),
+      [
+        { label: '“Don’t you get lonely?”', next: 'loneliness' },
+        { label: '“What keeps you going?”', next: 'keeps-going' }
+      ]
+    ),
+    visitorDialogueNode(
+      'loneliness',
+      [
+        '“Certainly. Loneliness is only solitude asking to be introduced. On the worst evenings I keep faith with Good Gourd, the Pumpkin Lord. A road-prayer goes like this:',
+        `${GOOD_GOURD_HYMN}”`
+      ].join('\n\n')
+    ),
+    visitorDialogueNode(
+      'keeps-going',
+      [
+        '“Mostly another bend in the road. Beyond that, I keep faith with Good Gourd, the Pumpkin Lord. When the road asks why, I answer:',
+        `${GOOD_GOURD_HYMN}”`
+      ].join('\n\n')
+    )
+  ])
+});
+
+export function forestTransientVisitorDialogueNode(id) {
+  return FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.find(node => node.id === id)
+    || FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes[0];
+}
+
+export const FOREST_TRANSIENT_VISITOR_AFTER_DIALOGUE =
+  '“A good road to you, little miscreant. Leave a few mysteries untrampled.”';
 
 export const FOREST_BIRD_VARIANTS = Object.freeze([
   Object.freeze({ id: 'moss-cap', body: '#63714d', wing: '#394b40', breast: '#d7c58f' }),
@@ -187,6 +267,67 @@ export function selectForestTransientGroundGroup(scene, objects = []) {
   return { point: null, attempts: 48, exhausted: true };
 }
 
+function visitorRouteAt(scene, point, angle, objects) {
+  for (const direction of [-1, 1]) {
+    const routePoint = {
+      worldX: Math.round(point.worldX + (Math.cos(angle) * 34 * direction)),
+      worldY: Math.round(point.worldY + (Math.sin(angle) * 34 * direction))
+    };
+    const samples = [routePoint, ...[0.25, 0.5, 0.75].map(progress => ({
+      worldX: Math.round(point.worldX + ((routePoint.worldX - point.worldX) * progress)),
+      worldY: Math.round(point.worldY + ((routePoint.worldY - point.worldY) * progress))
+    }))];
+    if (samples.every(sample => forestTransientGroundSuitability(
+      scene, sample, objects
+    ).valid)) {
+      return [point, routePoint];
+    }
+  }
+  return null;
+}
+
+export function selectForestTransientVisitor(scene, objects = []) {
+  const spawn = scene.exploration.spawn;
+  const crossings = [...(scene.crossings || [])].sort((left, right) => (
+    Math.hypot(left.worldX - spawn.worldX, left.worldY - spawn.worldY)
+      - Math.hypot(right.worldX - spawn.worldX, right.worldY - spawn.worldY)
+      || left.id.localeCompare(right.id)
+  ));
+  let attempts = 0;
+  for (const crossing of crossings) {
+    const angle = crossing.angleMilliradians / 1000;
+    for (const side of [-1, 1]) {
+      for (const lateral of [-34, 34, 0]) {
+        attempts += 1;
+        const point = forestBridgeWorldPosition(
+          crossing, side * (crossing.halfLength + 58), lateral
+        );
+        const rounded = { worldX: Math.round(point.worldX), worldY: Math.round(point.worldY) };
+        if (!forestTransientGroundSuitability(scene, rounded, objects).valid) continue;
+        const route = visitorRouteAt(scene, rounded, angle + (Math.PI / 2), objects);
+        if (route) return { point: rounded, route, landmarkId: crossing.id, attempts,
+          exhausted: false };
+      }
+    }
+  }
+  for (let attempt = 0; attempt < 48; attempt += 1) {
+    attempts += 1;
+    const angle = stableUnit(`${scene.seed}:visitor:${attempt}:angle`) * Math.PI * 2;
+    const distance = 210 + Math.round(stableUnit(
+      `${scene.seed}:visitor:${attempt}:distance`
+    ) * 230);
+    const point = {
+      worldX: Math.round(spawn.worldX + (Math.cos(angle) * distance)),
+      worldY: Math.round(spawn.worldY + (Math.sin(angle) * distance))
+    };
+    if (!forestTransientGroundSuitability(scene, point, objects).valid) continue;
+    const route = visitorRouteAt(scene, point, angle + (Math.PI / 2), objects);
+    if (route) return { point, route, landmarkId: 'entrance-trail', attempts,
+      exhausted: false };
+  }
+  return { point: null, route: [], landmarkId: null, attempts, exhausted: true };
+}
+
 function groundPoint(center, actorIndex) {
   const side = actorIndex % 2 ? 1 : -1;
   const worldX = center.worldX + (side * 9);
@@ -241,6 +382,30 @@ export function createForestTransientLife(scene, {
     };
   });
   const groundActors = actors.filter(({ groupId }) => groupId);
+  const visitorObstacles = groundSelection.point ? [{
+    worldX: groundSelection.point.worldX,
+    worldY: groundSelection.point.worldY,
+    collisionRadius: 64
+  }] : [];
+  const visitorSelection = selectForestTransientVisitor(scene, [...objects, ...visitorObstacles]);
+  const visitorIdentity = stableHash(`${scene.seed}:visitor:tansy-rook`);
+  const visitor = visitorSelection.point ? {
+    schemaVersion: FOREST_TRANSIENT_VISITOR_SCHEMA_VERSION,
+    id: 'forest-visitor-v1-01',
+    kind: 'visitor',
+    name: 'Tansy Rook',
+    profileId: 'visitor',
+    landmarkId: visitorSelection.landmarkId,
+    route: visitorSelection.route,
+    routeIndex: 0,
+    position: visitorSelection.point,
+    state: 'resting',
+    elapsedMilliseconds: 0,
+    durationMilliseconds: 12000 + (visitorIdentity % 7000),
+    transitionCount: 0,
+    conversationCompleted: false,
+    humanoidMotion: createForestHumanoidMotion('left')
+  } : null;
   return {
     version: FOREST_TRANSIENT_LIFE_VERSION,
     seed: `${scene.seed}:transient-life-v${FOREST_TRANSIENT_LIFE_VERSION}`,
@@ -248,6 +413,7 @@ export function createForestTransientLife(scene, {
     elapsedMilliseconds: 0,
     remainderMilliseconds: 0,
     actors,
+    visitor,
     groundGroup: groundSelection.point ? {
       id: 'forest-ground-flock-v1-01',
       center: groundSelection.point,
@@ -261,7 +427,9 @@ export function createForestTransientLife(scene, {
       autonomousTransitions: 0,
       playerStartledTransitions: 0,
       branchHops: 0,
-      selectionExhaustions: count < FOREST_TRANSIENT_BIRD_LIMIT || groundSelection.exhausted ? 1 : 0,
+      visitorTransitions: 0,
+      selectionExhaustions: count < FOREST_TRANSIENT_BIRD_LIMIT || groundSelection.exhausted
+        || visitorSelection.exhausted ? 1 : 0,
       suppressedByReducedMotion: false,
       lastStepCount: 0
     }
@@ -305,23 +473,59 @@ function validGroundGroup(group) {
     && Number.isInteger(group.selectionAttempts));
 }
 
+function validWorldPoint(point) {
+  return exactKeys(point, ['worldX', 'worldY'])
+    && Number.isFinite(point.worldX) && Number.isFinite(point.worldY);
+}
+
+function validHumanoidMotion(motion) {
+  return exactKeys(motion, [
+    'facingRadians', 'targetFacingRadians', 'speed', 'distance', 'stepPhase'
+  ]) && ['facingRadians', 'targetFacingRadians', 'speed', 'distance', 'stepPhase'].every(
+    key => Number.isFinite(motion[key])
+  ) && motion.speed >= 0 && motion.distance >= 0;
+}
+
+function validVisitor(visitor) {
+  return visitor === null || (exactKeys(visitor, [
+    'schemaVersion', 'id', 'kind', 'name', 'profileId', 'landmarkId', 'route', 'routeIndex',
+    'position', 'state', 'elapsedMilliseconds', 'durationMilliseconds', 'transitionCount',
+    'conversationCompleted', 'humanoidMotion'
+  ]) && visitor.schemaVersion === FOREST_TRANSIENT_VISITOR_SCHEMA_VERSION
+    && visitor.id === 'forest-visitor-v1-01' && visitor.kind === 'visitor'
+    && visitor.name === 'Tansy Rook' && visitor.profileId === 'visitor'
+    && typeof visitor.landmarkId === 'string' && visitor.landmarkId.length <= 200
+    && Array.isArray(visitor.route) && visitor.route.length === 2
+    && visitor.route.every(validWorldPoint)
+    && Number.isInteger(visitor.routeIndex) && [0, 1].includes(visitor.routeIndex)
+    && validWorldPoint(visitor.position)
+    && ['resting', 'walking'].includes(visitor.state)
+    && Number.isFinite(visitor.elapsedMilliseconds) && visitor.elapsedMilliseconds >= 0
+    && Number.isFinite(visitor.durationMilliseconds) && visitor.durationMilliseconds >= 0
+    && Number.isInteger(visitor.transitionCount) && visitor.transitionCount >= 0
+    && typeof visitor.conversationCompleted === 'boolean'
+    && validHumanoidMotion(visitor.humanoidMotion));
+}
+
 export function validateForestTransientLife(life) {
   if (!exactKeys(life, [
     'version', 'seed', 'randomState', 'elapsedMilliseconds', 'remainderMilliseconds', 'actors',
-    'groundGroup', 'diagnostics'
+    'visitor', 'groundGroup', 'diagnostics'
   ]) || life.version !== FOREST_TRANSIENT_LIFE_VERSION
     || typeof life.seed !== 'string' || life.seed.length > 200
     || !Number.isInteger(life.randomState) || life.randomState < 0
     || !Number.isFinite(life.elapsedMilliseconds)
     || !Number.isFinite(life.remainderMilliseconds)
     || !Array.isArray(life.actors) || life.actors.length > FOREST_TRANSIENT_BIRD_LIMIT
+    || !validVisitor(life.visitor)
     || !validGroundGroup(life.groundGroup)
     || !exactKeys(life.diagnostics, [
       'autonomousTransitions', 'playerStartledTransitions', 'branchHops',
-      'selectionExhaustions', 'suppressedByReducedMotion', 'lastStepCount'
+      'visitorTransitions', 'selectionExhaustions', 'suppressedByReducedMotion', 'lastStepCount'
     ])
     || !['autonomousTransitions', 'playerStartledTransitions', 'branchHops',
-      'selectionExhaustions', 'lastStepCount'].every(key => Number.isInteger(life.diagnostics[key])
+      'visitorTransitions', 'selectionExhaustions', 'lastStepCount'].every(
+      key => Number.isInteger(life.diagnostics[key])
         && life.diagnostics[key] >= 0)
     || typeof life.diagnostics.suppressedByReducedMotion !== 'boolean') return false;
   return life.actors.every(actor => exactKeys(actor, [
@@ -707,7 +911,66 @@ function updateGroundGroup(life, scene, objects, placements, assetsByKey, player
   }
 }
 
-function updateStep(life, scene, objects, placements, assetsByKey, viewport, player) {
+function updateVisitor(life, viewport, paused = false) {
+  const visitor = life.visitor;
+  if (!visitor || paused || !pointWithinSimulationMargin({
+    x: visitor.position.worldX, projectedY: visitor.position.worldY
+  }, viewport)) return;
+  const elapsedSeconds = FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS / 1000;
+  if (visitor.state === 'resting') {
+    visitor.humanoidMotion = advanceForestHumanoidMotion(visitor.humanoidMotion, {
+      from: visitor.position, to: visitor.position, elapsedSeconds
+    });
+    visitor.elapsedMilliseconds += FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS;
+    if (visitor.elapsedMilliseconds < visitor.durationMilliseconds) return;
+    visitor.state = 'walking';
+    visitor.elapsedMilliseconds = 0;
+    const destination = visitor.route[(visitor.routeIndex + 1) % visitor.route.length];
+    visitor.durationMilliseconds = Math.round(Math.hypot(
+      destination.worldX - visitor.position.worldX,
+      destination.worldY - visitor.position.worldY
+    ) / 0.032);
+    visitor.transitionCount += 1;
+    life.diagnostics.autonomousTransitions += 1;
+    life.diagnostics.visitorTransitions += 1;
+    return;
+  }
+  const from = { ...visitor.position };
+  visitor.elapsedMilliseconds = Math.min(
+    visitor.durationMilliseconds,
+    visitor.elapsedMilliseconds + FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS
+  );
+  const targetIndex = (visitor.routeIndex + 1) % visitor.route.length;
+  const destination = visitor.route[targetIndex];
+  const origin = visitor.route[visitor.routeIndex];
+  const progress = visitor.elapsedMilliseconds / visitor.durationMilliseconds;
+  visitor.position = {
+    worldX: origin.worldX + ((destination.worldX - origin.worldX) * progress),
+    worldY: origin.worldY + ((destination.worldY - origin.worldY) * progress)
+  };
+  visitor.humanoidMotion = advanceForestHumanoidMotion(visitor.humanoidMotion, {
+    from,
+    to: visitor.position,
+    direction: {
+      x: destination.worldX - origin.worldX,
+      y: destination.worldY - origin.worldY
+    },
+    elapsedSeconds
+  });
+  if (progress < 1) return;
+  visitor.state = 'resting';
+  visitor.routeIndex = targetIndex;
+  visitor.elapsedMilliseconds = 0;
+  visitor.durationMilliseconds = 13000
+    + ((stableHash(`${life.seed}:visitor-rest:${visitor.transitionCount}`)) % 9000);
+  visitor.transitionCount += 1;
+  life.diagnostics.autonomousTransitions += 1;
+  life.diagnostics.visitorTransitions += 1;
+}
+
+function updateStep(life, scene, objects, placements, assetsByKey, viewport, player,
+  visitorPaused) {
+  updateVisitor(life, viewport, visitorPaused);
   updateGroundGroup(life, scene, objects, placements, assetsByKey, player, viewport);
   let transitionStarted = life.actors.some(actor => (
     ['flight', 'branch-hop', 'ground-wander'].includes(actor.behavior.state)
@@ -750,6 +1013,7 @@ export function advanceForestTransientLife(life, {
   assetsByKey = new Map(),
   viewport = null,
   player = null,
+  visitorPaused = false,
   documentHidden = false,
   reducedMotion = false
 } = {}) {
@@ -762,7 +1026,7 @@ export function advanceForestTransientLife(life, {
   );
   while (life.remainderMilliseconds >= FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS
     && life.diagnostics.lastStepCount < FOREST_TRANSIENT_MAX_STEPS_PER_UPDATE) {
-    updateStep(life, scene, objects, placements, assetsByKey, viewport, player);
+    updateStep(life, scene, objects, placements, assetsByKey, viewport, player, visitorPaused);
     life.remainderMilliseconds -= FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS;
     life.elapsedMilliseconds += FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS;
     life.diagnostics.lastStepCount += 1;
@@ -808,6 +1072,12 @@ export function forestTransientDepthItems(life, viewport, reducedMotion = false,
     forestTransientFlightAboveBridgeRails(actor, crossings)
   ));
   const items = [
+    ...(life.visitor && pointWithinSimulationMargin({
+      x: life.visitor.position.worldX, projectedY: life.visitor.position.worldY
+    }, viewport) ? [{
+        kind: 'transient-visitor', id: life.visitor.id,
+        worldY: life.visitor.position.worldY, visitor: life.visitor
+      }] : []),
     ...forestTransientGroundBirds(life, viewport, reducedMotion).map(actor => ({
       kind: 'transient-ground-bird', id: actor.id,
       worldY: actor.behavior.state === 'ground-wander'
@@ -821,6 +1091,25 @@ export function forestTransientDepthItems(life, viewport, reducedMotion = false,
   return { items, highBridgeFlights };
 }
 
+export function forestTransientVisitorFocus(life, player,
+  interactionRadius = FOREST_TRANSIENT_VISITOR_INTERACTION_RADIUS) {
+  if (!life.visitor || !player) return null;
+  const distance = Math.hypot(
+    player.worldX - life.visitor.position.worldX,
+    player.worldY - life.visitor.position.worldY
+  );
+  return distance <= interactionRadius ? {
+    kind: 'visitor', id: life.visitor.id, value: life.visitor, distance,
+    reach: interactionRadius
+  } : null;
+}
+
+export function completeForestTransientVisitorConversation(life) {
+  if (!life.visitor) return false;
+  life.visitor.conversationCompleted = true;
+  return true;
+}
+
 export function forestTransientLifeDiagnostic(life) {
   const counts = Object.fromEntries(BIRD_STATES.map(state => [
     state, life.actors.filter(actor => actor.behavior.state === state).length
@@ -831,6 +1120,9 @@ export function forestTransientLifeDiagnostic(life) {
     autonomousTransitions: life.diagnostics.autonomousTransitions,
     playerStartledTransitions: life.diagnostics.playerStartledTransitions,
     branchHops: life.diagnostics.branchHops,
+    visitor: life.visitor ? `${life.visitor.name} · ${life.visitor.state} · ${
+      life.visitor.conversationCompleted ? 'spoken-with' : 'unmet'}` : 'unavailable',
+    visitorTransitions: life.diagnostics.visitorTransitions,
     selectionExhaustions: life.diagnostics.selectionExhaustions,
     suppressedByReducedMotion: life.diagnostics.suppressedByReducedMotion,
     groundGroup: life.groundGroup ? (life.groundGroup.startled ? 'retreating-or-away'

--- a/spec/forestHumanoidSpec.js
+++ b/spec/forestHumanoidSpec.js
@@ -1,0 +1,91 @@
+import {
+  advanceForestHumanoidMotion,
+  createForestHumanoidMotion,
+  FOREST_HUMANOID_MAX_RUN_CYCLES_PER_SECOND,
+  FOREST_HUMANOID_PRESENTATION_VERSION,
+  FOREST_HUMANOID_RUN_THRESHOLD,
+  forestHumanoidCadence,
+  forestHumanoidFootTravel,
+  forestHumanoidGait
+} from '../public/js/forest-humanoid.js';
+
+describe('Activity Forest humanoid presentation', () => {
+  it('uses a versioned exact motion shape and derives facing from actual travel', () => {
+    const initial = createForestHumanoidMotion();
+    const moved = advanceForestHumanoidMotion(initial, {
+      from: { worldX: 20, worldY: 30 },
+      to: { worldX: 32, worldY: 34 },
+      elapsedSeconds: 0.2
+    });
+
+    expect(FOREST_HUMANOID_PRESENTATION_VERSION).toBe(3);
+    expect(Object.keys(moved).sort()).toEqual([
+      'distance', 'facingRadians', 'speed', 'stepPhase', 'targetFacingRadians'
+    ]);
+    expect(moved.targetFacingRadians).toBeCloseTo(Math.atan2(4, 12));
+    expect(moved.facingRadians).not.toBe(initial.facingRadians);
+    expect(moved.distance).toBeCloseTo(Math.hypot(12, 4));
+    expect(moved.speed).toBeCloseTo(Math.hypot(12, 4) / 0.2);
+  });
+
+  it('scales the gait from walking to running according to travel rate', () => {
+    const walking = advanceForestHumanoidMotion(createForestHumanoidMotion(), {
+      from: { worldX: 0, worldY: 0 }, to: { worldX: 8, worldY: 0 }, elapsedSeconds: 0.1
+    });
+    const running = advanceForestHumanoidMotion(createForestHumanoidMotion(), {
+      from: { worldX: 0, worldY: 0 }, to: { worldX: 15, worldY: 0 }, elapsedSeconds: 0.1
+    });
+
+    expect(walking.speed).toBeLessThan(FOREST_HUMANOID_RUN_THRESHOLD);
+    expect(forestHumanoidGait(walking).running).toBeFalse();
+    expect(running.speed).toBeGreaterThan(FOREST_HUMANOID_RUN_THRESHOLD);
+    expect(forestHumanoidGait(running).running).toBeTrue();
+    expect(running.stepPhase).toBeGreaterThan(walking.stepPhase);
+  });
+
+  it('uses an explicit running cadence and caps hyper-speed leg motion', () => {
+    const ordinaryRun = forestHumanoidCadence(150);
+    const impossibleSprint = forestHumanoidCadence(10000);
+
+    expect(ordinaryRun).toBeGreaterThan(forestHumanoidCadence(80));
+    expect(ordinaryRun).toBeLessThanOrEqual(FOREST_HUMANOID_MAX_RUN_CYCLES_PER_SECOND);
+    expect(impossibleSprint).toBe(FOREST_HUMANOID_MAX_RUN_CYCLES_PER_SECOND);
+  });
+
+  it('keeps walking cadence legible and gives each foot a planted and recovery phase', () => {
+    expect(forestHumanoidCadence(30)).toBeGreaterThan(1.5);
+    expect(forestHumanoidFootTravel(0)).toBe(1);
+    expect(forestHumanoidFootTravel(Math.PI * 2 * 0.62)).toBeCloseTo(-1);
+    expect(forestHumanoidFootTravel(Math.PI * 2 * 0.81)).toBeCloseTo(0);
+    expect(forestHumanoidFootTravel(Math.PI * 2 * 0.99)).toBeGreaterThan(0.9);
+  });
+
+  it('preserves travel and facing while suppressing reduced-motion animation', () => {
+    const reduced = advanceForestHumanoidMotion(createForestHumanoidMotion('left'), {
+      from: { worldX: 40, worldY: 40 }, to: { worldX: 40, worldY: 20 },
+      elapsedSeconds: 0.1, reducedMotion: true
+    });
+
+    expect(reduced.facingRadians).toBeCloseTo(-Math.PI / 2);
+    expect(reduced.targetFacingRadians).toBeCloseTo(-Math.PI / 2);
+    expect(reduced.distance).toBe(20);
+    expect(reduced.speed).toBe(0);
+    expect(reduced.stepPhase).toBe(0);
+    expect(forestHumanoidGait(reduced, true).moving).toBeFalse();
+  });
+
+  it('eases toward analog intent even when collision prevents travel', () => {
+    const initial = createForestHumanoidMotion('down');
+    const turning = advanceForestHumanoidMotion(initial, {
+      from: { worldX: 20, worldY: 20 },
+      to: { worldX: 20, worldY: 20 },
+      direction: { x: -0.8, y: -0.6 },
+      elapsedSeconds: 0.05
+    });
+
+    expect(turning.speed).toBe(0);
+    expect(turning.targetFacingRadians).toBeCloseTo(Math.atan2(-0.6, -0.8));
+    expect(turning.facingRadians).not.toBe(initial.facingRadians);
+    expect(turning.facingRadians).not.toBe(turning.targetFacingRadians);
+  });
+});

--- a/spec/forestTransientLifeSpec.js
+++ b/spec/forestTransientLifeSpec.js
@@ -1,5 +1,6 @@
 import {
   advanceForestTransientLife,
+  completeForestTransientVisitorConversation,
   createForestTransientLife,
   FOREST_TRANSIENT_BIRD_LIMIT,
   FOREST_TRANSIENT_FIXED_STEP_MILLISECONDS,
@@ -8,6 +9,7 @@ import {
   FOREST_TRANSIENT_MAX_STEPS_PER_UPDATE,
   FOREST_TRANSIENT_STARTLE_RADIUS,
   FOREST_TRANSIENT_STARTLE_RESET_RADIUS,
+  FOREST_TRANSIENT_VISITOR_DIALOGUE,
   forestBirdForagePecking,
   forestBirdPerchPoint,
   forestTransientBirdsForTree,
@@ -17,7 +19,10 @@ import {
   forestTransientGroundBirds,
   forestTransientGroundSuitability,
   forestTransientLifeDiagnostic,
+  forestTransientVisitorDialogueNode,
+  forestTransientVisitorFocus,
   selectForestTransientGroundGroup,
+  selectForestTransientVisitor,
   validateForestTransientLife,
   validForestPerchAnchor
 } from '../public/js/forest-transient-life.js';
@@ -120,6 +125,85 @@ describe('Activity Forest transient-life boundary', () => {
       worldX: selection.point.worldX, worldY: selection.point.worldY
     }, [{ worldX: selection.point.worldX, worldY: selection.point.worldY,
       collisionRadius: 12 }]).reason).toBe('authored-object-ground');
+  });
+
+  it('places one original visitor on a bounded valid two-point route', () => {
+    const { scene } = fixture();
+    const selection = selectForestTransientVisitor(scene);
+    const life = createForestTransientLife(scene);
+
+    expect(selection.exhausted).toBeFalse();
+    expect(selection.route.length).toBe(2);
+    expect(selection.route.every(point => (
+      forestTransientGroundSuitability(scene, point).valid
+    ))).toBeTrue();
+    expect([0.25, 0.5, 0.75].every((progress) => forestTransientGroundSuitability(scene, {
+      worldX: Math.round(selection.route[0].worldX
+        + ((selection.route[1].worldX - selection.route[0].worldX) * progress)),
+      worldY: Math.round(selection.route[0].worldY
+        + ((selection.route[1].worldY - selection.route[0].worldY) * progress))
+    }).valid)).toBeTrue();
+    expect(life.visitor.name).toBe('Tansy Rook');
+    expect(life.visitor.kind).toBe('visitor');
+    expect(life.visitor.state).toBe('resting');
+    expect(validateForestTransientLife(life)).toBeTrue();
+  });
+
+  it('walks the visitor slowly between two rests and pauses her for dialogs', () => {
+    const { scene, assetsByKey } = fixture();
+    const life = createForestTransientLife(scene);
+    const visitor = life.visitor;
+    visitor.durationMilliseconds = 0;
+    const options = activeOptions(scene, assetsByKey);
+
+    advanceForestTransientLife(life, { ...options, elapsedMilliseconds: 50 });
+    expect(visitor.state).toBe('walking');
+    const walkingSnapshot = JSON.parse(JSON.stringify(visitor));
+    advanceForestTransientLife(life, {
+      ...options, elapsedMilliseconds: 200, visitorPaused: true
+    });
+    expect(visitor).toEqual(walkingSnapshot);
+    for (let index = 0; index < 8 && visitor.state === 'walking'; index += 1) {
+      advanceForestTransientLife(life, { ...options, elapsedMilliseconds: 200 });
+    }
+    expect(visitor.state).toBe('resting');
+    expect(visitor.routeIndex).toBe(1);
+    expect(life.diagnostics.visitorTransitions).toBe(2);
+    expect(validateForestTransientLife(life)).toBeTrue();
+  });
+
+  it('keeps visitor interaction bounded, optional, and still under reduced motion', () => {
+    const { scene, assetsByKey } = fixture();
+    const life = createForestTransientLife(scene);
+    const initial = JSON.parse(JSON.stringify(life.visitor));
+    const player = { ...life.visitor.position };
+
+    expect(forestTransientVisitorFocus(life, player)?.value).toBe(life.visitor);
+    expect(FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.length).toBe(5);
+    const nodeIds = FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.map(({ id }) => id);
+    const choices = FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.flatMap(node => node.choices);
+    expect(forestTransientVisitorDialogueNode(
+      FOREST_TRANSIENT_VISITOR_DIALOGUE.start
+    ).choices.length).toBe(2);
+    expect(choices.length).toBe(6);
+    expect(choices.every(choice => nodeIds.includes(choice.next))).toBeTrue();
+    expect(Math.max(...FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.map(
+      node => node.choices.length
+    ))).toBe(2);
+    const endings = FOREST_TRANSIENT_VISITOR_DIALOGUE.nodes.filter(
+      node => node.choices.length === 0
+    );
+    expect(endings.length).toBe(2);
+    expect(endings.every(node => node.text.includes('Pumpkin Lord'))).toBeTrue();
+    expect(endings.every(node => node.text.startsWith('“'))).toBeTrue();
+    expect(endings.every(node => node.text.endsWith('”'))).toBeTrue();
+    expect(completeForestTransientVisitorConversation(life)).toBeTrue();
+    expect(life.visitor.conversationCompleted).toBeTrue();
+    life.visitor = initial;
+    advanceForestTransientLife(life, {
+      ...activeOptions(scene, assetsByKey), elapsedMilliseconds: 10000, reducedMotion: true
+    });
+    expect(life.visitor).toEqual(initial);
   });
 
   it('validates exact perch shapes and favors a readable real anchor for one-third of identities', () => {

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -247,7 +247,7 @@ block content
         dt Transient update
         dd(data-forest-transient-duration) No transient frames yet
       div
-        dt Nearby tree
+        dt Nearby focus
         dd(data-forest-focus) None
       div
         dt Last render
@@ -287,6 +287,24 @@ block content
             dd(data-forest-meaning-tint)
         ul(data-forest-meaning-reasons)
       button(type='button' data-forest-dialog-close) Return to the forest
+
+    dialog.activity-forest__dialog(
+      data-forest-visitor-dialog
+      aria-labelledby='forest-visitor-title'
+    )
+      p.activity-forest__dialog-eyebrow A traveler between roads
+      h2#forest-visitor-title Tansy Rook
+      p.activity-forest__dialog-context Weathered wayfarer · keeper of improbable faith
+      p.activity-forest__dialog-excerpt.activity-forest__visitor-text(
+        data-forest-visitor-text
+        aria-live='polite'
+      )
+      .activity-forest__visitor-replies(data-forest-visitor-replies hidden)
+        p.activity-forest__visitor-reply-label What do you say?
+        .activity-forest__visitor-reply-buttons(role='group' aria-label='Choose your reply')
+          button(type='button' data-forest-visitor-choice='0')
+          button(type='button' data-forest-visitor-choice='1')
+      button(type='button' data-forest-visitor-next hidden) Wish her a good road
 
     dialog.activity-forest__dialog(data-forest-object-dialog aria-labelledby='forest-object-title')
       p.activity-forest__dialog-eyebrow A clearing object


### PR DESCRIPTION
## Summary

Completes the second half of Activity Forest Milestone 9 by introducing Tansy Rook, an original transient traveler with a small, warm conversation, and by upgrading both the player and visitor to a shared expressive humanoid presentation.

## What changed

- Replace the original player marker with a more detailed pixel humanoid:
  - orange beanie, shaggy hair, blue shirt, black pants, and red shoes
  - eased 360-degree facing for analog movement
  - grounded hip–knee–foot walking animation
  - distinct, capped running cadence
  - movement timing derived from actual travel speed
- Add a reusable humanoid renderer shared by the player and Tansy.
- Add Tansy Rook as a non-solid transient visitor:
  - selects a validated dry route near a bridge approach or forest entrance
  - rests and walks slowly between two nearby points
  - participates in ordinary depth sorting and simulation culling
  - pauses during dialogs, menus, and editing
  - remains stable under reduced-motion preferences
- Add keyboard, touch, and focus interaction using the forest’s existing prompt conventions.
- Add a bounded five-node conversation with two reply moments:
  - each choice receives a distinct response
  - paths reconverge without quests or lasting consequences
  - the exchange naturally leads into Tansy’s hymn to Good Gourd, the Pumpkin Lord
  - subsequent interactions during the page session use her “little miscreant” farewell
- Add accessible reply controls and live dialogue announcements.
- Expand transient-life diagnostics, contract documentation, and focused test coverage.

## Behavioral boundaries

- Tansy introduces no quest, reward, inventory effect, relationship meter, schedule, or generalized NPC framework.
- Her position, movement, and conversation completion remain page-lifetime state for this milestone.
- Production account-level encounter continuity is intentionally deferred.
- Policies for named NPCs in personal, communal, and read-only foreign territories are also deferred to the later visiting architecture.

## Verification

- ESLint passes for the affected JavaScript and specs.
- The Activity Forest Pug template compiles successfully.
- All **699 Jasmine specs** pass with zero failures.
- `git diff --check` passes.
- Player movement, Tansy’s presentation, and the complete conversation were reviewed in the composed forest scene.