### PR TITLE
Fix locale-aware translation selection for pinned home posts

### DIFF
--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -531,11 +531,11 @@ export function mergePinnedHomeBlocks(pinnedBlocks, ordinaryBlocks, { limit = 20
   return merged;
 }
 
-async function getPinnedHomeBlocks({ preferredLang = 'en', lockedOnly = false, limit = HOME_PINNED_BLOCK_LIMIT } = {}) {
+export async function getPinnedHomeBlocks({ preferredLang = 'en', lockedOnly = false, limit = HOME_PINNED_BLOCK_LIMIT } = {}) {
   const match = publiclyVisibleBlockMatch({ pinnedAt: { $exists: true, $ne: null } });
   if (lockedOnly) match.status = 'locked';
 
-  return Block.aggregate([
+  const pinnedBlocks = await Block.aggregate([
     { $match: match },
     { $sort: { pinnedAt: -1, createdAt: -1 } },
     { $group: { _id: '$groupId', docs: { $push: '$$ROOT' } } },
@@ -567,6 +567,22 @@ async function getPinnedHomeBlocks({ preferredLang = 'en', lockedOnly = false, l
     { $sort: { pinnedAt: -1, createdAt: -1 } },
     { $limit: Number(limit) }
   ]).exec();
+
+  // Pinning one document pins its translation group, but the aggregation above
+  // can only choose among variants that carry pinnedAt themselves. Resolve the
+  // user's preferred variant across the whole group after selecting the pins.
+  const preferredBlocks = await loadPreferredTranslationVariants(
+    pinnedBlocks,
+    preferredLang,
+    { lockedOnly }
+  );
+
+  // The selected translation may not be the document on which the pin was set.
+  // Carry the anchor's pin metadata over for ordering and the pinned badge.
+  return preferredBlocks.map((block, index) => ({
+    ...block,
+    pinnedAt: pinnedBlocks[index]?.pinnedAt
+  }));
 }
 
 // Fallback para bloques por room (locked o in-progress)

--- a/spec/homePinnedBlocksSpec.js
+++ b/spec/homePinnedBlocksSpec.js
@@ -1,8 +1,10 @@
 import {
+  getPinnedHomeBlocks,
   HOME_PINNED_BLOCK_LIMIT,
   mergePinnedHomeBlocks,
   replaceWithPreferredTranslationVariants
 } from '../server/db/blockService.js';
+import Block from '../server/db/models/Block.js';
 
 describe('home pinned blocks', () => {
   function block(id, overrides = {}) {
@@ -98,5 +100,48 @@ describe('home pinned blocks', () => {
     );
 
     expect(result.map(b => b._id)).toEqual(['older-en', 'untranslated']);
+  });
+
+  it('uses a preferred-language translation when only another variant is pinned', async () => {
+    const pinnedAt = new Date('2026-07-08T00:00:00.000Z');
+    const pinnedRussian = block('pinned-ru', {
+      groupId: 'translated-post',
+      lang: 'ru',
+      pinnedAt
+    });
+    const hindiTranslation = block('older-hi', {
+      groupId: 'translated-post',
+      lang: 'hi',
+      createdAt: new Date('2026-06-01T00:00:00.000Z')
+    });
+
+    spyOn(Block, 'aggregate').and.returnValue({
+      exec: async () => [pinnedRussian]
+    });
+    const findSpy = spyOn(Block, 'find').and.returnValue({
+      lean() {
+        return this;
+      },
+      exec: async () => [hindiTranslation]
+    });
+
+    const result = await getPinnedHomeBlocks({ preferredLang: 'hi' });
+
+    expect(result.map(item => item._id)).toEqual(['older-hi']);
+    expect(result[0].pinnedAt).toEqual(pinnedAt);
+    expect(findSpy).toHaveBeenCalledWith({
+      $and: [
+        {
+          groupId: { $in: ['translated-post'] },
+          lang: 'hi'
+        },
+        {
+          $or: [
+            { visibility: 'public' },
+            { visibility: 'unlisted', status: 'locked' }
+          ]
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes language-specific post deduplication for pinned posts on the home page.

Previously, translation selection only considered variants that had their own `pinnedAt` value. If a Russian variant was pinned but its Hindi translation was not, the Russian post could appear when browsing the site in Hindi.

## Changes

- Treats pinning one translation as pinning the entire post group.
- Resolves pinned groups to the user's preferred site language when a public translation exists.
- Falls back to the pinned variant when no preferred-language translation is available.
- Preserves the original pin timestamp for ordering and the pinned badge.
- Adds regression coverage for selecting an unpinned Hindi translation from a group pinned through its Russian variant.

## Testing

- Full test suite: 708 specs passed.
- Focused home and room language-deduplication tests passed.
- ESLint passed.