### PR TITLE
Prefer site-language translations on room dashboards

### DIFF
--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -475,7 +475,11 @@ export function replaceWithPreferredTranslationVariants(blocks, preferredTransla
   });
 }
 
-async function loadPreferredTranslationVariants(blocks, preferredLang, { lockedOnly = false } = {}) {
+async function loadPreferredTranslationVariants(
+  blocks,
+  preferredLang,
+  { lockedOnly = false, roomId = null, status = null } = {}
+) {
   const groupIds = [...new Set(
     (blocks || [])
       .filter(block => block?.groupId && block.lang !== preferredLang)
@@ -484,12 +488,15 @@ async function loadPreferredTranslationVariants(blocks, preferredLang, { lockedO
 
   if (groupIds.length === 0) return blocks;
 
-  const match = publiclyVisibleBlockMatch({
+  const variantMatch = {
     groupId: { $in: groupIds },
     lang: preferredLang
-  });
-  if (lockedOnly) match.status = 'locked';
+  };
+  if (roomId) variantMatch.roomId = roomId;
+  if (status) variantMatch.status = status;
+  else if (lockedOnly) variantMatch.status = 'locked';
 
+  const match = publiclyVisibleBlockMatch(variantMatch);
   const preferredTranslations = await Block.find(match).lean().exec();
   return replaceWithPreferredTranslationVariants(blocks, preferredTranslations, preferredLang);
 }
@@ -597,7 +604,12 @@ export async function getBlocksByRoomWithFallback({
     }
 
     if (blocks.length > 0) {
-      return { blocks, period: win };
+      const preferredBlocks = await loadPreferredTranslationVariants(
+        blocks,
+        preferredLang,
+        { roomId, status }
+      );
+      return { blocks: preferredBlocks, period: win };
     }
   }
 

--- a/spec/roomLanguageDedupeSpec.js
+++ b/spec/roomLanguageDedupeSpec.js
@@ -1,0 +1,56 @@
+import Block from '../server/db/models/Block.js';
+import { getBlocksByRoomWithFallback } from '../server/db/blockService.js';
+
+describe('room dashboard language deduplication', () => {
+  it('uses an older preferred-language counterpart after recency-window deduplication', async () => {
+    const newerRussian = {
+      _id: 'newer-ru',
+      groupId: 'translated-post',
+      roomId: 'general',
+      status: 'locked',
+      visibility: 'public',
+      lang: 'ru',
+      createdAt: new Date('2026-07-08T00:00:00.000Z')
+    };
+    const olderEnglish = {
+      ...newerRussian,
+      _id: 'older-en',
+      lang: 'en',
+      createdAt: new Date('2026-06-01T00:00:00.000Z')
+    };
+
+    spyOn(Block, 'aggregate').and.returnValue({
+      exec: async () => [newerRussian]
+    });
+    const findSpy = spyOn(Block, 'find').and.returnValue({
+      lean() {
+        return this;
+      },
+      exec: async () => [olderEnglish]
+    });
+
+    const result = await getBlocksByRoomWithFallback({
+      roomId: 'general',
+      status: 'locked',
+      preferredLang: 'en'
+    });
+
+    expect(result.blocks.map(block => block._id)).toEqual(['older-en']);
+    expect(findSpy).toHaveBeenCalledWith({
+      $and: [
+        {
+          groupId: { $in: ['translated-post'] },
+          lang: 'en',
+          roomId: 'general',
+          status: 'locked'
+        },
+        {
+          $or: [
+            { visibility: 'public' },
+            { visibility: 'unlisted', status: 'locked' }
+          ]
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Align room-dashboard translation de-dupe behavior with the home page
- Replace the selected post with its preferred-language counterpart, even when that translation falls outside the active recency window
- Keep replacement queries scoped to the same room, post status, and public visibility
- Add regression coverage for older preferred-language translations

## Testing

- `npm test` — 700 specs passed
- ESLint passed
- `git diff --check` passed