### PR TITLE
Prefer complete sentences in post metadata descriptions

### DIFF
--- a/server/utils/postSeo.js
+++ b/server/utils/postSeo.js
@@ -6,9 +6,22 @@ function truncateDescription(value, maxLength = POST_META_DESCRIPTION_MAX_LENGTH
   const normalized = String(value || '').replace(/\s+/g, ' ').trim();
   if (normalized.length <= maxLength) return normalized;
 
+  const sentenceCandidate = normalized.slice(0, maxLength);
+  const minimumSentenceLength = Math.floor(maxLength * 0.5);
+  const sentenceEndPattern = /[.!?](?:["'’”)\]]*)(?=\s|$)/gu;
+  let sentenceEnd = -1;
+
+  for (const match of sentenceCandidate.matchAll(sentenceEndPattern)) {
+    const end = match.index + match[0].length;
+    if (end >= minimumSentenceLength) sentenceEnd = end;
+  }
+
+  if (sentenceEnd >= 0) return sentenceCandidate.slice(0, sentenceEnd);
+
   const candidate = normalized.slice(0, maxLength - 1);
   const lastSpace = candidate.lastIndexOf(' ');
-  const cutAt = lastSpace >= Math.floor(maxLength * 0.6) ? lastSpace : candidate.length;
+  const minimumWordBoundary = Math.floor(maxLength * 0.6);
+  const cutAt = lastSpace >= minimumWordBoundary ? lastSpace : candidate.length;
   return `${candidate.slice(0, cutAt).trimEnd()}…`;
 }
 

--- a/spec/postSeoSpec.js
+++ b/spec/postSeoSpec.js
@@ -60,6 +60,32 @@ describe('post SEO metadata', () => {
     expect(metadata.socialCardType).toBe('summary');
   });
 
+  it('prefers a complete sentence when a description exceeds the metadata limit', () => {
+    const completeSentence =
+      'Build a core–satellite portfolio with clear boundaries and explicit rebalancing rules.';
+    const metadata = buildPostSeo({
+      title: 'A resilient portfolio',
+      description: `${completeSentence} The follow-up thought ${'continues '.repeat(20)}past the limit.`
+    }, options);
+
+    expect(completeSentence.length)
+      .toBeGreaterThanOrEqual(Math.floor(POST_META_DESCRIPTION_MAX_LENGTH * 0.5));
+    expect(metadata.description).toBe(completeSentence);
+    expect(metadata.socialDescription).toBe(completeSentence);
+    expect(JSON.parse(metadata.articleJsonLd).description).toBe(completeSentence);
+  });
+
+  it('uses a word-boundary ellipsis when the first sentence is too long', () => {
+    const metadata = buildPostSeo({
+      title: 'One long thought',
+      description: `${'A continuous explanation without a sentence boundary '.repeat(5)}ends here.`
+    }, options);
+
+    expect(metadata.description.length).toBeLessThanOrEqual(POST_META_DESCRIPTION_MAX_LENGTH);
+    expect(metadata.description.endsWith('…')).toBeTrue();
+    expect(metadata.description.endsWith(' …')).toBeFalse();
+  });
+
   it('includes a valid publication timestamp when one exists', () => {
     const metadata = buildPostSeo({
       title: 'Dated post',


### PR DESCRIPTION
## Summary

- prefer the last complete sentence that fits within the post metadata limit
- retain word-boundary truncation with an ellipsis when no substantial complete sentence fits
- keep descriptions consistent across standard metadata, Open Graph, Twitter cards, and Article JSON-LD
- add regression coverage for both truncation paths

## Testing

- `npm test` — 991 specs passed
- `npm run lint`
- `git diff --check`