### PR TITLE
Fix translated text overflow and sidebar scrolling

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -959,6 +959,11 @@ html[data-theme="dark"] .home-support-widget__fill {
   gap: 1rem;
   position: sticky;
   top: calc(var(--site-header-height, 0px) + 1rem);
+  max-height: calc(100vh - var(--site-header-height, 0px) - 2rem);
+  max-height: calc(100dvh - var(--site-header-height, 0px) - 2rem);
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  scrollbar-width: thin;
 }
 
 .home-discovery__panel {
@@ -1019,14 +1024,27 @@ html[data-theme='dark'] .home-discovery .trending-tags-widget {
 
 .home-quests-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: start;
   justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 0.8rem;
 }
 
+.home-quests-heading > div {
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
 .home-quests-heading h2 {
   margin-bottom: 0;
+  overflow-wrap: anywhere;
+}
+
+.home-quests-heading .home-quests-card__link {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .home-quest-list {
@@ -1197,6 +1215,9 @@ html[data-theme='dark'] .home-quests-heading h2 {
 
   .home-discovery__sidebar {
     position: static;
+    max-height: none;
+    overflow-y: visible;
+    overscroll-behavior-y: auto;
   }
 
   .home-discovery__panel:not(.is-active) {

--- a/public/css/tags.css
+++ b/public/css/tags.css
@@ -323,6 +323,8 @@ html[data-theme="dark"] .chart-container {
     padding-right: 0.45rem;
     padding-left: 0.45rem;
     text-align: center;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 }
 
@@ -438,6 +440,5 @@ html[data-theme="dark"] .tag-activity .chart-container {
     padding-right: 0.25rem;
     padding-left: 0.25rem;
     font-size: 0.78rem;
-    white-space: normal;
   }
 }

--- a/spec/homeDiscoveryLayoutSpec.js
+++ b/spec/homeDiscoveryLayoutSpec.js
@@ -9,8 +9,24 @@ describe('home discovery layout', () => {
 
     expect(sidebarRule).toContain('position: sticky');
     expect(sidebarRule).toContain('top: calc(var(--site-header-height, 0px) + 1rem)');
+    expect(sidebarRule).toContain('max-height: calc(100vh - var(--site-header-height, 0px) - 2rem)');
+    expect(sidebarRule).toContain('max-height: calc(100dvh - var(--site-header-height, 0px) - 2rem)');
+    expect(sidebarRule).toContain('overflow-y: auto');
+    expect(sidebarRule).toContain('overscroll-behavior-y: contain');
     expect(authScript).toContain("style.setProperty('--site-header-height'");
     expect(authScript).toContain('siteHeader.getBoundingClientRect().height');
+  });
+
+  it('allows translated quest headings and actions to wrap based on their content', () => {
+    const headingRule = homeStyles.match(/\.home-quests-heading \{[\s\S]*?\n\}/)?.[0] || '';
+    const headingCopyRule = homeStyles.match(/\.home-quests-heading > div \{[\s\S]*?\n\}/)?.[0] || '';
+    const headingLinkRule = homeStyles.match(/\.home-quests-heading \.home-quests-card__link \{[\s\S]*?\n\}/)?.[0] || '';
+
+    expect(headingRule).toContain('flex-wrap: wrap');
+    expect(headingCopyRule).toContain('min-width: 0');
+    expect(headingCopyRule).toContain('flex: 1 1 12rem');
+    expect(headingLinkRule).toContain('overflow-wrap: anywhere');
+    expect(headingLinkRule).toContain('white-space: normal');
   });
 
   it('uses the page background behind the trending tag pills', () => {

--- a/spec/tagDetailLayoutSpec.js
+++ b/spec/tagDetailLayoutSpec.js
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+
+const tagStyles = fs.readFileSync('public/css/tags.css', 'utf8');
+
+describe('tag detail layout', () => {
+  it('allows translated timeframe labels to wrap throughout the compact layout', () => {
+    const compactStart = tagStyles.indexOf('@media (max-width: 800px)');
+    const compactEnd = tagStyles.indexOf('.tag-range-option:hover', compactStart);
+    const compactStyles = tagStyles.slice(compactStart, compactEnd);
+
+    expect(compactStyles).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
+    expect(compactStyles).toContain('overflow-wrap: anywhere');
+    expect(compactStyles).toContain('white-space: normal');
+  });
+});


### PR DESCRIPTION
## Summary

- Allow community quest headings and actions to wrap based on available space
- Allow tag timeframe labels to wrap across all compact viewport widths
- Add independent scrolling to tall desktop home-page sidebars
- Preserve normal document scrolling on mobile layouts
- Add regression coverage for the updated responsive behavior

These changes are language-agnostic and respond to rendered text length rather than relying on language-specific rules or narrow breakpoint exceptions.

## Testing

- `npm test` — 727 specs passed
- `npm run lint`
- `git diff --check`
- Manually verified the affected layouts with Russian translations