### PR TITLE
Fix Activity Forest trail editing across touch and desktop

### DIFF
--- a/public/js/activity-forest.js
+++ b/public/js/activity-forest.js
@@ -1358,12 +1358,12 @@ if (payload && viewportElement && canvas) {
     }
   }
 
-  function paintTrailJoins() {
-    const byId = new Map(placedObjects.map((object) => [object.id, object]));
+  function paintTrailJoins(objects = placedObjects) {
+    const byId = new Map(objects.map((object) => [object.id, object]));
     context.lineWidth = 5;
     context.lineCap = 'round';
     context.strokeStyle = 'rgba(112, 94, 66, 0.36)';
-    for (const join of forestSteppingStoneJoins(placedObjects)) {
+    for (const join of forestSteppingStoneJoins(objects)) {
       const from = byId.get(join.fromId);
       const to = byId.get(join.toId);
       context.beginPath();
@@ -1462,7 +1462,14 @@ if (payload && viewportElement && canvas) {
       paintStream(elapsedSeconds);
       crossings.forEach(paintBridgeDeck);
     }
-    paintTrailJoins();
+    const trailJoinObjects = trailEditor.tool === 'move' && trailEditor.preview
+      ? placedObjects.map((object) => (
+        object.id === trailEditor.movingId ? trailEditor.preview.stone : object
+      )) : placedObjects;
+    paintTrailJoins(trailJoinObjects);
+    if (trailEditor.active && trailEditor.preview) {
+      paintSteppingStone(trailEditor.preview.stone, true);
+    }
     const visibility = visibilityCache.read(camera, player);
     const { items: actorItems, highBridgeFlights } = forestTransientDepthItems(
       transientLife, camera, reducedMotionQuery.matches, crossings
@@ -1476,7 +1483,9 @@ if (payload && viewportElement && canvas) {
       else if (item.kind === 'transient-flight') paintFlyingBird(item.actor);
       else if (item.kind === 'transient-ground-bird') paintGroundBird(item.actor);
       else if (item.kind === 'marker') paintMarker(item.object);
-      else if (item.kind === FOREST_STEPPING_STONE_TYPE) paintSteppingStone(item.object);
+      else if (item.kind === FOREST_STEPPING_STONE_TYPE) {
+        if (item.object.id !== trailEditor.movingId) paintSteppingStone(item.object);
+      }
       else if (item.kind === FOREST_DISCOVERY_TYPE) paintDiscovery(item.object);
       else if (item.kind === FOREST_BOULDER_TYPE) paintBoulder(item.object);
       else if (isForestClearingObject(item.object)) {
@@ -1485,9 +1494,6 @@ if (payload && viewportElement && canvas) {
         }
       }
       else paintTree(item.placement, elapsedSeconds);
-    }
-    if (trailEditor.active && trailEditor.preview) {
-      paintSteppingStone(trailEditor.preview.stone, true);
     }
     if (clearingEditor.active && clearingEditor.preview) {
       paintClearingObject(clearingEditor.preview.object, true, elapsedSeconds);
@@ -1723,7 +1729,8 @@ if (payload && viewportElement && canvas) {
     if (clearingEditor.active) {
       commitClearingPlacement();
     } else if (trailEditor.active) {
-      commitTrailAt(worldX, worldY);
+      if (trailEditor.tool === 'remove') commitTrailAt(worldX, worldY);
+      else commitTrailPlacementAtPreview();
       viewportElement.focus();
     }
   }
@@ -2167,6 +2174,9 @@ if (payload && viewportElement && canvas) {
     trailToggle.setAttribute('aria-pressed', String(trailEditor.active));
     trailToggle.textContent = trailEditor.active ? 'Editing trail' : 'Edit trail';
     trailModeLabel.textContent = `Trail editing: ${trailEditor.tool}`;
+    document.querySelector('[data-forest-trail-place]').textContent =
+      trailEditor.tool === 'move' && trailEditor.movingId ? 'Move here'
+        : trailEditor.tool === 'place' ? 'Place here' : 'Place new';
     for (const tool of ['place', 'move', 'remove']) {
       document.querySelector(`[data-forest-trail-${tool}]`).setAttribute(
         'aria-pressed', String(trailEditor.tool === tool)
@@ -2184,9 +2194,10 @@ if (payload && viewportElement && canvas) {
       reportTrail('Stand near a stone, then choose Move nearest.', 'no nearby stone');
     } else if (tool === 'remove') {
       reportTrail('Choose a stone to remove. Removal is rejected if it would split the trail.');
+    } else if (tool === 'move') {
+      previewTrailAt(player.worldX, player.worldY, false);
     } else {
-      reportTrail(tool === 'move' ? 'Choose a new clear position for the selected stone.'
-        : 'Choose clear ground; connected stones stay 26–96 px apart.');
+      reportTrail('Choose clear ground; connected stones stay 26–96 px apart.');
     }
     requestRender();
   }
@@ -2221,7 +2232,9 @@ if (payload && viewportElement && canvas) {
       worldX, worldY, id, scene, otherObjects
     );
     const validity = trailEditor.preview;
-    reportTrail(validity.valid ? 'Valid position. Click or press Enter to save.'
+    const action = trailEditor.tool === 'move' ? 'Move here' : 'Place here';
+    reportTrail(validity.valid
+      ? `Valid preview. Tap or click the forest, choose ${action}, or press Enter to save.`
       : (trailReasonText[validity.reason] || validity.reason),
     validity.valid ? 'valid preview' : `invalid: ${validity.reason}`);
     if (shouldRender) requestRender();
@@ -2240,7 +2253,16 @@ if (payload && viewportElement && canvas) {
     }
     setOverlay(result.overlay, `trail ${action} saved locally`);
     trailEditor.preview = null;
-    if (trailEditor.tool === 'move') trailEditor.movingId = null;
+    if (action === 'moved') {
+      trailEditor.movingId = null;
+      setTrailTool('place');
+      previewTrailAt(player.worldX, player.worldY, false);
+      reportTrail(trailEditor.preview
+        ? 'Stone moved. Place mode restored; walk to a valid position for the next stone.'
+        : 'Stone moved. Place mode restored, but this focused trail has reached its limit.',
+      'moved · place mode');
+      return true;
+    }
     reportTrail(`Stone ${action}. The overlay is saved locally.`, action);
     return true;
   }
@@ -2270,6 +2292,13 @@ if (payload && viewportElement && canvas) {
     saveTrailResult(overlayWithForestSteppingStone(
       overlay, trailEditor.preview.stone, scene
     ), trailEditor.tool === 'move' ? 'moved' : 'placed');
+  }
+
+  function commitTrailPlacementAtPreview() {
+    commitTrailAt(
+      trailEditor.preview?.stone.worldX ?? player.worldX,
+      trailEditor.preview?.stone.worldY ?? player.worldY
+    );
   }
 
   function placeMarker() {
@@ -2366,8 +2395,7 @@ if (payload && viewportElement && canvas) {
       toggleTrailEditor(false);
     } else if (trailEditor.active && event.key === 'Enter') {
       event.preventDefault();
-      commitTrailAt(trailEditor.preview?.stone.worldX ?? player.worldX,
-        trailEditor.preview?.stone.worldY ?? player.worldY);
+      commitTrailPlacementAtPreview();
     } else if ((event.key === 'e' || event.key === 'E' || event.key === 'Enter')
       && focusedItem) {
       event.preventDefault();
@@ -2420,13 +2448,15 @@ if (payload && viewportElement && canvas) {
     viewportElement.focus();
   });
   viewportElement.addEventListener('pointermove', (event) => {
-    if (event.pointerType === 'mouse' && clearingEditor.active) {
+    if (event.pointerType === 'mouse' && clearingEditor.active
+      && !event.target.closest('button')) {
       const viewportRect = viewportElement.getBoundingClientRect();
       previewClearingAt(camera.x + event.clientX - viewportRect.left,
         camera.y + event.clientY - viewportRect.top);
       return;
     }
-    if (event.pointerType === 'mouse' && trailEditor.active) {
+    if (event.pointerType === 'mouse' && trailEditor.active
+      && !event.target.closest('button')) {
       const viewportRect = viewportElement.getBoundingClientRect();
       previewTrailAt(camera.x + event.clientX - viewportRect.left,
         camera.y + event.clientY - viewportRect.top);
@@ -2508,7 +2538,14 @@ if (payload && viewportElement && canvas) {
     toggleTrailEditor();
   });
   document.querySelector('[data-forest-trail-place]').addEventListener('click', () => {
-    setTrailTool('place');
+    if (trailEditor.tool === 'move' && trailEditor.movingId) {
+      commitTrailPlacementAtPreview();
+      viewportElement.focus();
+      return;
+    }
+    if (trailEditor.tool !== 'place') setTrailTool('place');
+    previewTrailAt(player.worldX, player.worldY, false);
+    commitTrailPlacementAtPreview();
     viewportElement.focus();
   });
   document.querySelector('[data-forest-trail-move]').addEventListener('click', () => {

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -352,8 +352,12 @@ export function forestDepthOrder(placements, player, objects = []) {
     ...objects.map((object) => ({ kind: object.type || 'marker', id: object.id,
       worldY: object.worldY, object })),
     { kind: 'player', id: '~player', worldY: player.worldY, player }
-  ].sort((left, right) => left.worldY - right.worldY
-    || (left.kind === right.kind ? left.id.localeCompare(right.id)
-      : left.kind === 'player' ? 1 : right.kind === 'player' ? -1
-        : left.kind.localeCompare(right.kind)));
+  ].sort((left, right) => {
+    const layerDifference = Number(left.kind !== FOREST_STEPPING_STONE_TYPE)
+      - Number(right.kind !== FOREST_STEPPING_STONE_TYPE);
+    return layerDifference || left.worldY - right.worldY
+      || (left.kind === right.kind ? left.id.localeCompare(right.id)
+        : left.kind === 'player' ? 1 : right.kind === 'player' ? -1
+          : left.kind.localeCompare(right.kind));
+  });
 }

--- a/spec/forestTouchPlacementSpec.js
+++ b/spec/forestTouchPlacementSpec.js
@@ -24,4 +24,70 @@ describe('Activity Forest touch placement gestures', () => {
     expect(script).toContain("? 'Drop here' : 'Place here'");
     expect(script).toContain('item.object.id !== clearingEditor.movingId');
   });
+
+  it('drops a touch-carried trail stone at its preview instead of at the deposit tap', () => {
+    const touchRelease = script.match(/function finishTouchMovement[^\0]*?function reportPickup/)[0];
+    expect(touchRelease).toContain("if (trailEditor.tool === 'remove') commitTrailAt(worldX, worldY)");
+    expect(touchRelease).toContain('else commitTrailPlacementAtPreview()');
+    expect(touchRelease).not.toContain('else commitTrailAt(worldX, worldY)');
+  });
+
+  it('lets the visible trail Place control commit at the player-carried preview', () => {
+    const placeHandlerStart = script.indexOf(
+      "document.querySelector('[data-forest-trail-place]').addEventListener"
+    );
+    const placeHandlerEnd = script.indexOf(
+      "document.querySelector('[data-forest-trail-move]').addEventListener",
+      placeHandlerStart
+    );
+    expect(placeHandlerStart).toBeGreaterThan(-1);
+    expect(placeHandlerEnd).toBeGreaterThan(placeHandlerStart);
+    const placeHandler = script.slice(placeHandlerStart, placeHandlerEnd);
+    expect(placeHandler).toContain("if (trailEditor.tool !== 'place') setTrailTool('place')");
+    expect(placeHandler).toContain('previewTrailAt(player.worldX, player.worldY, false)');
+    expect(placeHandler).toContain('commitTrailPlacementAtPreview()');
+  });
+
+  it('shows an explicit carried preview while moving a trail stone', () => {
+    expect(script).toContain('item.object.id !== trailEditor.movingId');
+    expect(script).toContain(
+      "object.id === trailEditor.movingId ? trailEditor.preview.stone : object"
+    );
+    expect(script).toContain("} else if (tool === 'move') {");
+    expect(script).toContain('previewTrailAt(player.worldX, player.worldY, false)');
+  });
+
+  it('uses input-neutral move instructions and a working Move here control', () => {
+    expect(script).toContain(
+      'Valid preview. Tap or click the forest, choose ${action}, or press Enter to save.'
+    );
+    expect(script).toContain("? 'Move here'");
+    expect(script).toContain("if (trailEditor.tool === 'move' && trailEditor.movingId)");
+  });
+
+  it('keeps the last visible mouse preview while the pointer crosses a HUD button', () => {
+    expect(script).toContain("event.pointerType === 'mouse' && clearingEditor.active\n"
+      + "      && !event.target.closest('button')");
+    expect(script).toContain("event.pointerType === 'mouse' && trailEditor.active\n"
+      + "      && !event.target.closest('button')");
+  });
+
+  it('treats Move nearest as one-shot and restores a carried placement preview', () => {
+    const saveStart = script.indexOf('function saveTrailResult');
+    const saveEnd = script.indexOf('function commitTrailAt', saveStart);
+    const saveHandler = script.slice(saveStart, saveEnd);
+    expect(saveHandler).toContain("if (action === 'moved')");
+    expect(saveHandler).toContain("setTrailTool('place')");
+    expect(saveHandler).toContain('previewTrailAt(player.worldX, player.worldY, false)');
+    expect(saveHandler).toContain(
+      'Stone moved. Place mode restored; walk to a valid position for the next stone.'
+    );
+  });
+
+  it('paints the carried trail preview on the ground before the avatar depth pass', () => {
+    const previewPaint = script.indexOf('paintSteppingStone(trailEditor.preview.stone, true)');
+    const depthPaint = script.indexOf('for (const item of depthOrder)', previewPaint);
+    expect(previewPaint).toBeGreaterThan(-1);
+    expect(depthPaint).toBeGreaterThan(previewPaint);
+  });
 });

--- a/spec/forestWorldOverlaySpec.js
+++ b/spec/forestWorldOverlaySpec.js
@@ -344,14 +344,14 @@ describe('Activity Forest personal overlay contract', () => {
       .toBe('unsupported-version');
   });
 
-  it('culls stones by their bounded footprint and uses stable ground-Y depth ordering and joins', () => {
+  it('culls stones by their bounded footprint and keeps their ground layer below the player', () => {
     const stones = [
       createForestSteppingStone(50, 60, 'forest-stone-v1-02'),
       createForestSteppingStone(50, 60, 'forest-stone-v1-01'),
       createForestSteppingStone(100, 60, 'forest-stone-v1-03')
     ];
     const visible = visibleForestObjects(stones, { x: 55, y: 55, width: 40, height: 20 }, 0);
-    const order = forestDepthOrder([], { worldX: 0, worldY: 60 }, visible);
+    const order = forestDepthOrder([], { worldX: 0, worldY: 20 }, visible);
 
     expect(visible.map(({ id }) => id)).toEqual([
       'forest-stone-v1-01', 'forest-stone-v1-02', 'forest-stone-v1-03'

--- a/views/dev/activity-forest.pug
+++ b/views/dev/activity-forest.pug
@@ -75,7 +75,7 @@ block content
         strong(data-forest-trail-mode) Trail editing: place
         span(data-forest-trail-status role='status' aria-live='polite') Choose clear ground; connected stones stay 26–96 px apart.
         .activity-forest__trail-actions
-          button(type='button' data-forest-trail-place aria-pressed='true') Place
+          button(type='button' data-forest-trail-place aria-pressed='true') Place here
           button(type='button' data-forest-trail-move aria-pressed='false') Move nearest
           button(type='button' data-forest-trail-remove aria-pressed='false') Remove
           button(type='button' data-forest-trail-done) Done


### PR DESCRIPTION
## Summary

- Place touch-carried trail stones at the avatar preview instead of the tapped coordinate.
- Make the trail editor’s primary control perform the visible **Place here** or **Move here** action.
- Show an explicit moved-stone preview that follows the avatar on touch/keyboard and the forest cursor on desktop.
- Preserve the preview when the cursor crosses HUD controls.
- Use instructions covering touch, pointer, and keyboard input.
- Treat **Move nearest** as a one-shot action that returns to ordinary placement mode.
- Render saved and preview trail stones beneath the avatar and other upright scene elements.

## Motivation

Milestone 10 playtesting exposed several inconsistencies in the trail editor:

- Touch deposits ignored the carried preview.
- The **Place** control appeared actionable but only selected a mode.
- Move instructions described mouse and keyboard input but not touch.
- Moving a stone did not clearly distinguish its saved and prospective positions.
- Move mode remained active after completing its expected one-shot action.
- Ground-Y ordering could paint trail stones over the avatar’s feet.

These changes make trail editing behave consistently across Firefox keyboard/pointer input and iPhone Safari touch input.

## Verification

- 71 focused forest specs passed.
- 185 complete forest specs passed.
- ESLint passed.
- `git diff --check` passed.
- Manually reviewed the touch and desktop trail-editing flows.