### PR TITLE
Fix post header spacing for long translated action labels

### DIFF
--- a/public/css/block-view.css
+++ b/public/css/block-view.css
@@ -757,9 +757,13 @@ hr {
 
 .interact-section {
   display: flex;
+  flex: 1 1 34rem;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.5rem;
+  max-width: 50rem;
+  min-width: 0;
   margin-left: auto;
   align-self: flex-start;
 }
@@ -771,7 +775,8 @@ hr {
   }
 
   .title-main {
-    flex-basis: 0;
+    flex-basis: 36rem;
+    min-width: min(100%, 34rem);
   }
 
   .block-meta-card {
@@ -785,8 +790,11 @@ hr {
 
 .interact-section a.block-edit-btn,
 .interact-section button.delete-btn,
-.interact-section button.share-btn {
-  white-space: nowrap;
+.interact-section button.share-btn,
+.interact-section #flag-block-btn {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .block-edit-btn,
@@ -884,20 +892,20 @@ hr {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
+  justify-content: flex-end;
   gap: 0.5rem;
   margin-top: 0.5rem;
   align-content: flex-start;
+  width: 100%;
 }
 
 .action-buttons.left-align {
   justify-content: flex-start;
 }
 
-.action-buttons>* {
-  flex-shrink: 0;
-  /* Don't allow buttons to shrink */
-  min-width: max-content;
-  /* Makes them only as small as their content */
+.action-buttons > * {
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 #flag-block-btn {

--- a/spec/blockViewLayoutSpec.js
+++ b/spec/blockViewLayoutSpec.js
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+
+const blockStyles = fs.readFileSync('public/css/block-view.css', 'utf8');
+
+const ruleFor = (selector) => (
+  blockStyles.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\{[\\s\\S]*?\\n\\}`))?.[0] || ''
+);
+
+describe('post view header layout', () => {
+  it('reserves balanced space for metadata while allowing translated actions to wrap', () => {
+    const controlsRule = ruleFor('.interact-section');
+    const actionsRule = ruleFor('.action-buttons');
+    const actionItemsRule = ruleFor('.action-buttons > *');
+
+    expect(controlsRule).toContain('flex: 1 1 34rem');
+    expect(controlsRule).toContain('max-width: 50rem');
+    expect(controlsRule).toContain('min-width: 0');
+    expect(actionsRule).toContain('flex-wrap: wrap');
+    expect(actionsRule).toContain('width: 100%');
+    expect(actionItemsRule).toContain('flex: 0 1 auto');
+    expect(actionItemsRule).toContain('min-width: 0');
+    expect(blockStyles).not.toContain('min-width: max-content');
+  });
+
+  it('gives the title and metadata column a usable desktop floor', () => {
+    const desktopStart = blockStyles.indexOf('@media (min-width: 1100px)');
+    const desktopEnd = blockStyles.indexOf('.interact-section.left-align', desktopStart);
+    const desktopStyles = blockStyles.slice(desktopStart, desktopEnd);
+
+    expect(desktopStyles).toContain('flex-basis: 36rem');
+    expect(desktopStyles).toContain('min-width: min(100%, 34rem)');
+    expect(desktopStyles).not.toContain('flex-basis: 0');
+  });
+
+  it('permits individual translated labels to break as a final overflow safeguard', () => {
+    const translatedActionsStart = blockStyles.indexOf('.interact-section a.block-edit-btn');
+    const translatedActionsEnd = blockStyles.indexOf('\n\n.block-edit-btn,', translatedActionsStart);
+    const translatedActionsRule = blockStyles.slice(translatedActionsStart, translatedActionsEnd);
+
+    expect(translatedActionsRule).toContain('.interact-section #flag-block-btn');
+    expect(translatedActionsRule).toContain('overflow-wrap: anywhere');
+    expect(translatedActionsRule).toContain('white-space: normal');
+  });
+});


### PR DESCRIPTION
## Summary

Improve the post-view header layout for languages with longer translated action labels.

The action controls previously preserved their intrinsic widths while the title and metadata column could shrink excessively. This could make the metadata card too narrow and cause its content to overflow.

This change:

- gives the title and metadata column a usable minimum width on desktop;
- gives the action region a flexible, bounded width;
- allows action buttons to wrap within their available space;
- allows individual translated labels to wrap as a final overflow safeguard; and
- preserves the existing stacked mobile layout and action alignment behavior.

## Testing

- Added regression coverage for the post header flex and wrapping rules.
- Ran the full test suite: 761 specs passing.
- Confirmed the layout with the French interface and longer translated action labels.