### PR TITLE
Expand room dashboard post history

### DIFF
--- a/app.js
+++ b/app.js
@@ -534,10 +534,10 @@ async function getSupportFundingViewModel() {
             roomEditorialClusters
           ] = await Promise.all([
             getRoomMetadata(room_id, uiLang),
-            getBlocksByRoomWithFallback({
+            getTopBlocksWithFallback({
               roomId: room_id,
-              userId,
               status: 'locked',
+              lockedOnly: true,
               limit: 20,
               preferredLang: preferredContentLang,
             }),
@@ -586,7 +586,10 @@ async function getSupportFundingViewModel() {
 
           const date = DateHelper.currentDateI18n(uiLang || 'en', 'Europe/London');
 
-          const showInProgressTab = (inProgressPeriod !== 'all' && inProgressBlocks.length > 0);
+          const lockedPeriodLabel = lockedPeriod?.type === 'all'
+            ? 'all'
+            : (lockedPeriod?.value ?? lockedPeriod);
+          const showInProgressTab = (inProgressBlocks.length > 0);
           const showLockedTab = (lockedBlocks.length > 0);
           const useTabs = (showLockedTab ? 1 : 0) + (showInProgressTab ? 1 : 0) >= 2;
 
@@ -599,7 +602,7 @@ async function getSupportFundingViewModel() {
 
             lockedBlocks: lightLocked,
             inProgressBlocks: lightInProg,
-            lockedPeriod,
+            lockedPeriod: lockedPeriodLabel,
             inProgressPeriod,
             showInProgressTab,
             showLockedTab,

--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -364,7 +364,9 @@ export async function getTopBlocksWithFallback(options = {}) {
     limit = 20,
     preferredLang = "en",
     includePinnedHome = false,
-    pinnedLimit = HOME_PINNED_BLOCK_LIMIT
+    pinnedLimit = HOME_PINNED_BLOCK_LIMIT,
+    roomId = null,
+    status = null
   } = options;
 
   const now = Date.now();
@@ -412,12 +414,24 @@ export async function getTopBlocksWithFallback(options = {}) {
 
     const cacheKey =
       w.toDays == null
-        ? `top-blocks-band-all-${lockedOnly}-${preferredLang}-${BAND_FETCH}`
-        : `top-blocks-band-${w.fromDays}-${w.toDays}-${lockedOnly}-${preferredLang}-${BAND_FETCH}`;
+        ? `top-blocks-band-all-${lockedOnly}-${preferredLang}-${roomId || 'global'}-${status || 'any'}-${BAND_FETCH}`
+        : `top-blocks-band-${w.fromDays}-${w.toDays}-${lockedOnly}-${preferredLang}-${roomId || 'global'}-${status || 'any'}-${BAND_FETCH}`;
 
     const bandBlocks = await cache.get(
       cacheKey,
       async () => {
+        if (roomId) {
+          return await findByRoomWithLangPref({
+            roomId,
+            preferredLang,
+            status,
+            sortBy: 'voteCount',
+            limit: BAND_FETCH,
+            startDate,
+            endDate,
+          });
+        }
+
         return await findTopGlobalWithLangPref({
           preferredLang,
           lockedOnly,
@@ -453,7 +467,7 @@ export async function getTopBlocksWithFallback(options = {}) {
   const preferredBlocks = await loadPreferredTranslationVariants(
     collected,
     preferredLang,
-    { lockedOnly }
+    { lockedOnly, roomId, status }
   );
 
   return {

--- a/spec/roomLanguageDedupeSpec.js
+++ b/spec/roomLanguageDedupeSpec.js
@@ -1,5 +1,8 @@
 import Block from '../server/db/models/Block.js';
-import { getBlocksByRoomWithFallback } from '../server/db/blockService.js';
+import {
+  getBlocksByRoomWithFallback,
+  getTopBlocksWithFallback
+} from '../server/db/blockService.js';
 
 describe('room dashboard language deduplication', () => {
   it('uses an older preferred-language counterpart after recency-window deduplication', async () => {
@@ -52,5 +55,52 @@ describe('room dashboard language deduplication', () => {
         }
       ]
     });
+  });
+
+  it('fills the locked-post target from progressively older room activity', async () => {
+    const recent = {
+      _id: 'recent-room-post',
+      groupId: 'recent-room-group',
+      roomId: 'cumulative-room',
+      status: 'locked',
+      visibility: 'public',
+      lang: 'en',
+      voteCount: 3
+    };
+    const older = {
+      ...recent,
+      _id: 'older-room-post',
+      groupId: 'older-room-group',
+      voteCount: 8
+    };
+    let band = 0;
+
+    const aggregateSpy = spyOn(Block, 'aggregate').and.callFake(() => ({
+      exec: async () => {
+        band += 1;
+        if (band === 1) return [recent];
+        if (band === 2) return [older];
+        return [];
+      }
+    }));
+
+    const result = await getTopBlocksWithFallback({
+      roomId: 'cumulative-room',
+      status: 'locked',
+      lockedOnly: true,
+      limit: 2,
+      preferredLang: 'en'
+    });
+
+    expect(result.blocks.map(block => block._id)).toEqual([
+      'recent-room-post',
+      'older-room-post'
+    ]);
+    expect(result.period).toEqual({ type: 'days', value: 7 });
+    expect(aggregateSpy.calls.count()).toBe(2);
+
+    const firstMatch = aggregateSpy.calls.argsFor(0)[0][0].$match;
+    expect(firstMatch.$and[0].roomId).toBe('cumulative-room');
+    expect(firstMatch.status).toBe('locked');
   });
 });


### PR DESCRIPTION
## Summary

- Fill room dashboards with up to 20 locked posts across progressively older time bands
- Scope the homepage-style selection logic to the current room
- Preserve translation-group deduplication
- Continue showing in-progress posts in a separate section whenever any are available

## Motivation

Room dashboards previously stopped at the first non-empty timeframe. When that timeframe contained only one or two posts, the page appeared sparse even if the room had substantial older content.

This change progressively expands the search window until the dashboard is populated or all available history has been considered. This should provide visitors and search engines with a more representative view of each room.

## Validation

- Added coverage for accumulating room posts across multiple time bands
- All 728 specs pass
- ESLint passes for the changed files