### PR TITLE
Improve post page titles and social metadata

### DIFF
--- a/i18n/ar/blockView.json
+++ b/i18n/ar/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "منشور - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "منشور"
     },
     "labels": {

--- a/i18n/cs/blockView.json
+++ b/i18n/cs/blockView.json
@@ -1,6 +1,6 @@
 {
   "blockView": {
-    "meta": { "title": "Příspěvek – {blockTitle}", "titleFallback": "Příspěvek" },
+    "meta": { "title": "{blockTitle} | Daily Page", "titleFallback": "Příspěvek" },
     "labels": {
       "room": "Místnost", "author": "Autor", "created": "Vytvořeno", "unknownAuthor": "Anonym",
       "authorAvatarAlt": "Avatar uživatele {username}", "viewAuthorProfile": "Zobrazit profil uživatele {username}",

--- a/i18n/da/blockView.json
+++ b/i18n/da/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Indlæg - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Stolpe"
     },
     "labels": {

--- a/i18n/de/blockView.json
+++ b/i18n/de/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Beitrag - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Beitrag"
     },
     "labels": {

--- a/i18n/el/blockView.json
+++ b/i18n/el/blockView.json
@@ -1,6 +1,6 @@
 {
   "blockView": {
-    "meta": { "title": "Ανάρτηση - {blockTitle}", "titleFallback": "Ανάρτηση" },
+    "meta": { "title": "{blockTitle} | Daily Page", "titleFallback": "Ανάρτηση" },
     "labels": {
       "room": "Δωμάτιο",
       "author": "Συντάκτης",

--- a/i18n/en/blockView.json
+++ b/i18n/en/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Post - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Post"
     },
     "labels": {

--- a/i18n/es/blockView.json
+++ b/i18n/es/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Post - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Post"
     },
     "labels": {

--- a/i18n/fi/blockView.json
+++ b/i18n/fi/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Julkaisu - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Julkaisu"
     },
     "labels": {

--- a/i18n/fr/blockView.json
+++ b/i18n/fr/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Publication - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Publication"
     },
     "labels": {

--- a/i18n/he/blockView.json
+++ b/i18n/he/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "פוסט - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "פוסט"
     },
     "labels": {

--- a/i18n/hi/blockView.json
+++ b/i18n/hi/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "पोस्ट - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "अवरोध पैदा करना"
     },
     "labels": {

--- a/i18n/id/blockView.json
+++ b/i18n/id/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Postingan - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Postingan"
     },
     "labels": {

--- a/i18n/it/blockView.json
+++ b/i18n/it/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Post - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Post"
     },
     "labels": {

--- a/i18n/ja/blockView.json
+++ b/i18n/ja/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "投稿 - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "投稿"
     },
     "labels": {

--- a/i18n/ko/blockView.json
+++ b/i18n/ko/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "게시물 - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "게시물"
     },
     "labels": {

--- a/i18n/nl/blockView.json
+++ b/i18n/nl/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Bericht - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Bericht"
     },
     "labels": {

--- a/i18n/no/blockView.json
+++ b/i18n/no/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Innlegg - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Innlegg"
     },
     "labels": {

--- a/i18n/pl/blockView.json
+++ b/i18n/pl/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Post - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Post"
     },
     "labels": {

--- a/i18n/pt/blockView.json
+++ b/i18n/pt/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Post - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Post"
     },
     "labels": {

--- a/i18n/ru/blockView.json
+++ b/i18n/ru/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Блок — {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Блок"
     },
     "labels": {

--- a/i18n/sv/blockView.json
+++ b/i18n/sv/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Inlägg - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Inlägg"
     },
     "labels": {

--- a/i18n/th/blockView.json
+++ b/i18n/th/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "โพสต์ - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "โพสต์"
     },
     "labels": {

--- a/i18n/tr/blockView.json
+++ b/i18n/tr/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Gönderi - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Gönderi"
     },
     "labels": {

--- a/i18n/vi/blockView.json
+++ b/i18n/vi/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "Bài viết - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "Bài viết"
     },
     "labels": {

--- a/i18n/zh/blockView.json
+++ b/i18n/zh/blockView.json
@@ -1,7 +1,7 @@
 {
   "blockView": {
     "meta": {
-      "title": "帖子 - {blockTitle}",
+      "title": "{blockTitle} | Daily Page",
       "titleFallback": "帖子"
     },
     "labels": {

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -29,6 +29,7 @@ import {
   parseEditTokens
 } from '../utils/block.js';
 import { canonicalBlockPath } from '../utils/canonical.js';
+import { buildPostSeo } from '../utils/postSeo.js';
 
 const router = express.Router();
 const INITIAL_COMMENT_LIMIT = 20;
@@ -216,13 +217,11 @@ router.get(
         }
         : null;
 
-      // Page title i18n w/ safe fallback
-      const key = 'blockView.meta.title';
-      const raw = t(key, { blockTitle: block.title });
-      const title =
-        raw && raw !== key
-          ? raw
-          : `${t('blockView.meta.titleFallback')} - ${block.title}`;
+      const seo = buildPostSeo(block, {
+        siteName: t('layout.siteName'),
+        baseUrl: res.locals.baseUrl,
+        canonicalUrl: res.locals.canonicalUrl
+      });
 
       const focusedThreadAlreadyIncluded = Boolean(
         focusedCommentData?.topLevelCommentId &&
@@ -237,7 +236,7 @@ router.get(
         recommendations: recommendationItems,
         editorialContext,
         descriptionHTML,
-        title,
+        ...seo,
         header: block.title,
         translations,
         canManageBlock: canManageBlock(req.user, block, editTokens),

--- a/server/utils/markdownHelper.js
+++ b/server/utils/markdownHelper.js
@@ -245,3 +245,35 @@ export function renderMarkdownPreview(content, opts) {
 export function renderMarkdownContent(content, opts) {
   return renderMarkdownFull(content, opts);
 }
+
+/**
+ * Extracts readable text from Markdown without passing rendered HTML into
+ * metadata attributes. This intentionally ignores image URLs while retaining
+ * their alt text.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function markdownToPlainText(content) {
+  const cleaned = content ? String(content).replace(/\u200B/g, '').trim() : '';
+  if (!cleaned) return '';
+
+  const tokens = md.parse(cleaned, { allowStreetViewEmbeds: false });
+  const parts = [];
+
+  for (const token of tokens) {
+    if (token.type === 'inline' && Array.isArray(token.children)) {
+      for (const child of token.children) {
+        if (['text', 'code_inline', 'image'].includes(child.type) && child.content) {
+          parts.push(child.content);
+        } else if (['softbreak', 'hardbreak'].includes(child.type)) {
+          parts.push(' ');
+        }
+      }
+    } else if (['fence', 'code_block'].includes(token.type) && token.content) {
+      parts.push(token.content);
+    }
+  }
+
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}

--- a/server/utils/postSeo.js
+++ b/server/utils/postSeo.js
@@ -1,0 +1,44 @@
+import { markdownToPlainText } from './markdownHelper.js';
+
+export const POST_META_DESCRIPTION_MAX_LENGTH = 160;
+
+function truncateDescription(value, maxLength = POST_META_DESCRIPTION_MAX_LENGTH) {
+  const normalized = String(value || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+
+  const candidate = normalized.slice(0, maxLength - 1);
+  const lastSpace = candidate.lastIndexOf(' ');
+  const cutAt = lastSpace >= Math.floor(maxLength * 0.6) ? lastSpace : candidate.length;
+  return `${candidate.slice(0, cutAt).trimEnd()}…`;
+}
+
+export function buildPostSeo(block, { siteName, baseUrl, canonicalUrl }) {
+  const normalizedSiteName = String(siteName || 'Daily Page').trim() || 'Daily Page';
+  const postTitle = String(block?.title || normalizedSiteName).trim() || normalizedSiteName;
+  const title = `${postTitle} | ${normalizedSiteName}`;
+  const descriptionSource = block?.description || block?.content || postTitle;
+  const description = truncateDescription(markdownToPlainText(descriptionSource) || postTitle);
+  const hasShareableBanner = block?.bannerImage?.url &&
+    (!block.bannerImage.kind || block.bannerImage.kind === 'image');
+  const normalizedBaseUrl = String(baseUrl || '').replace(/\/$/, '');
+  const image = hasShareableBanner
+    ? block.bannerImage.url
+    : `${normalizedBaseUrl}/assets/img/logo-512.png`;
+
+  return {
+    title,
+    description,
+    canonicalUrl,
+    socialTitle: title,
+    socialDescription: description,
+    socialImageUrl: image,
+    socialImageAlt: hasShareableBanner
+      ? (block.bannerImage.caption || postTitle)
+      : normalizedSiteName,
+    socialCardType: hasShareableBanner ? 'summary_large_image' : 'summary',
+    openGraphType: 'article',
+    socialPublishedTime: block?.createdAt
+      ? new Date(block.createdAt).toISOString()
+      : null
+  };
+}

--- a/spec/postSeoSpec.js
+++ b/spec/postSeoSpec.js
@@ -1,0 +1,87 @@
+import { buildPostSeo, POST_META_DESCRIPTION_MAX_LENGTH } from '../server/utils/postSeo.js';
+import pug from 'pug';
+
+describe('post SEO metadata', () => {
+  const options = {
+    siteName: 'Daily Page',
+    baseUrl: 'https://dailypage.org/',
+    canonicalUrl: 'https://dailypage.org/rooms/science/blocks/temperature'
+  };
+
+  it('builds branded page and social titles with a Markdown-free description', () => {
+    const metadata = buildPostSeo({
+      title: 'How to Read a Temperature–Entropy Diagram',
+      description: '**Learn** how [temperature](https://example.com) relates to entropy.'
+    }, options);
+
+    expect(metadata.title)
+      .toBe('How to Read a Temperature–Entropy Diagram | Daily Page');
+    expect(metadata.socialTitle).toBe(metadata.title);
+    expect(metadata.description).toBe('Learn how temperature relates to entropy.');
+    expect(metadata.socialDescription).toBe(metadata.description);
+    expect(metadata.canonicalUrl).toBe(options.canonicalUrl);
+    expect(metadata.openGraphType).toBe('article');
+  });
+
+  it('uses an image banner for large social cards', () => {
+    const metadata = buildPostSeo({
+      title: 'A visual post',
+      description: 'A useful summary.',
+      bannerImage: {
+        kind: 'image',
+        url: 'https://images.example.com/banner.jpg',
+        caption: 'Temperature and entropy chart'
+      }
+    }, options);
+
+    expect(metadata.socialImageUrl).toBe('https://images.example.com/banner.jpg');
+    expect(metadata.socialImageAlt).toBe('Temperature and entropy chart');
+    expect(metadata.socialCardType).toBe('summary_large_image');
+  });
+
+  it('falls back to content and the site image for posts without an image banner', () => {
+    const metadata = buildPostSeo({
+      title: 'A post without a banner',
+      content: `${'A useful sentence '.repeat(20)}ending.`,
+      bannerImage: {
+        kind: 'streetview',
+        url: 'https://www.google.com/maps/embed?pb=example'
+      }
+    }, options);
+
+    expect(metadata.description.length).toBeLessThanOrEqual(POST_META_DESCRIPTION_MAX_LENGTH);
+    expect(metadata.description.endsWith('…')).toBeTrue();
+    expect(metadata.socialImageUrl).toBe('https://dailypage.org/assets/img/logo-512.png');
+    expect(metadata.socialImageAlt).toBe('Daily Page');
+    expect(metadata.socialCardType).toBe('summary');
+  });
+
+  it('includes a valid publication timestamp when one exists', () => {
+    const metadata = buildPostSeo({
+      title: 'Dated post',
+      createdAt: new Date('2026-08-02T12:30:00Z')
+    }, options);
+
+    expect(metadata.socialPublishedTime).toBe('2026-08-02T12:30:00.000Z');
+  });
+
+  it('renders Open Graph and Twitter card tags', () => {
+    const metadata = buildPostSeo({
+      title: 'Temperature & entropy',
+      description: 'A concise guide.',
+      bannerImage: { url: 'https://images.example.com/diagram.jpg' }
+    }, options);
+    const html = pug.renderFile('views/partials/_social_meta.pug', metadata);
+
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('content="Temperature &amp; entropy | Daily Page"');
+    expect(html).toContain('property="og:description"');
+    expect(html).toContain('property="og:image"');
+    expect(html).toContain('property="og:url"');
+    expect(html).toContain('property="og:type" content="article"');
+    expect(html).toContain('name="twitter:card" content="summary_large_image"');
+    expect(html).toContain('name="twitter:title"');
+    expect(html).toContain('name="twitter:description"');
+    expect(html).toContain('name="twitter:image"');
+  });
+});

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -12,6 +12,7 @@ html(lang=htmlLang dir=(uiDir || 'ltr'))
         meta(name="description" content=description)
       if canonicalUrl
         link(rel="canonical" href=canonicalUrl)
+      include partials/_social_meta
       if hreflang
         each alt in hreflang
           link(rel="alternate" hreflang=alt.lang href=alt.href)

--- a/views/partials/_social_meta.pug
+++ b/views/partials/_social_meta.pug
@@ -1,0 +1,24 @@
+if socialTitle
+  meta(property='og:title' content=socialTitle)
+if socialDescription
+  meta(property='og:description' content=socialDescription)
+if socialImageUrl
+  meta(property='og:image' content=socialImageUrl)
+if socialImageAlt
+  meta(property='og:image:alt' content=socialImageAlt)
+if canonicalUrl && socialTitle
+  meta(property='og:url' content=canonicalUrl)
+if openGraphType
+  meta(property='og:type' content=openGraphType)
+if socialPublishedTime
+  meta(property='article:published_time' content=socialPublishedTime)
+if socialCardType
+  meta(name='twitter:card' content=socialCardType)
+if socialTitle
+  meta(name='twitter:title' content=socialTitle)
+if socialDescription
+  meta(name='twitter:description' content=socialDescription)
+if socialImageUrl
+  meta(name='twitter:image' content=socialImageUrl)
+if socialImageAlt
+  meta(name='twitter:image:alt' content=socialImageAlt)


### PR DESCRIPTION
## Summary

- change post page titles to use the format `Post Title | Daily Page`
- add post-specific meta descriptions derived from the description or content
- add Open Graph metadata for richer link previews
- add Twitter card metadata
- use post banner images when available, with the Daily Page logo as a fallback
- include image alt text and article publication timestamps
- update the title format across all supported locales

## Validation

- `npm run lint`
- `npm test` — 766 specs passed
- confirmed the post-view Pug template compiles successfully