### PR TITLE
Fix invisible collision at Activity Forest bridge approaches

### DIFF
--- a/public/js/forest-environment.js
+++ b/public/js/forest-environment.js
@@ -14,7 +14,7 @@ export const FOREST_GROUND_DETAIL_CELL_SIZE = 48;
 export const FOREST_BOULDER_TYPE = 'generated-boulder';
 export { FOREST_BRIDGE_TYPE } from './forest-bridges.js';
 export const FOREST_CROSSING_SCHEMA_VERSION = 3;
-export const FOREST_CROSSING_GENERATION_VERSION = 6;
+export const FOREST_CROSSING_GENERATION_VERSION = 7;
 export const FOREST_ROCK_PALETTES = Object.freeze([
   Object.freeze({
     id: 'mossed-green', weight: 40,
@@ -348,8 +348,8 @@ export function validateForestStreamCrossing(crossing, world) {
     || crossing.schemaVersion !== FOREST_CROSSING_SCHEMA_VERSION
     || crossing.generationVersion !== FOREST_CROSSING_GENERATION_VERSION
     || ![
-      'forest-crossing-v6-stream-footbridge-primary',
-      'forest-crossing-v6-stream-footbridge-secondary'
+      'forest-crossing-v7-stream-footbridge-primary',
+      'forest-crossing-v7-stream-footbridge-secondary'
     ].includes(crossing.id)
     || crossing.type !== FOREST_BRIDGE_TYPE
     || !boundedInteger(crossing.worldX, 0, world.width)
@@ -372,6 +372,16 @@ export function forestBridgeContains(crossing, position, padding = 0) {
   const local = forestBridgeLocalCoordinates(crossing, position);
   return Math.abs(local.lateral) <= crossing.halfWidth + padding
     && Math.abs(local.longitudinal) <= crossing.halfLength + padding;
+}
+
+export function forestBridgeDeckTraversable(crossing, position, radius = 0) {
+  if (!crossing || crossing.type !== FOREST_BRIDGE_TYPE
+    || !Number.isFinite(position?.worldX) || !Number.isFinite(position?.worldY)
+    || !Number.isFinite(radius) || radius < 0) return false;
+  const local = forestBridgeLocalCoordinates(crossing, position);
+  const epsilon = 0.000001;
+  return Math.abs(local.lateral) <= crossing.halfWidth - radius + epsilon
+    && Math.abs(local.longitudinal) <= crossing.halfLength + radius + epsilon;
 }
 
 export function forestBridgeRailCollides(crossing, position, radius = 0) {

--- a/public/js/forest-scene-math.js
+++ b/public/js/forest-scene-math.js
@@ -15,7 +15,7 @@ import {
 } from './forest-discoveries.js';
 import {
   FOREST_BOULDER_TYPE,
-  forestBridgeContains,
+  forestBridgeDeckTraversable,
   forestBridgeRailCollides,
   forestStreamWaterContains
 } from './forest-environment.js';
@@ -261,8 +261,8 @@ export function forestTerrainTraversableAt(scene, position) {
     crossing, position, position.radius || 0
   ))) return false;
   if (!forestStreamWaterContains(scene.environment, position, position.radius || 0)) return true;
-  return crossings.some(crossing => forestBridgeContains(
-    crossing, position, -(position.radius || 0)
+  return crossings.some(crossing => forestBridgeDeckTraversable(
+    crossing, position, position.radius || 0
   ));
 }
 

--- a/server/services/forestTerrainFeatures.js
+++ b/server/services/forestTerrainFeatures.js
@@ -53,19 +53,22 @@ export function generateForestStreamCrossing(scene, corridorCenterAt) {
     const difference = Math.abs(worldY - forestStreamCenterY(scene.environment, worldX));
     if (!best || difference < best.difference) best = { worldX, worldY, difference };
   }
-  const halfLength = scene.environment.stream.halfWidth
+  const angleMilliradians = 1100 + Math.floor(decisionUnit(
+    scene.environment.seed, best.worldX, best.worldY, 'bridge-angle'
+  ) * 100);
+  const angle = angleMilliradians / 1000;
+  const requiredSpan = scene.environment.stream.halfWidth
     + scene.environment.stream.bankWidth + 34;
+  const halfLength = Math.min(160, Math.ceil(requiredSpan / Math.abs(Math.sin(angle))));
   return validateForestStreamCrossing({
     schemaVersion: FOREST_CROSSING_SCHEMA_VERSION,
     generationVersion: FOREST_CROSSING_GENERATION_VERSION,
-    id: 'forest-crossing-v6-stream-footbridge-primary',
+    id: 'forest-crossing-v7-stream-footbridge-primary',
     type: FOREST_BRIDGE_TYPE,
     worldX: best.worldX,
     worldY: best.worldY,
     orientation: 'world-angle',
-    angleMilliradians: 1100 + Math.floor(decisionUnit(
-      scene.environment.seed, best.worldX, best.worldY, 'bridge-angle'
-    ) * 100),
+    angleMilliradians,
     definitionId: FOREST_BRIDGE_DEFINITION_ID,
     halfWidth: 31,
     halfLength,
@@ -90,7 +93,7 @@ export function generateForestStreamCrossings(scene, corridorCenterAt) {
     const candidate = validateForestStreamCrossing({
       schemaVersion: FOREST_CROSSING_SCHEMA_VERSION,
       generationVersion: FOREST_CROSSING_GENERATION_VERSION,
-      id: 'forest-crossing-v6-stream-footbridge-secondary',
+      id: 'forest-crossing-v7-stream-footbridge-secondary',
       type: FOREST_BRIDGE_TYPE,
       worldX,
       worldY: forestStreamCenterY(scene.environment, worldX),

--- a/spec/forestEnvironmentSpec.js
+++ b/spec/forestEnvironmentSpec.js
@@ -22,6 +22,7 @@ import {
   FOREST_ROCK_PALETTES,
   FOREST_WORLD_GENERATION_VERSION,
   forestBridgeContains,
+  forestBridgeDeckTraversable,
   forestBridgeElevationAt,
   forestBridgeLocalCoordinates,
   forestBridgeRailCollides,
@@ -516,6 +517,11 @@ describe('first Activity Forest environment grammar', () => {
     const secondAngle = secondBridge.angleMilliradians / 1000;
     expect(Math.abs(Math.cos(angle))).toBeGreaterThan(0.25);
     expect(Math.abs(Math.sin(angle))).toBeGreaterThan(0.25);
+    const requiredPrimarySpan = scene.environment.stream.halfWidth
+      + scene.environment.stream.bankWidth + 34;
+    expect(bridge.halfLength).toBe(Math.ceil(
+      requiredPrimarySpan / Math.abs(Math.sin(angle))
+    ));
     expect(Math.abs(secondAngle - angle)).toBeGreaterThan(0.75);
     expect(validateForestStreamCrossing(secondBridge, scene.world)).toBe(secondBridge);
     expect(secondBridge.worldY).toBe(forestStreamCenterY(
@@ -578,6 +584,27 @@ describe('first Activity Forest environment grammar', () => {
     expect(forestTerrainTraversableAt(scene, {
       worldX: offBridgeX, worldY: offBridgeStreamY, radius: 10
     })).toBeFalse();
+
+    let waterTransitionCount = 0;
+    for (const crossing of scene.crossings) {
+      for (const endSign of [-1, 1]) {
+        for (let longitudinal = crossing.halfLength - 10;
+          longitudinal <= crossing.halfLength + 10; longitudinal += 2) {
+          for (let lateral = -crossing.halfWidth + 12;
+            lateral <= crossing.halfWidth - 12; lateral += 2) {
+            const position = {
+              ...forestBridgeWorldPosition(crossing, endSign * longitudinal, lateral),
+              radius: 10
+            };
+            if (!forestStreamWaterContains(scene.environment, position, position.radius)) continue;
+            waterTransitionCount += 1;
+            expect(forestBridgeDeckTraversable(crossing, position, position.radius)).toBeTrue();
+            expect(forestTerrainTraversableAt(scene, position)).toBeTrue();
+          }
+        }
+      }
+    }
+    expect(waterTransitionCount).toBeGreaterThan(0);
 
     const walk = (crossing) => {
       const crossingAngle = crossing.angleMilliradians / 1000;


### PR DESCRIPTION
## Summary

- Make the primary bridge span account for its angle across the stream.
- Add a dedicated bridge-deck traversal predicate.
- Allow continuous player-circle movement between dry land and open bridge ends.
- Preserve lateral collision against the visible bridge rails.
- Advance crossing generation to version 7.
- Add regression coverage for water-overlapping approach geometry on both bridges.

## Problem

Players could become stuck near the transition between a bridge and dry land despite no visible obstacle being present.

Two geometry rules caused the issue:

1. The angled primary bridge used a span calculated as though it crossed the stream perpendicularly.
2. Bridge traversal inset the open ends by the player radius, creating gaps between valid land and valid deck positions.

The centerline remained traversable, so the existing straight-crossing test did not expose blocked pockets near the sides of an approach.

## Solution

The primary bridge now derives its span from the crossing angle. A separate traversal predicate applies different clearance rules to the two bridge axes:

- Lateral bounds remain inset to preserve rail and water clearance.
- Longitudinal bounds extend through the open ends by the player radius, allowing a continuous transition to land.

## Persistence note

Because bridge geometry and traversability changed, crossing generation advances from version 6 to version 7. This changes the generated-base identity.

Development overlays and discovery state saved under the previous base remain stored under their old keys rather than being silently applied or migrated.

## Verification

- Confirmed the previously affected bridge approaches manually.
- Regression scan reports zero blocked water-transition samples inside the safe bridge corridor.
- 17 environment specs passed.
- 185 complete forest specs passed.
- ESLint passed.
- `git diff --check` passed.