### PR TITLE
Add 600-tree Activity Forest pressure evidence

### DIFF
--- a/docs/testing/account-deletion-integration-fixtures.md
+++ b/docs/testing/account-deletion-integration-fixtures.md
@@ -129,6 +129,66 @@ To start the same scenario again, rerun its seed command. To remove it without r
 npm run account-deletion:fixture -- reset <scenario> --write
 ```
 
+## Test bounded writing and large-forest pressure
+
+The 55-tree pagination and 600-tree pressure profiles must be run from separately reseeded fixture
+scenarios so that their measurements do not accumulate into one larger, ambiguous history.
+
+To exercise three forward and backward writing pages:
+
+```bash
+npm run account-deletion:fixture -- seed anonymous --write
+npm run account-deletion:fixture -- seed-forest-pagination anonymous --write
+```
+
+To create 600 disposable eligible owner groups through the production reconciliation service and
+measure the resulting private forest:
+
+```bash
+npm run account-deletion:fixture -- seed anonymous --write
+npm run account-deletion:fixture -- seed-forest-pressure anonymous --write
+```
+
+Run the development server with scheduled background work disabled before seeding this profile:
+
+```bash
+DISABLE_BACKGROUND_JOBS=true npm start
+```
+
+The pressure command performs every exact owner/group reconciliation directly, so disabling the
+scheduled queue and convergence workers does not skip tree creation. It prevents the periodic
+whole-world convergence sweep from claiming the newly seeded world during the several-minute bulk
+setup and temporarily replacing the forest with its reconciling state. Disabling background jobs
+after a sweep has already started will not complete that sweep; either let the normally configured
+worker finish first or reseed after restarting with background jobs disabled.
+
+The pressure command reports only aggregate synthetic evidence:
+
+- source status, visibility, and language counts;
+- Block-upsert and per-group reconciliation timings and outcomes;
+- occupied spatial-cell count, span, and occupancy percentiles;
+- complete bounded writing-page counts, bytes, omissions, and timing samples;
+- center, densest, and outer signed 3-by-3 regional page counts, placements, bytes, and timings; and
+- one authorized batch of at most 24 lossless-raster assets measured cold and warm in the fixture
+  process.
+
+The command verifies that every pressure Block has one active visible durable tree, writing cursors
+return every active visible tree without duplication, each regional request remains within the
+production 250-placement page bound, and both asset passes return every authorized key. Exact
+titles, owner ids, group ids, tree ids, positions, asset keys, routes, and cursors are not printed.
+
+The fixture process starts with empty process-local tree and raster caches, so the first asset pass
+is the local cold sample and the immediately repeated pass is the warm sample. These timings are
+diagnostic baselines for the named machine, not universal latency budgets. Browser network,
+preparation, frame, memory, and travel behavior should still be reviewed manually against the
+seeded `/en/forest` route.
+
+Reseeding or resetting the scenario removes both pressure records and their forest ledger:
+
+```bash
+npm run account-deletion:fixture -- reset anonymous --write
+```
+
 ## Test the active-quest guard
 
 Seed any scenario with an active quest:

--- a/scripts/dev/accountDeletionFixture.js
+++ b/scripts/dev/accountDeletionFixture.js
@@ -51,6 +51,16 @@ import {
   listForestOwnerWritingTrees
 } from '../../server/services/forestOwnerNonCanvasRead.js';
 import {
+  deliverForestOwnerRegionAssets
+} from '../../server/services/forestOwnerRegionAssetDelivery.js';
+import {
+  FOREST_OWNER_REGION_MAX_PAGE_SIZE,
+  readForestOwnerRegionManifest
+} from '../../server/services/forestOwnerRegionManifest.js';
+import {
+  FOREST_ASSET_TRANSPORT_RASTER
+} from '../../server/services/forestSceneAssetTransport.js';
+import {
   ACCOUNT_DELETION_FIXTURE_ROOM_ID,
   ACCOUNT_DELETION_FIXTURE_SCENARIOS,
   ACCOUNT_DELETION_FIXTURE_TAG,
@@ -60,6 +70,14 @@ import {
   expectedRetainedPostKeys,
   parseAccountDeletionFixtureArgs
 } from '../lib/accountDeletionFixture.js';
+import {
+  buildForestOwnerPressurePosts,
+  forestPressureNeighborhoods,
+  FOREST_OWNER_PRESSURE_TAG,
+  FOREST_OWNER_PRESSURE_TREE_COUNT,
+  summarizeForestPressureCells,
+  summarizeForestPressureTimings
+} from '../lib/forestOwnerPressureFixture.js';
 
 function usage() {
   console.log('Usage: npm run account-deletion:fixture -- <command> <scenario> [options]');
@@ -71,7 +89,8 @@ function usage() {
   console.log('  verify-before <scenario>                  Verify the login-ready fixture.');
   console.log('  delete-direct <scenario> --write          Invoke the deletion service directly.');
   console.log('  create-tree-direct <scenario> --write     Verify transactional tree creation.');
-  console.log('  seed-forest-pagination <scenario> --write Add enough real trees for two read pages.');
+  console.log('  seed-forest-pagination <scenario> --write Seed and verify three writing pages.');
+  console.log('  seed-forest-pressure <scenario> --write   Seed and measure 600 real trees.');
   console.log('  verify-after <scenario>                   Verify the completed deletion.');
   console.log('  archive-quest <scenario> --write          Remove the active-quest guard.');
   console.log('  reset <scenario> --write                  Remove one fixture scenario.');
@@ -898,13 +917,21 @@ async function createTreeDirect(scenario) {
 async function seedForestPagination(scenario) {
   const fixture = scenarioDefinition(scenario);
   const ownerUserId = fixture.users.owner._id;
-  const [owner, world] = await Promise.all([
+  const [owner, world, pressureRecords] = await Promise.all([
     User.findById(ownerUserId).lean(),
-    ForestOwnerWorld.findOne({ ownerUserId, worldRole: 'primary' }).lean()
+    ForestOwnerWorld.findOne({ ownerUserId, worldRole: 'primary' }).lean(),
+    Block.countDocuments({
+      userId: ownerUserId,
+      tags: FOREST_OWNER_PRESSURE_TAG
+    })
   ]);
   requireFixtureCondition(
     owner && world?.status === 'active' && world?.reconciliation?.state === 'idle',
     `Seed and verify the ${scenario} fixture before adding forest pagination records.`
+  );
+  requireFixtureCondition(
+    pressureRecords === 0,
+    `Reseed the ${scenario} scenario before switching from 600-tree to 55-tree pressure.`
   );
 
   const posts = buildForestReadPaginationPosts({ scenario, owner });
@@ -998,6 +1025,272 @@ async function seedForestPagination(scenario) {
     password: process.env.ACCOUNT_DELETION_FIXTURE_PASSWORD
       || DEFAULT_ACCOUNT_DELETION_FIXTURE_PASSWORD
   });
+}
+
+function elapsedMilliseconds(startedAt) {
+  return Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+}
+
+async function measured(work) {
+  const startedAt = process.hrtime.bigint();
+  const result = await work();
+  return { result, elapsedMs: elapsedMilliseconds(startedAt) };
+}
+
+function serializedBytes(value) {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function fixtureDistribution(values) {
+  return Object.fromEntries([...values.reduce((counts, value) => (
+    counts.set(value, (counts.get(value) || 0) + 1)
+  ), new Map()).entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+async function measureWritingPages(ownerUserId) {
+  const durations = [];
+  const seenTreeIds = new Set();
+  const seenCursors = new Set();
+  let cursor = null;
+  let pageCount = 0;
+  let totalBytes = 0;
+  let maximumPageRows = 0;
+  let omittedUnavailableCount = 0;
+  do {
+    const page = await measured(() => listForestOwnerWritingTrees({
+      ownerUserId,
+      preferredContentLang: 'en',
+      cursor
+    }));
+    requireFixtureCondition(page.result.status === 'ready', 'Writing pressure read was not ready.');
+    durations.push(page.elapsedMs);
+    totalBytes += serializedBytes(page.result);
+    maximumPageRows = Math.max(maximumPageRows, page.result.trees.length);
+    omittedUnavailableCount += page.result.page.omittedUnavailableCount;
+    for (const tree of page.result.trees) {
+      requireFixtureCondition(
+        !seenTreeIds.has(tree.writingTreeId),
+        'Writing pressure pagination returned a duplicate tree.'
+      );
+      seenTreeIds.add(tree.writingTreeId);
+    }
+    pageCount += 1;
+    const nextCursor = page.result.page.nextCursor;
+    if (nextCursor) {
+      requireFixtureCondition(
+        !seenCursors.has(nextCursor),
+        'Writing pressure pagination repeated a cursor.'
+      );
+      seenCursors.add(nextCursor);
+    }
+    cursor = nextCursor;
+    requireFixtureCondition(pageCount <= 100, 'Writing pressure pagination exceeded 100 pages.');
+  } while (cursor);
+  return {
+    pageCount,
+    returnedTreeCount: seenTreeIds.size,
+    maximumPageRows,
+    omittedUnavailableCount,
+    serializedBytes: totalBytes,
+    timings: summarizeForestPressureTimings(durations)
+  };
+}
+
+async function measureNeighborhood(ownerUserId, neighborhood) {
+  const durations = [];
+  const pages = [];
+  let cursor = null;
+  let pageCount = 0;
+  let placementCount = 0;
+  let totalBytes = 0;
+  do {
+    const requestCursor = cursor;
+    const page = await measured(() => readForestOwnerRegionManifest({
+      ownerUserId,
+      cells: neighborhood.cells,
+      cursor: requestCursor,
+      limit: FOREST_OWNER_REGION_MAX_PAGE_SIZE
+    }));
+    requireFixtureCondition(page.result.status === 'ready', 'Pressure region was not ready.');
+    durations.push(page.elapsedMs);
+    pages.push({ cursor: requestCursor, manifest: page.result });
+    pageCount += 1;
+    placementCount += page.result.placements.length;
+    totalBytes += serializedBytes(page.result);
+    cursor = page.result.page.nextCursor;
+    requireFixtureCondition(pageCount <= 10, 'Pressure region exceeded 10 pages.');
+  } while (cursor);
+  return {
+    label: neighborhood.label,
+    cells: neighborhood.cells,
+    pageCount,
+    placementCount,
+    serializedBytes: totalBytes,
+    timings: summarizeForestPressureTimings(durations),
+    pages
+  };
+}
+
+async function measureAssetDelivery(ownerUserId, neighborhood) {
+  const firstPage = neighborhood.pages[0];
+  const assetKeys = [...new Set(firstPage.manifest.placements.map(
+    placement => placement.assetKey
+  ))].slice(0, 24);
+  requireFixtureCondition(assetKeys.length > 0, 'Pressure region had no assets to measure.');
+  const input = {
+    ownerUserId,
+    cells: neighborhood.cells,
+    cursor: firstPage.cursor,
+    assetKeys,
+    transport: FOREST_ASSET_TRANSPORT_RASTER
+  };
+  const cold = await measured(() => deliverForestOwnerRegionAssets(input));
+  const warm = await measured(() => deliverForestOwnerRegionAssets(input));
+  for (const delivery of [cold.result, warm.result]) {
+    requireFixtureCondition(
+      delivery.status === 'ready' && delivery.assets.length === assetKeys.length,
+      'Pressure asset delivery did not return every authorized asset.'
+    );
+  }
+  return {
+    neighborhood: neighborhood.label,
+    requestedAssetCount: assetKeys.length,
+    transport: FOREST_ASSET_TRANSPORT_RASTER,
+    cold: {
+      elapsedMs: summarizeForestPressureTimings([cold.elapsedMs]).totalMs,
+      serializedBytes: serializedBytes(cold.result)
+    },
+    warm: {
+      elapsedMs: summarizeForestPressureTimings([warm.elapsedMs]).totalMs,
+      serializedBytes: serializedBytes(warm.result)
+    }
+  };
+}
+
+async function seedForestPressure(scenario) {
+  const fixture = scenarioDefinition(scenario);
+  const ownerUserId = fixture.users.owner._id;
+  const [owner, world, paginationRecords] = await Promise.all([
+    User.findById(ownerUserId).lean(),
+    ForestOwnerWorld.findOne({ ownerUserId, worldRole: 'primary' }).lean(),
+    Block.countDocuments({
+      userId: ownerUserId,
+      tags: 'forest-read-pagination'
+    })
+  ]);
+  requireFixtureCondition(
+    owner && world?.status === 'active' && world?.reconciliation?.state === 'idle',
+    `Seed and verify the ${scenario} fixture before adding forest pressure records.`
+  );
+  requireFixtureCondition(
+    paginationRecords === 0,
+    `Reseed the ${scenario} scenario before switching from 55-tree to 600-tree pressure.`
+  );
+
+  const posts = buildForestOwnerPressurePosts({ scenario, owner });
+  const insert = await measured(() => Block.bulkWrite(posts.map(({ _id, ...post }) => ({
+    updateOne: {
+      filter: { _id },
+      update: { $set: post },
+      upsert: true
+    }
+  })), { ordered: true }));
+
+  const reconciliationDurations = [];
+  const reconciliationOutcomes = {};
+  for (let index = 0; index < posts.length; index += 1) {
+    const reconciliation = await measured(() => reconcileForestOwnerGroup({
+      ownerUserId,
+      translationGroupId: posts[index].groupId,
+      now: new Date()
+    }));
+    reconciliationDurations.push(reconciliation.elapsedMs);
+    reconciliationOutcomes[reconciliation.result.outcome] =
+      (reconciliationOutcomes[reconciliation.result.outcome] || 0) + 1;
+    if ((index + 1) % 100 === 0) {
+      console.log(`Forest pressure reconciliation: ${index + 1}/${posts.length}`);
+    }
+  }
+
+  const groupIds = posts.map(post => post.groupId);
+  const [pressurePostCount, pressureTrees, visibleTreeCount] = await Promise.all([
+    Block.countDocuments({
+      userId: ownerUserId,
+      tags: FOREST_OWNER_PRESSURE_TAG
+    }),
+    ForestWritingTree.find({
+      ownerUserId,
+      translationGroupId: { $in: groupIds }
+    }, {
+      _id: 0,
+      sourceState: 1,
+      hiddenFromForest: 1,
+      placementIndex: 1
+    }).lean(),
+    ForestWritingTree.countDocuments({
+      ownerUserId,
+      sourceState: 'active',
+      hiddenFromForest: false
+    })
+  ]);
+  requireFixtureCondition(
+    pressurePostCount === FOREST_OWNER_PRESSURE_TREE_COUNT
+      && pressureTrees.length === FOREST_OWNER_PRESSURE_TREE_COUNT
+      && pressureTrees.every(tree => (
+        tree.sourceState === 'active' && tree.hiddenFromForest === false
+      )),
+    'Pressure fixture did not converge to 600 active visible trees.'
+  );
+
+  const cellSummary = summarizeForestPressureCells(pressureTrees);
+  const neighborhoods = [];
+  for (const definition of forestPressureNeighborhoods(cellSummary)) {
+    neighborhoods.push(await measureNeighborhood(ownerUserId, definition));
+  }
+  const writing = await measureWritingPages(ownerUserId);
+  requireFixtureCondition(
+    writing.returnedTreeCount === visibleTreeCount,
+    'Writing pressure pagination did not return every active visible tree.'
+  );
+  const assetNeighborhood = neighborhoods.slice().sort((left, right) => (
+    right.placementCount - left.placementCount
+  ))[0];
+  const assets = await measureAssetDelivery(ownerUserId, assetNeighborhood);
+
+  const report = {
+    database: mongoose.connection.name,
+    scenario,
+    generatedPressurePosts: pressurePostCount,
+    activeVisibleTreesIncludingBaseline: visibleTreeCount,
+    sourceDistribution: {
+      status: fixtureDistribution(posts.map(post => post.status)),
+      visibility: fixtureDistribution(posts.map(post => post.visibility)),
+      language: fixtureDistribution(posts.map(post => post.lang))
+    },
+    setup: {
+      blockUpsertMs: summarizeForestPressureTimings([insert.elapsedMs]).totalMs,
+      reconciliationOutcomes,
+      reconciliationTimings: summarizeForestPressureTimings(reconciliationDurations)
+    },
+    spatialDistribution: {
+      treeCount: cellSummary.treeCount,
+      occupiedCellCount: cellSummary.occupiedCellCount,
+      cellSpanX: cellSummary.cellSpanX,
+      cellSpanY: cellSummary.cellSpanY,
+      occupancy: cellSummary.occupancy
+    },
+    writing,
+    regionalNeighborhoods: neighborhoods.map(neighborhood => ({
+      label: neighborhood.label,
+      pageCount: neighborhood.pageCount,
+      placementCount: neighborhood.placementCount,
+      serializedBytes: neighborhood.serializedBytes,
+      timings: neighborhood.timings
+    })),
+    assets
+  };
+  console.log('Activity Forest 600-tree pressure fixture passes:');
+  console.log(JSON.stringify(report, null, 2));
 }
 
 async function verifyAfter(scenario) {
@@ -1370,6 +1663,9 @@ async function main() {
       break;
     case 'seed-forest-pagination':
       await seedForestPagination(args.scenario);
+      break;
+    case 'seed-forest-pressure':
+      await seedForestPressure(args.scenario);
       break;
     case 'verify-after':
       await verifyAfter(args.scenario);

--- a/scripts/lib/accountDeletionFixture.js
+++ b/scripts/lib/accountDeletionFixture.js
@@ -93,6 +93,7 @@ export function parseAccountDeletionFixtureArgs(argv) {
     'delete-direct',
     'create-tree-direct',
     'seed-forest-pagination',
+    'seed-forest-pressure',
     'verify-after',
     'archive-quest'
   ];
@@ -115,7 +116,8 @@ export function parseAccountDeletionFixtureArgs(argv) {
   if (args.activeQuest && command !== 'seed') {
     throw new Error('--active-quest is only valid with the seed command.');
   }
-  if (['seed', 'reset', 'delete-direct', 'create-tree-direct', 'seed-forest-pagination', 'archive-quest'].includes(command)
+  if (['seed', 'reset', 'delete-direct', 'create-tree-direct', 'seed-forest-pagination',
+    'seed-forest-pressure', 'archive-quest'].includes(command)
     && !args.write) {
     throw new Error(`${command} changes data and requires --write.`);
   }

--- a/scripts/lib/forestOwnerPressureFixture.js
+++ b/scripts/lib/forestOwnerPressureFixture.js
@@ -1,0 +1,149 @@
+import {
+  ACCOUNT_DELETION_FIXTURE_ROOM_ID,
+  ACCOUNT_DELETION_FIXTURE_TAG,
+  assertFixtureScenario,
+  fixtureObjectId
+} from './accountDeletionFixture.js';
+
+export const FOREST_OWNER_PRESSURE_TREE_COUNT = 600;
+export const FOREST_OWNER_PRESSURE_TAG = 'forest-owner-pressure';
+
+function boundedCount(value) {
+  if (!Number.isSafeInteger(value) || value < 1 || value > FOREST_OWNER_PRESSURE_TREE_COUNT) {
+    throw new Error(
+      `Pressure fixture count must be an integer from 1 through ${FOREST_OWNER_PRESSURE_TREE_COUNT}.`
+    );
+  }
+  return value;
+}
+
+export function buildForestOwnerPressurePosts({
+  scenario,
+  owner,
+  count = FOREST_OWNER_PRESSURE_TREE_COUNT
+}) {
+  assertFixtureScenario(scenario);
+  boundedCount(count);
+  if (!owner?._id || !owner?.username) {
+    throw new Error('A fixture owner with stable id and username is required.');
+  }
+
+  const baseTime = Date.parse('2025-01-01T12:00:00.000Z');
+  return Array.from({ length: count }, (_, index) => {
+    const ordinal = index + 1;
+    const createdAt = new Date(baseTime + (index * 60_000));
+    const status = index % 2 === 0 ? 'locked' : 'in-progress';
+    return {
+      _id: fixtureObjectId(scenario, `forest-pressure:post:${ordinal}`),
+      title: `[Forest pressure] Writing tree ${String(ordinal).padStart(3, '0')}`,
+      description: 'Disposable post for Activity Forest pressure measurement.',
+      tags: [
+        ACCOUNT_DELETION_FIXTURE_TAG,
+        `account-deletion-${scenario}`,
+        FOREST_OWNER_PRESSURE_TAG
+      ],
+      content: `# Forest pressure tree ${ordinal}\n\nDisposable pressure-fixture writing.`,
+      roomId: ACCOUNT_DELETION_FIXTURE_ROOM_ID,
+      creator: owner.username,
+      userId: owner._id,
+      authorshipState: 'live',
+      visibility: index % 3 === 0 ? 'unlisted' : 'public',
+      status,
+      groupId: fixtureObjectId(scenario, `forest-pressure:group:${ordinal}`),
+      lang: index % 7 === 0 ? 'es' : 'en',
+      ...(status === 'locked' ? { lockedAt: createdAt } : {}),
+      createdAt,
+      updatedAt: createdAt
+    };
+  });
+}
+
+function percentile(sorted, fraction) {
+  if (!sorted.length) return 0;
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+export function summarizeForestPressureTimings(values) {
+  if (!Array.isArray(values)
+    || values.some(value => typeof value !== 'number' || !Number.isFinite(value) || value < 0)) {
+    throw new Error('Pressure timings must be a list of finite nonnegative numbers.');
+  }
+  const sorted = values.slice().sort((left, right) => left - right);
+  const rounded = value => Math.round(value * 100) / 100;
+  return {
+    samples: sorted.length,
+    totalMs: rounded(sorted.reduce((total, value) => total + value, 0)),
+    minimumMs: rounded(sorted[0] || 0),
+    medianMs: rounded(percentile(sorted, 0.5)),
+    p95Ms: rounded(percentile(sorted, 0.95)),
+    maximumMs: rounded(sorted.at(-1) || 0)
+  };
+}
+
+export function summarizeForestPressureCells(trees) {
+  if (!Array.isArray(trees) || trees.some(tree => (
+    !Number.isSafeInteger(tree?.placementIndex?.cellX)
+    || !Number.isSafeInteger(tree?.placementIndex?.cellY)
+  ))) {
+    throw new Error('Pressure trees require exact placement-index cells.');
+  }
+  const counts = new Map();
+  for (const tree of trees) {
+    const { cellX, cellY } = tree.placementIndex;
+    const key = `${cellX}:${cellY}`;
+    counts.set(key, { cellX, cellY, count: (counts.get(key)?.count || 0) + 1 });
+  }
+  const cells = [...counts.values()].sort((left, right) => (
+    right.count - left.count
+    || (Math.abs(left.cellX) + Math.abs(left.cellY))
+      - (Math.abs(right.cellX) + Math.abs(right.cellY))
+    || left.cellY - right.cellY
+    || left.cellX - right.cellX
+  ));
+  const occupancies = cells.map(cell => cell.count).sort((left, right) => left - right);
+  const cellXs = cells.map(cell => cell.cellX);
+  const cellYs = cells.map(cell => cell.cellY);
+  return {
+    treeCount: trees.length,
+    occupiedCellCount: cells.length,
+    cellSpanX: cells.length ? Math.max(...cellXs) - Math.min(...cellXs) + 1 : 0,
+    cellSpanY: cells.length ? Math.max(...cellYs) - Math.min(...cellYs) + 1 : 0,
+    occupancy: {
+      minimum: occupancies[0] || 0,
+      median: percentile(occupancies, 0.5),
+      p95: percentile(occupancies, 0.95),
+      maximum: occupancies.at(-1) || 0
+    },
+    cells
+  };
+}
+
+export function forestPressureNeighborhoods(cellSummary) {
+  if (!cellSummary?.cells?.length) return [];
+  const densest = cellSummary.cells[0];
+  const outermost = cellSummary.cells.slice().sort((left, right) => (
+    (Math.abs(right.cellX) + Math.abs(right.cellY))
+      - (Math.abs(left.cellX) + Math.abs(left.cellY))
+    || right.count - left.count
+  ))[0];
+  const centers = [
+    { label: 'center', cellX: 0, cellY: 0 },
+    { label: 'densest', cellX: densest.cellX, cellY: densest.cellY },
+    { label: 'outer', cellX: outermost.cellX, cellY: outermost.cellY }
+  ];
+  const seen = new Set();
+  return centers.filter((center) => {
+    const key = `${center.cellX}:${center.cellY}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).map(center => ({
+    ...center,
+    cells: [-1, 0, 1].flatMap(yOffset => (
+      [-1, 0, 1].map(xOffset => ({
+        cellX: center.cellX + xOffset,
+        cellY: center.cellY + yOffset
+      }))
+    ))
+  }));
+}

--- a/spec/accountDeletionFixtureSpec.js
+++ b/spec/accountDeletionFixtureSpec.js
@@ -7,6 +7,13 @@ import {
   fixtureUuid,
   parseAccountDeletionFixtureArgs
 } from '../scripts/lib/accountDeletionFixture.js';
+import {
+  buildForestOwnerPressurePosts,
+  forestPressureNeighborhoods,
+  FOREST_OWNER_PRESSURE_TREE_COUNT,
+  summarizeForestPressureCells,
+  summarizeForestPressureTimings
+} from '../scripts/lib/forestOwnerPressureFixture.js';
 import AuthSession from '../server/db/models/AuthSession.js';
 import Backup from '../server/db/models/Backup.js';
 import Block from '../server/db/models/Block.js';
@@ -182,6 +189,8 @@ describe('account deletion integration fixture definitions', () => {
       .toThrowError('create-tree-direct changes data and requires --write.');
     expect(() => parseAccountDeletionFixtureArgs(['seed-forest-pagination', 'delete']))
       .toThrowError('seed-forest-pagination changes data and requires --write.');
+    expect(() => parseAccountDeletionFixtureArgs(['seed-forest-pressure', 'delete']))
+      .toThrowError('seed-forest-pressure changes data and requires --write.');
     expect(parseAccountDeletionFixtureArgs([
       'seed',
       'anonymous',
@@ -219,6 +228,64 @@ describe('account deletion integration fixture definitions', () => {
     for (const post of first) {
       await expectAsync(new Block(post).validate()).toBeResolved();
     }
+  });
+
+  it('builds 600 deterministic eligible owner groups for forest pressure review', async () => {
+    const fixture = buildAccountDeletionFixture({
+      scenario: 'anonymous',
+      passwordHash: 'hash'
+    });
+    const first = buildForestOwnerPressurePosts({
+      scenario: fixture.scenario,
+      owner: fixture.users.owner
+    });
+    const second = buildForestOwnerPressurePosts({
+      scenario: fixture.scenario,
+      owner: fixture.users.owner
+    });
+
+    expect(first).toEqual(second);
+    expect(first).toHaveSize(FOREST_OWNER_PRESSURE_TREE_COUNT);
+    expect(new Set(first.map(post => post._id)).size)
+      .toBe(FOREST_OWNER_PRESSURE_TREE_COUNT);
+    expect(new Set(first.map(post => post.groupId)).size)
+      .toBe(FOREST_OWNER_PRESSURE_TREE_COUNT);
+    expect(first.some(post => post.lang === 'es')).toBeTrue();
+    expect(first.some(post => post.visibility === 'unlisted')).toBeTrue();
+    expect(first.some(post => post.status === 'in-progress')).toBeTrue();
+    for (const post of first) {
+      await expectAsync(new Block(post).validate()).toBeResolved();
+    }
+  });
+
+  it('summarizes pressure timings and selects bounded spatial neighborhoods', () => {
+    expect(summarizeForestPressureTimings([9.126, 1, 5, 3, 7])).toEqual({
+      samples: 5,
+      totalMs: 25.13,
+      minimumMs: 1,
+      medianMs: 5,
+      p95Ms: 9.13,
+      maximumMs: 9.13
+    });
+    const cells = summarizeForestPressureCells([
+      { placementIndex: { cellX: 0, cellY: 0 } },
+      { placementIndex: { cellX: 0, cellY: 0 } },
+      { placementIndex: { cellX: 3, cellY: -2 } },
+      { placementIndex: { cellX: -1, cellY: 1 } }
+    ]);
+    expect(cells).toEqual(jasmine.objectContaining({
+      treeCount: 4,
+      occupiedCellCount: 3,
+      cellSpanX: 5,
+      cellSpanY: 4,
+      occupancy: { minimum: 1, median: 1, p95: 2, maximum: 2 }
+    }));
+    const neighborhoods = forestPressureNeighborhoods(cells);
+    expect(neighborhoods.map(item => item.label)).toEqual(['center', 'outer']);
+    expect(neighborhoods.every(item => item.cells.length === 9)).toBeTrue();
+    expect(new Set(neighborhoods.flatMap(item => (
+      item.cells.map(cell => `${item.label}:${cell.cellX}:${cell.cellY}`)
+    ))).size).toBe(18);
   });
 
   it('rejects production and unknown CLI options', () => {


### PR DESCRIPTION
## Summary

- add a deterministic 600-post Activity Forest pressure profile
- create trees through the production owner-group reconciliation service
- verify bounded private-writing pagination without duplicates or omissions
- measure center, dense, and outer regional neighborhood delivery
- exercise authorized raster asset delivery with local cold and warm samples
- report privacy-safe aggregate placement, payload, and timing evidence
- prevent accidental mixing of the 55-tree and 600-tree fixture profiles
- document running the pressure profile with background jobs disabled

## Verification

- `npm test -- spec/accountDeletionFixtureSpec.js`
- `npx eslint scripts/dev/accountDeletionFixture.js scripts/lib/accountDeletionFixture.js scripts/lib/forestOwnerPressureFixture.js spec/accountDeletionFixtureSpec.js`
- `git diff --check`
- complete repository suite: 991 specs, 0 failures
- manually seeded and explored the 600-tree anonymous-owner forest

## Limitations

The reported timings are synthetic development-environment evidence rather than production latency budgets. They do not establish mobile-device rendering, real network performance, or final forest capacity.