### PR TITLE
Use post group resolver for hreflang x-default

### DIFF
--- a/server/db/blockService.js
+++ b/server/db/blockService.js
@@ -88,6 +88,13 @@ export async function getPublicTranslations(groupId) {
   return await Block.find(publiclyVisibleBlockMatch({ groupId })).select('lang _id title roomId');
 }
 
+export async function getPublicTranslationResolverCandidates(groupId) {
+  if (!groupId) return [];
+  return await Block.find(publiclyVisibleBlockMatch({ groupId }))
+    .select('lang _id roomId originalBlock createdAt')
+    .sort({ createdAt: 1, _id: 1 });
+}
+
 export async function getGlobalBlockStats() {
   return await cache.get(
     `global-block-stats`,

--- a/server/routes/blockView.js
+++ b/server/routes/blockView.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import {
   getBlockById,
+  getPublicTranslationResolverCandidates,
   getPublicTranslations,
   getPublicTranslationByGroupAndLang,
   isPubliclyVisibleBlock
@@ -31,9 +32,35 @@ import {
 } from '../utils/block.js';
 import { canonicalBlockPath } from '../utils/canonical.js';
 import { buildPostSeo } from '../utils/postSeo.js';
+import { getPreferredContentLang } from '../services/localeContext.js';
+import { selectPublicPostTranslation } from '../services/postTranslationResolver.js';
 
 const router = express.Router();
 const INITIAL_COMMENT_LIMIT = 20;
+
+export function createPostGroupResolver({
+  getCandidates = getPublicTranslationResolverCandidates
+} = {}) {
+  return async function postGroupResolver(req, res) {
+    try {
+      const candidates = await getCandidates(req.params.group_id);
+      const selected = selectPublicPostTranslation(
+        candidates,
+        getPreferredContentLang(res)
+      );
+
+      if (!selected) return res.sendStatus(404);
+
+      res.set('Cache-Control', 'private, no-store');
+      res.vary('Accept-Language');
+      res.vary('Cookie');
+      return res.redirect(302, canonicalBlockPath(selected));
+    } catch (error) {
+      console.error(`Error resolving post group ${req.params.group_id}:`, error);
+      return res.sendStatus(500);
+    }
+  };
+}
 
 function normalizeCommentsSortDir(sortDir) {
   return sortDir === 'desc' ? 'desc' : 'asc';
@@ -43,6 +70,8 @@ function normalizeCommentId(commentId) {
   const value = String(commentId || '').trim();
   return value || null;
 }
+
+router.get('/posts/:group_id', createPostGroupResolver());
 
 async function addRecommendationRoomNames(recommendations, currentRoomId, roomMetadata, uiLang) {
   const roomIds = Array.from(new Set(

--- a/server/services/postTranslationResolver.js
+++ b/server/services/postTranslationResolver.js
@@ -1,0 +1,47 @@
+function normalizedLang(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function baseLang(value) {
+  return normalizedLang(value).split('-')[0];
+}
+
+function compareCandidates(left, right) {
+  const leftCreatedAt = new Date(left?.createdAt || 0).getTime();
+  const rightCreatedAt = new Date(right?.createdAt || 0).getTime();
+
+  if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt - rightCreatedAt;
+  return String(left?._id || '').localeCompare(String(right?._id || ''));
+}
+
+/**
+ * Select the concrete public post for a language-independent translation-group URL.
+ * Candidates are sorted here so the fallback remains stable even if a caller's query
+ * does not guarantee document order.
+ */
+export function selectPublicPostTranslation(candidates, preferredLang) {
+  const available = (Array.isArray(candidates) ? candidates : [])
+    .filter(candidate => candidate?._id && candidate?.roomId && candidate?.lang)
+    .slice()
+    .sort(compareCandidates);
+
+  if (!available.length) return null;
+
+  const preferred = normalizedLang(preferredLang);
+  const preferredBase = baseLang(preferred);
+  const exactPreferred = preferred
+    ? available.find(candidate => normalizedLang(candidate.lang) === preferred)
+    : null;
+  if (exactPreferred) return exactPreferred;
+
+  const basePreferred = preferredBase
+    ? available.find(candidate => baseLang(candidate.lang) === preferredBase)
+    : null;
+  if (basePreferred) return basePreferred;
+
+  const english = available.find(candidate => baseLang(candidate.lang) === 'en');
+  if (english) return english;
+
+  const original = available.find(candidate => !candidate.originalBlock);
+  return original || available[0];
+}

--- a/spec/postTranslationResolverSpec.js
+++ b/spec/postTranslationResolverSpec.js
@@ -1,0 +1,110 @@
+import pug from 'pug';
+import { createPostGroupResolver } from '../server/routes/blockView.js';
+import { selectPublicPostTranslation } from '../server/services/postTranslationResolver.js';
+
+describe('post translation group resolver', () => {
+  function post(id, lang, overrides = {}) {
+    return {
+      _id: id,
+      roomId: 'general',
+      lang,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      ...overrides
+    };
+  }
+
+  it('selects the visitor language before the English fallback', () => {
+    const english = post('english-id', 'en');
+    const japanese = post('japanese-id', 'ja', { originalBlock: 'english-id' });
+
+    expect(selectPublicPostTranslation([english, japanese], 'ja')).toBe(japanese);
+    expect(selectPublicPostTranslation([english, japanese], 'fr')).toBe(english);
+  });
+
+  it('matches a regional preference to the corresponding base language', () => {
+    const portuguese = post('portuguese-id', 'pt');
+    const english = post('english-id', 'en');
+
+    expect(selectPublicPostTranslation([english, portuguese], 'pt-BR')).toBe(portuguese);
+  });
+
+  it('uses the original and then the oldest public candidate when English is absent', () => {
+    const original = post('original-id', 'ja', {
+      createdAt: new Date('2026-02-01T00:00:00.000Z')
+    });
+    const translation = post('translation-id', 'es', {
+      originalBlock: 'missing-id',
+      createdAt: new Date('2026-01-01T00:00:00.000Z')
+    });
+
+    expect(selectPublicPostTranslation([translation, original], 'fr')).toBe(original);
+    expect(selectPublicPostTranslation([
+      { ...translation, originalBlock: 'source-id' },
+      post('later-id', 'de', {
+        originalBlock: 'source-id',
+        createdAt: new Date('2026-03-01T00:00:00.000Z')
+      })
+    ], 'fr')._id).toBe('translation-id');
+  });
+
+  it('redirects the group URL without making the negotiated response cacheable', async () => {
+    const getCandidates = jasmine.createSpy('getCandidates').and.resolveTo([
+      post('english-id', 'en'),
+      post('japanese-id', 'ja', { roomId: 'translated-room' })
+    ]);
+    const handler = createPostGroupResolver({ getCandidates });
+    const res = {
+      locals: { uiLang: 'ja' },
+      set: jasmine.createSpy('set'),
+      vary: jasmine.createSpy('vary'),
+      redirect: jasmine.createSpy('redirect'),
+      sendStatus: jasmine.createSpy('sendStatus')
+    };
+
+    await handler({ params: { group_id: 'group-id' } }, res);
+
+    expect(getCandidates).toHaveBeenCalledOnceWith('group-id');
+    expect(res.set).toHaveBeenCalledOnceWith('Cache-Control', 'private, no-store');
+    expect(res.vary.calls.allArgs()).toEqual([['Accept-Language'], ['Cookie']]);
+    expect(res.redirect).toHaveBeenCalledOnceWith(
+      302,
+      '/rooms/translated-room/blocks/japanese-id'
+    );
+  });
+
+  it('returns 404 when a group has no publicly visible translations', async () => {
+    const handler = createPostGroupResolver({ getCandidates: async () => [] });
+    const res = {
+      locals: { uiLang: 'en' },
+      sendStatus: jasmine.createSpy('sendStatus')
+    };
+
+    await handler({ params: { group_id: 'missing-group' } }, res);
+
+    expect(res.sendStatus).toHaveBeenCalledOnceWith(404);
+  });
+});
+
+describe('block hreflang metadata', () => {
+  it('uses concrete translation rooms and one language-independent group URL', () => {
+    const html = pug.renderFile('views/partials/_block_hreflang.pug', {
+      baseUrl: 'https://dailypage.org',
+      room_id: 'source-room',
+      block: { groupId: 'group/id' },
+      translations: [
+        { _id: 'english-id', roomId: 'source-room', lang: 'en' },
+        { _id: 'japanese-id', roomId: 'translated-room', lang: 'ja' }
+      ]
+    });
+
+    expect(html).toContain(
+      'hreflang="en" href="https://dailypage.org/rooms/source-room/blocks/english-id"'
+    );
+    expect(html).toContain(
+      'hreflang="ja" href="https://dailypage.org/rooms/translated-room/blocks/japanese-id"'
+    );
+    expect(html).toContain(
+      'hreflang="x-default" href="https://dailypage.org/posts/group%2Fid"'
+    );
+  });
+});

--- a/views/partials/_block_hreflang.pug
+++ b/views/partials/_block_hreflang.pug
@@ -1,0 +1,4 @@
+- const makeBlockAbs = (roomId, id) => `${baseUrl}/rooms/${roomId}/blocks/${id}`;
+each tr in translations
+  link(rel='alternate' hreflang=tr.lang href=makeBlockAbs(tr.roomId || room_id, tr._id))
+link(rel='alternate' hreflang='x-default' href=`${baseUrl}/posts/${encodeURIComponent(block.groupId)}`)

--- a/views/rooms/block-view.pug
+++ b/views/rooms/block-view.pug
@@ -5,13 +5,7 @@ block nav
 
 block append head
   include ../partials/_article_json_ld
-  -
-    // Helpers (baseUrl comes from res.locals via middleware)
-    const makeAbs = (id) => `${baseUrl}/rooms/${room_id}/blocks/${id}`;
-  each tr in translations
-    link(rel='alternate' hreflang=tr.lang href=makeAbs(tr._id))
-  // fallback for “any/unknown” language
-  link(rel='alternate' hreflang='x-default' href=makeAbs(block._id))
+  include ../partials/_block_hreflang
   link(rel='stylesheet' href='/css/block-common.css')
   link(rel='stylesheet' href='/css/block-view.css')
   link(rel='stylesheet' href='/css/block-tags.css')


### PR DESCRIPTION
## Summary

Add a language-independent post-group resolver and use it as the shared `hreflang="x-default"` URL for translated posts.

Previously, each translation pointed `x-default` to itself, causing the fallback URL to change depending on which translation was being viewed.

## Changes

- Add `/posts/:groupId` as a stable, language-independent post URL.
- Redirect visitors to the best publicly visible translation using:
  1. Exact preferred language
  2. Matching base language
  3. English
  4. Original public post
  5. Oldest public translation
- Mark negotiated redirects as private and non-cacheable.
- Point every translation in a group to the same `x-default` URL.
- Build language-specific alternate links using each translation's actual room ID.
- Add focused resolver and rendered-metadata coverage.

## Database impact

No schema changes or data migration are required. The resolver uses the existing translation `groupId`.

## Testing

- `npx jasmine spec/postTranslationResolverSpec.js`
- `npx eslint server/routes/blockView.js server/db/blockService.js server/services/postTranslationResolver.js spec/postTranslationResolverSpec.js`
- `npx jasmine`

All 776 specs pass.