### PR TITLE
Fix missing whitespace in localized login greetings

### DIFF
--- a/i18n/ar/nav.json
+++ b/i18n/ar/nav.json
@@ -11,7 +11,7 @@
     "support": "يدعم",
     "otherProjects": "مشاريع أخرى",
     "auth": {
-      "welcomePrefix": "مرحباً،",
+      "welcomePrefix": "مرحباً، ",
       "welcomeFallbackUser": "أنت",
       "welcomeSuffix": "!"
     },

--- a/i18n/da/nav.json
+++ b/i18n/da/nav.json
@@ -11,7 +11,7 @@
     "support": "Støtte",
     "otherProjects": "Andre projekter",
     "auth": {
-      "welcomePrefix": "Velkomst,",
+      "welcomePrefix": "Velkomst, ",
       "welcomeFallbackUser": "du",
       "welcomeSuffix": "!"
     },

--- a/i18n/hi/nav.json
+++ b/i18n/hi/nav.json
@@ -11,7 +11,7 @@
     "support": "सहायता",
     "otherProjects": "अन्य परियोजनाएँ",
     "auth": {
-      "welcomePrefix": "स्वागत,",
+      "welcomePrefix": "स्वागत, ",
       "welcomeFallbackUser": "आप",
       "welcomeSuffix": "!"
     },

--- a/i18n/nl/nav.json
+++ b/i18n/nl/nav.json
@@ -11,7 +11,7 @@
     "support": "Steun",
     "otherProjects": "Andere projecten",
     "auth": {
-      "welcomePrefix": "Welkom,",
+      "welcomePrefix": "Welkom, ",
       "welcomeFallbackUser": "Jij",
       "welcomeSuffix": "!"
     },

--- a/i18n/no/nav.json
+++ b/i18n/no/nav.json
@@ -11,7 +11,7 @@
     "support": "Støtte",
     "otherProjects": "Andre prosjekter",
     "auth": {
-      "welcomePrefix": "Velkomst,",
+      "welcomePrefix": "Velkomst, ",
       "welcomeFallbackUser": "du",
       "welcomeSuffix": "!"
     },

--- a/i18n/sv/nav.json
+++ b/i18n/sv/nav.json
@@ -11,7 +11,7 @@
     "support": "Support",
     "otherProjects": "Andra projekt",
     "auth": {
-      "welcomePrefix": "Välkommen,",
+      "welcomePrefix": "Välkommen, ",
       "welcomeFallbackUser": "dig",
       "welcomeSuffix": "!"
     },

--- a/i18n/vi/nav.json
+++ b/i18n/vi/nav.json
@@ -11,7 +11,7 @@
     "support": "Ủng hộ",
     "otherProjects": "Dự án khác",
     "auth": {
-      "welcomePrefix": "Chào mừng,",
+      "welcomePrefix": "Chào mừng, ",
       "welcomeFallbackUser": "Bạn",
       "welcomeSuffix": "!"
     },

--- a/spec/loginGreetingI18nSpec.js
+++ b/spec/loginGreetingI18nSpec.js
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+
+const localeRoot = 'i18n';
+const noSpaceAfterComma = new Set(['ja', 'zh']);
+
+describe('localized login greetings', () => {
+  it('separates comma-terminated prefixes from the username where required', () => {
+    const locales = fs.readdirSync(localeRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
+    for (const locale of locales) {
+      const nav = JSON.parse(fs.readFileSync(`${localeRoot}/${locale}/nav.json`, 'utf8'));
+      const prefix = nav.nav.auth.welcomePrefix;
+      const endsWithComma = /[,،、，]\s*$/.test(prefix);
+
+      if (endsWithComma && !noSpaceAfterComma.has(locale)) {
+        expect(prefix)
+          .withContext(`${locale} welcomePrefix must include spacing before the username`)
+          .toMatch(/\s$/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add missing spacing between login greeting prefixes and usernames
- fix affected Arabic, Danish, Hindi, Dutch, Norwegian, Swedish, and Vietnamese translations
- preserve intentional direct joining in Japanese, Chinese, and Thai
- add a regression test covering localized comma-terminated greetings

## Why

The floating header concatenates the localized greeting prefix and username without inserting additional whitespace. Several translation prefixes ended immediately after their comma, producing greetings such as:

```text
Chào mừng,Username!