### PR TITLE
Add Article JSON-LD to public post pages

### DIFF
--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -2,7 +2,8 @@ import express from 'express';
 import {
   getBlockById,
   getPublicTranslations,
-  getPublicTranslationByGroupAndLang
+  getPublicTranslationByGroupAndLang,
+  isPubliclyVisibleBlock
 } from '../db/blockService.js';
 import { getBlockEditorialContext } from '../db/blockEditorialContextService.js';
 import {
@@ -218,9 +219,19 @@ router.get(
         : null;
 
       const seo = buildPostSeo(block, {
+        author: authorProfile
+          ? {
+              name: authorProfile.displayName,
+              url: authorProfile.profilePath
+                ? `${res.locals.baseUrl}${res.locals.uiPath(authorProfile.profilePath)}`
+                : undefined
+            }
+          : null,
         siteName: t('layout.siteName'),
         baseUrl: res.locals.baseUrl,
-        canonicalUrl: res.locals.canonicalUrl
+        canonicalUrl: res.locals.canonicalUrl,
+        includeArticleJsonLd: isPubliclyVisibleBlock(block),
+        roomName
       });
 
       const focusedThreadAlreadyIncluded = Boolean(

--- a/server/utils/postSeo.js
+++ b/server/utils/postSeo.js
@@ -12,7 +12,77 @@ function truncateDescription(value, maxLength = POST_META_DESCRIPTION_MAX_LENGTH
   return `${candidate.slice(0, cutAt).trimEnd()}…`;
 }
 
-export function buildPostSeo(block, { siteName, baseUrl, canonicalUrl }) {
+function isoDate(value) {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function jsonLdStringify(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+export function buildPostArticleJsonLd(block, {
+  author,
+  baseUrl,
+  canonicalUrl,
+  description,
+  roomName
+}) {
+  const normalizedBaseUrl = String(baseUrl || '').replace(/\/$/, '');
+  const hasArticleImage = block?.bannerImage?.url &&
+    (!block.bannerImage.kind || block.bannerImage.kind === 'image');
+  const datePublished = isoDate(block?.createdAt);
+  const dateModified = isoDate(block?.updatedAt);
+  const tags = Array.isArray(block?.tags)
+    ? block.tags.map((tag) => String(tag).trim()).filter(Boolean)
+    : [];
+
+  const article = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    '@id': `${canonicalUrl}#article`,
+    url: canonicalUrl,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl
+    },
+    headline: String(block?.title || '').trim(),
+    description,
+    inLanguage: block?.lang || undefined,
+    datePublished,
+    dateModified,
+    author: author?.name
+      ? {
+          '@type': 'Person',
+          name: author.name,
+          url: author.url || undefined
+        }
+      : undefined,
+    publisher: {
+      '@id': `${normalizedBaseUrl}/#organization`
+    },
+    image: hasArticleImage ? block.bannerImage.url : undefined,
+    articleSection: roomName || undefined,
+    keywords: tags.length ? tags : undefined
+  };
+
+  return jsonLdStringify(article);
+}
+
+export function buildPostSeo(block, {
+  author,
+  siteName,
+  baseUrl,
+  canonicalUrl,
+  includeArticleJsonLd = true,
+  roomName
+}) {
   const normalizedSiteName = String(siteName || 'Daily Page').trim() || 'Daily Page';
   const postTitle = String(block?.title || normalizedSiteName).trim() || normalizedSiteName;
   const title = `${postTitle} | ${normalizedSiteName}`;
@@ -24,6 +94,15 @@ export function buildPostSeo(block, { siteName, baseUrl, canonicalUrl }) {
   const image = hasShareableBanner
     ? block.bannerImage.url
     : `${normalizedBaseUrl}/assets/img/logo-512.png`;
+  const articleJsonLd = includeArticleJsonLd
+    ? buildPostArticleJsonLd(block, {
+        author,
+        baseUrl: normalizedBaseUrl,
+        canonicalUrl,
+        description,
+        roomName
+      })
+    : null;
 
   return {
     title,
@@ -37,8 +116,7 @@ export function buildPostSeo(block, { siteName, baseUrl, canonicalUrl }) {
       : normalizedSiteName,
     socialCardType: hasShareableBanner ? 'summary_large_image' : 'summary',
     openGraphType: 'article',
-    socialPublishedTime: block?.createdAt
-      ? new Date(block.createdAt).toISOString()
-      : null
+    socialPublishedTime: isoDate(block?.createdAt) || null,
+    articleJsonLd
   };
 }

--- a/spec/postSeoSpec.js
+++ b/spec/postSeoSpec.js
@@ -1,4 +1,8 @@
-import { buildPostSeo, POST_META_DESCRIPTION_MAX_LENGTH } from '../server/utils/postSeo.js';
+import {
+  buildPostArticleJsonLd,
+  buildPostSeo,
+  POST_META_DESCRIPTION_MAX_LENGTH
+} from '../server/utils/postSeo.js';
 import pug from 'pug';
 
 describe('post SEO metadata', () => {
@@ -65,6 +69,18 @@ describe('post SEO metadata', () => {
     expect(metadata.socialPublishedTime).toBe('2026-08-02T12:30:00.000Z');
   });
 
+  it('can omit Article markup for a post that is not publicly visible', () => {
+    const metadata = buildPostSeo({
+      title: 'Unlisted draft',
+      content: 'Work in progress.'
+    }, {
+      ...options,
+      includeArticleJsonLd: false
+    });
+
+    expect(metadata.articleJsonLd).toBeNull();
+  });
+
   it('renders Open Graph and Twitter card tags', () => {
     const metadata = buildPostSeo({
       title: 'Temperature & entropy',
@@ -83,5 +99,84 @@ describe('post SEO metadata', () => {
     expect(html).toContain('name="twitter:title"');
     expect(html).toContain('name="twitter:description"');
     expect(html).toContain('name="twitter:image"');
+  });
+
+  it('builds Article JSON-LD from visible post metadata', () => {
+    const article = JSON.parse(buildPostArticleJsonLd({
+      title: 'Reading a temperature diagram',
+      lang: 'en',
+      createdAt: '2026-08-01T12:00:00Z',
+      updatedAt: '2026-08-02T13:30:00Z',
+      tags: ['thermodynamics', ' diagrams '],
+      bannerImage: { url: 'https://images.example.com/diagram.jpg' }
+    }, {
+      author: {
+        name: 'Ada Reader',
+        url: 'https://dailypage.org/en/users/ada'
+      },
+      baseUrl: options.baseUrl,
+      canonicalUrl: options.canonicalUrl,
+      description: 'A concise guide.',
+      roomName: 'Physics'
+    }));
+
+    expect(article['@type']).toBe('Article');
+    expect(article['@id']).toBe(`${options.canonicalUrl}#article`);
+    expect(article.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': options.canonicalUrl
+    });
+    expect(article.headline).toBe('Reading a temperature diagram');
+    expect(article.description).toBe('A concise guide.');
+    expect(article.inLanguage).toBe('en');
+    expect(article.datePublished).toBe('2026-08-01T12:00:00.000Z');
+    expect(article.dateModified).toBe('2026-08-02T13:30:00.000Z');
+    expect(article.author).toEqual({
+      '@type': 'Person',
+      name: 'Ada Reader',
+      url: 'https://dailypage.org/en/users/ada'
+    });
+    expect(article.publisher).toEqual({
+      '@id': 'https://dailypage.org/#organization'
+    });
+    expect(article.image).toBe('https://images.example.com/diagram.jpg');
+    expect(article.articleSection).toBe('Physics');
+    expect(article.keywords).toEqual(['thermodynamics', 'diagrams']);
+  });
+
+  it('omits unavailable optional fields and non-image banners', () => {
+    const article = JSON.parse(buildPostArticleJsonLd({
+      title: 'A panorama',
+      bannerImage: {
+        kind: 'streetview',
+        url: 'https://www.google.com/maps/embed?pb=example'
+      }
+    }, {
+      baseUrl: options.baseUrl,
+      canonicalUrl: options.canonicalUrl,
+      description: 'A mapped location.'
+    }));
+
+    expect(article.image).toBeUndefined();
+    expect(article.author).toBeUndefined();
+    expect(article.datePublished).toBeUndefined();
+    expect(article.dateModified).toBeUndefined();
+    expect(article.keywords).toBeUndefined();
+  });
+
+  it('renders JSON-LD without allowing post content to close the script element', () => {
+    const articleJsonLd = buildPostArticleJsonLd({
+      title: '</script><script>alert("unsafe")</script>'
+    }, {
+      baseUrl: options.baseUrl,
+      canonicalUrl: options.canonicalUrl,
+      description: 'Safe description'
+    });
+    const html = pug.renderFile('views/partials/_article_json_ld.pug', { articleJsonLd });
+
+    expect(html.match(/<script/g).length).toBe(1);
+    expect(html).not.toContain('</script><script>');
+    expect(JSON.parse(articleJsonLd).headline)
+      .toBe('</script><script>alert("unsafe")</script>');
   });
 });

--- a/views/partials/_article_json_ld.pug
+++ b/views/partials/_article_json_ld.pug
@@ -1,0 +1,2 @@
+if articleJsonLd
+  script(type='application/ld+json')!= articleJsonLd

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -4,6 +4,7 @@ block nav
   include ../navLinks
 
 block append head
+  include ../partials/_article_json_ld
   -
     // Helpers (baseUrl comes from res.locals via middleware)
     const makeAbs = (id) => `${baseUrl}/rooms/${room_id}/blocks/${id}`;


### PR DESCRIPTION
## Summary

- add Schema.org `Article` JSON-LD to publicly visible post pages
- include canonical URL, headline, description, and content language
- include publication and modification timestamps
- identify the visible author and link their profile when available
- associate posts with the Daily Page publisher
- expose room names as article sections and post tags as keywords
- include genuine post banner images while excluding Street View embeds
- omit article markup from editable unlisted drafts
- safely serialize user-provided content inside JSON-LD script elements

## Validation

- `npm run lint`
- `npm test` — 770 specs passed
- confirmed the post-view Pug template compiles successfully
- `git diff --check`