### PR TITLE
Add restrained geographic variety to owner forests

### DIFF
--- a/docs/forest/owner-production-scene-contract.md
+++ b/docs/forest/owner-production-scene-contract.md
@@ -83,11 +83,18 @@ server placement and browser presentation. It preserves the version-1 coarse/fin
 noise field, calm-grove/rocky-rise identity, intergrade, ground-surface selection, and suitability
 calculation.
 
-The production view samples that field into restrained 64-unit flat ground tiles. Calm and rocky
-areas receive related colors and sparse detail without importing the development stream, bridges,
-boulders, or finite terrain manifest. Ground presentation version 1 is compatible with a later
-height field and movable 3D camera: durable `(worldX, worldY)` remain horizontal ground anchors,
-while this flat view is only the current camera/terrain presentation.
+Ground presentation version 2 samples that field into restrained 48-unit flat tiles. Closely
+related colors follow the continuous rockiness field, while deterministic grass, moss, pebble, and
+small-stone marks give calm cores, intergrades, and rocky rises quiet local recognition. A soft
+presentation-only influence makes the signed origin somewhat calmer and more open without changing
+tree habitat, placement eligibility, collision, or durable world identity.
+
+Ground details are derived only from the private world seed and signed tile coordinates. They are
+painted below the player and writing trees, confer no interaction or resource identity, and require
+no database record. The production scene still does not import the development stream, bridges,
+interactive boulders, or finite terrain manifest. This flat presentation remains compatible with a
+later height field and movable 3D camera: durable `(worldX, worldY)` remain horizontal ground
+anchors, while the current terrain and camera are replaceable presentation.
 
 ## Regional browser pipeline
 
@@ -116,8 +123,10 @@ the writing-grove link available without Canvas interaction.
 honest states, session-derived ownership, generic route failure, and localized routing.
 `spec/ownerForestSceneSpec.js` verifies signed 3×3 cell selection, asset batching, signed camera and
 movement, touch dead-zone and joystick policy, maximum-displacement gesture intent, collision
-behavior, and exact server/browser environment parity. Existing manifest and asset suites remain
-authority for regional privacy and generation.
+behavior, exact server/browser environment parity, deterministic origin treatment, and bounded
+ground-detail distribution. `npm run forest:environment-preview` renders the fixed-seed version-2
+overview in `tmp/` for visual review. Existing manifest and asset suites remain authority for
+regional privacy and generation.
 
 The next production boundary is end-to-end lifecycle, privacy, distribution, and performance
 evidence, including canonical writing return continuity. Later scene iteration should measure and

--- a/public/js/owner-forest-environment.js
+++ b/public/js/owner-forest-environment.js
@@ -2,7 +2,7 @@ export const FOREST_OWNER_ENVIRONMENT_POLICY_VERSION = 1;
 export const FOREST_OWNER_ENVIRONMENT_SCHEMA_VERSION = 1;
 export const FOREST_OWNER_WORLD_GENERATION_VERSION = 1;
 export const FOREST_OWNER_ENVIRONMENT_GRAMMAR_ID = 'owner-grove-patchwork-v1';
-export const FOREST_OWNER_GROUND_PRESENTATION_VERSION = 1;
+export const FOREST_OWNER_GROUND_PRESENTATION_VERSION = 2;
 
 export const FOREST_OWNER_ENVIRONMENT_CONFIG = Object.freeze({
   coarseCellSize: 1_920,
@@ -15,6 +15,17 @@ export const FOREST_OWNER_ENVIRONMENT_CONFIG = Object.freeze({
   groveTreeDensityPermille: 940,
   rockyTreeDensityPermille: 680
 });
+
+export const FOREST_OWNER_GROUND_PRESENTATION_CONFIG = Object.freeze({
+  tileSize: 48,
+  originClearingInnerRadius: 240,
+  originClearingOuterRadius: 760,
+  detailDensityPermille: 300
+});
+
+const GROUND_GROVE_COLOR = Object.freeze([82, 119, 72]);
+const GROUND_ROCKY_COLOR = Object.freeze([112, 108, 84]);
+const GROUND_ORIGIN_COLOR = Object.freeze([96, 130, 80]);
 
 const MAX_SEED_LENGTH = 80;
 const MAX_COORDINATE_MAGNITUDE = 1_000_000_000;
@@ -38,6 +49,10 @@ function smoothstep(value) {
 
 function interpolate(left, right, amount) {
   return left + ((right - left) * amount);
+}
+
+function clamp(value, minimum, maximum) {
+  return Math.max(minimum, Math.min(maximum, value));
 }
 
 function latticeUnit(worldSeed, scale, cellX, cellY) {
@@ -101,5 +116,80 @@ export function sampleOwnerForestEnvironment({ worldSeed, worldX, worldY }) {
     rockinessPermille: rockiness,
     treeDensityPermille: density,
     treeAllowed: suitabilityRoll < density
+  });
+}
+
+function originClearingPermille(worldX, worldY) {
+  const config = FOREST_OWNER_GROUND_PRESENTATION_CONFIG;
+  const distance = Math.hypot(worldX, worldY);
+  const progress = clamp(
+    (distance - config.originClearingInnerRadius)
+      / (config.originClearingOuterRadius - config.originClearingInnerRadius),
+    0,
+    1
+  );
+  return Math.round((1 - smoothstep(progress)) * 1_000);
+}
+
+function groundDetail({ worldSeed, worldX, worldY, rockinessPermille, clearingPermille }) {
+  const detailRoll = Math.floor(unit([
+    FOREST_OWNER_ENVIRONMENT_GRAMMAR_ID, worldSeed, 'ground-detail', worldX, worldY
+  ].join(':')) * 1_000);
+  const clearingReduction = Math.round(clearingPermille * 0.12);
+  if (detailRoll >= FOREST_OWNER_GROUND_PRESENTATION_CONFIG.detailDensityPermille
+    - clearingReduction) return null;
+
+  const variantRoll = Math.floor(unit([
+    FOREST_OWNER_ENVIRONMENT_GRAMMAR_ID, worldSeed, 'ground-detail-kind', worldX, worldY
+  ].join(':')) * 1_000);
+  let kind;
+  if (rockinessPermille >= 560) kind = variantRoll < 380 ? 'stone' : 'pebbles';
+  else if (rockinessPermille >= 420) kind = variantRoll < 460 ? 'pebbles' : 'grass';
+  else kind = variantRoll < 320 ? 'moss' : 'grass';
+
+  const offset = axis => Math.round((unit([
+    FOREST_OWNER_ENVIRONMENT_GRAMMAR_ID, worldSeed, `ground-detail-${axis}`, worldX, worldY
+  ].join(':')) - 0.5) * 560);
+  const scalePermille = 720 + Math.floor(unit([
+    FOREST_OWNER_ENVIRONMENT_GRAMMAR_ID, worldSeed, 'ground-detail-scale', worldX, worldY
+  ].join(':')) * 520);
+  return Object.freeze({
+    kind,
+    offsetXPermille: offset('x'),
+    offsetYPermille: offset('y'),
+    scalePermille
+  });
+}
+
+export function sampleOwnerForestGroundPresentation({ worldSeed, worldX, worldY }) {
+  const environment = sampleOwnerForestEnvironment({ worldSeed, worldX, worldY });
+  const clearingPermille = originClearingPermille(worldX, worldY);
+  const clearing = clearingPermille / 1_000;
+  const softenedRockiness = Math.min(environment.rockinessPermille, 320);
+  const presentedRockiness = Math.round(interpolate(
+    environment.rockinessPermille,
+    softenedRockiness,
+    clearing * 0.72
+  ));
+  const rocky = presentedRockiness / 1_000;
+  const clearingColorAmount = clearing * 0.34;
+  const color = GROUND_GROVE_COLOR.map((channel, index) => Math.round(interpolate(
+    interpolate(channel, GROUND_ROCKY_COLOR[index], rocky),
+    GROUND_ORIGIN_COLOR[index],
+    clearingColorAmount
+  )));
+  const detail = groundDetail({
+    worldSeed,
+    worldX,
+    worldY,
+    rockinessPermille: presentedRockiness,
+    clearingPermille
+  });
+  return Object.freeze({
+    presentationVersion: FOREST_OWNER_GROUND_PRESENTATION_VERSION,
+    color: Object.freeze({ red: color[0], green: color[1], blue: color[2] }),
+    rockinessPermille: presentedRockiness,
+    originClearingPermille: clearingPermille,
+    detail
   });
 }

--- a/public/js/owner-forest.js
+++ b/public/js/owner-forest.js
@@ -13,7 +13,10 @@ import {
   FOREST_HUMANOID_PROFILES,
   paintForestHumanoid
 } from './forest-humanoid.js';
-import { sampleOwnerForestEnvironment } from './owner-forest-environment.js';
+import {
+  FOREST_OWNER_GROUND_PRESENTATION_CONFIG,
+  sampleOwnerForestGroundPresentation
+} from './owner-forest-environment.js';
 import {
   decodeOwnerForestRaster,
   moveOwnerForestPlayer,
@@ -360,21 +363,65 @@ if (payload && copyPayload && viewport && canvas) {
   function groundSample(column, row) {
     const id = `${column}:${row}`;
     if (!groundSamples.has(id)) {
-      groundSamples.set(id, sampleOwnerForestEnvironment({
+      const cell = FOREST_OWNER_GROUND_PRESENTATION_CONFIG.tileSize;
+      groundSamples.set(id, sampleOwnerForestGroundPresentation({
         worldSeed: bootstrap.environment.seed,
         worldX: Math.max(-OWNER_FOREST_COORDINATE_LIMIT, Math.min(
-          OWNER_FOREST_COORDINATE_LIMIT, column * 64
+          OWNER_FOREST_COORDINATE_LIMIT, (column * cell) + (cell / 2)
         )),
         worldY: Math.max(-OWNER_FOREST_COORDINATE_LIMIT, Math.min(
-          OWNER_FOREST_COORDINATE_LIMIT, row * 64
+          OWNER_FOREST_COORDINATE_LIMIT, (row * cell) + (cell / 2)
         ))
       }));
     }
     return groundSamples.get(id);
   }
 
+  function paintGroundDetail(detail, x, y, cell) {
+    if (!detail) return;
+    const scale = detail.scalePermille / 1_000;
+    const centerX = x + (cell / 2) + ((detail.offsetXPermille / 1_000) * cell);
+    const centerY = y + (cell / 2) + ((detail.offsetYPermille / 1_000) * cell);
+    if (detail.kind === 'grass') {
+      context.strokeStyle = 'rgba(40, 78, 45, 0.42)';
+      context.lineWidth = 1;
+      context.beginPath();
+      context.moveTo(centerX, centerY + (3 * scale));
+      context.lineTo(centerX - (2 * scale), centerY - (3 * scale));
+      context.moveTo(centerX, centerY + (3 * scale));
+      context.lineTo(centerX + (1.5 * scale), centerY - (4 * scale));
+      context.moveTo(centerX + (1.5 * scale), centerY + (3 * scale));
+      context.lineTo(centerX + (4 * scale), centerY - (2 * scale));
+      context.stroke();
+      return;
+    }
+    if (detail.kind === 'moss') {
+      context.fillStyle = 'rgba(151, 151, 75, 0.3)';
+      context.fillRect(centerX - (3 * scale), centerY, 3 * scale, 1.5 * scale);
+      context.fillRect(centerX + scale, centerY - (2 * scale), 2 * scale, 1.5 * scale);
+      return;
+    }
+    if (detail.kind === 'pebbles') {
+      context.fillStyle = 'rgba(102, 102, 83, 0.42)';
+      context.beginPath();
+      context.ellipse(centerX - (2 * scale), centerY, 2.5 * scale, 1.4 * scale,
+        -0.15, 0, Math.PI * 2);
+      context.ellipse(centerX + (2.5 * scale), centerY + scale, 1.8 * scale,
+        1.1 * scale, 0.2, 0, Math.PI * 2);
+      context.fill();
+      return;
+    }
+    context.fillStyle = 'rgba(91, 92, 79, 0.5)';
+    context.strokeStyle = 'rgba(59, 69, 58, 0.36)';
+    context.lineWidth = 1;
+    context.beginPath();
+    context.ellipse(centerX, centerY, 5 * scale, 2.8 * scale, -0.12, 0, Math.PI * 2);
+    context.fill();
+    context.stroke();
+  }
+
   function paintGround() {
-    const cell = 64;
+    const cell = FOREST_OWNER_GROUND_PRESENTATION_CONFIG.tileSize;
     const firstX = Math.floor(camera.x / cell);
     const lastX = Math.ceil((camera.x + camera.width) / cell);
     const firstY = Math.floor(camera.y / cell);
@@ -382,18 +429,12 @@ if (payload && copyPayload && viewport && canvas) {
     for (let row = firstY; row <= lastY; row += 1) {
       for (let column = firstX; column <= lastX; column += 1) {
         const sample = groundSample(column, row);
-        const rocky = sample.rockinessPermille / 1000;
-        const red = Math.round(91 + (rocky * 22));
-        const green = Math.round(126 - (rocky * 16));
-        const blue = Math.round(76 + (rocky * 2));
+        const x = (column * cell) - camera.x;
+        const y = (row * cell) - camera.y;
+        const { red, green, blue } = sample.color;
         context.fillStyle = `rgb(${red}, ${green}, ${blue})`;
-        context.fillRect((column * cell) - camera.x, (row * cell) - camera.y, cell + 1, cell + 1);
-        if ((column + row) % 3 === 0) {
-          context.fillStyle = rocky > 0.56 ? 'rgba(112, 111, 94, 0.34)'
-            : 'rgba(180, 171, 102, 0.18)';
-          context.fillRect((column * cell) - camera.x + 18,
-            (row * cell) - camera.y + 24, rocky > 0.56 ? 9 : 5, 2);
-        }
+        context.fillRect(x, y, cell + 1, cell + 1);
+        paintGroundDetail(sample.detail, x, y, cell);
       }
     }
   }

--- a/scripts/dev/renderForestOwnerEnvironmentPreview.js
+++ b/scripts/dev/renderForestOwnerEnvironmentPreview.js
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'url';
 import sharp from 'sharp';
 
 import {
+  sampleOwnerForestGroundPresentation,
+} from '../../public/js/owner-forest-environment.js';
+import {
   buildForestOwnerEnvironmentPlacementExclusion,
   resolveForestOwnerEnvironment,
 } from '../../server/services/forestOwnerEnvironmentResolver.js';
@@ -32,17 +35,37 @@ function xml(value) {
     .replaceAll("'", '&apos;');
 }
 
-function mix(left, right, amount) {
-  return Math.round(left + ((right - left) * amount));
+function environmentColor(presentation) {
+  const { red, green, blue } = presentation.color;
+  return `rgb(${red},${green},${blue})`;
 }
 
-function environmentColor(rockinessPermille) {
-  const amount = rockinessPermille / 1_000;
-  const grove = [170, 188, 126];
-  const rocky = [137, 132, 106];
-  return `rgb(${grove.map((value, index) => (
-    mix(value, rocky[index], amount)
-  )).join(',')})`;
+function detailSvg(presentation, x, y, size) {
+  const detail = presentation.detail;
+  if (!detail) return '';
+  const centerX = x + (size / 2) + ((detail.offsetXPermille / 1_000) * size);
+  const centerY = y + (size / 2) + ((detail.offsetYPermille / 1_000) * size);
+  const scale = Math.max(0.65, detail.scalePermille / 1_000) * (size / 13);
+  if (detail.kind === 'grass') {
+    return `<path d="M ${centerX.toFixed(2)} ${(centerY + scale).toFixed(2)}`
+      + ` l ${(-0.8 * scale).toFixed(2)} ${(-2.1 * scale).toFixed(2)}`
+      + ` M ${centerX.toFixed(2)} ${(centerY + scale).toFixed(2)}`
+      + ` l ${(0.7 * scale).toFixed(2)} ${(-2.4 * scale).toFixed(2)}"`
+      + ' fill="none" stroke="#315637" stroke-width="0.7" opacity="0.62" />';
+  }
+  if (detail.kind === 'moss') {
+    return `<circle cx="${centerX.toFixed(2)}" cy="${centerY.toFixed(2)}"`
+      + ` r="${(1.25 * scale).toFixed(2)}" fill="#98974d" opacity="0.48" />`;
+  }
+  if (detail.kind === 'pebbles') {
+    return `<circle cx="${(centerX - scale).toFixed(2)}" cy="${centerY.toFixed(2)}"`
+      + ` r="${(0.85 * scale).toFixed(2)}" fill="#686956" opacity="0.62" />`
+      + `<circle cx="${(centerX + scale).toFixed(2)}" cy="${(centerY + (0.4 * scale)).toFixed(2)}"`
+      + ` r="${(0.6 * scale).toFixed(2)}" fill="#777560" opacity="0.58" />`;
+  }
+  return `<ellipse cx="${centerX.toFixed(2)}" cy="${centerY.toFixed(2)}"`
+    + ` rx="${(1.8 * scale).toFixed(2)}" ry="${scale.toFixed(2)}"`
+    + ' fill="#5d5e50" stroke="#40483e" stroke-width="0.45" opacity="0.68" />';
 }
 
 function previewFixture(worldSeed) {
@@ -85,11 +108,12 @@ function panelSvg(fixture, panelX, panelY) {
   const cellPixels = PLOT_SIZE / GRID_SIZE;
   const worldCell = (fixture.extent * 2) / GRID_SIZE;
   const cells = [];
+  const details = [];
   for (let row = 0; row < GRID_SIZE; row += 1) {
     for (let column = 0; column < GRID_SIZE; column += 1) {
       const worldX = Math.round(-fixture.extent + ((column + 0.5) * worldCell));
       const worldY = Math.round(-fixture.extent + ((row + 0.5) * worldCell));
-      const environment = resolveForestOwnerEnvironment({
+      const presentation = sampleOwnerForestGroundPresentation({
         worldSeed: fixture.worldSeed,
         worldX,
         worldY,
@@ -99,8 +123,14 @@ function panelSvg(fixture, panelX, panelY) {
         + ` y="${(plotY + (row * cellPixels)).toFixed(2)}"`
         + ` width="${(cellPixels + 0.2).toFixed(2)}"`
         + ` height="${(cellPixels + 0.2).toFixed(2)}"`
-        + ` fill="${environmentColor(environment.ecology.rockinessPermille)}" />`,
+        + ` fill="${environmentColor(presentation)}" />`,
       );
+      details.push(detailSvg(
+        presentation,
+        plotX + (column * cellPixels),
+        plotY + (row * cellPixels),
+        cellPixels,
+      ));
     }
   }
   const scale = PLOT_SIZE / (fixture.extent * 2);
@@ -127,6 +157,7 @@ function panelSvg(fixture, panelX, panelY) {
         · habitat exclusions ${fixture.exclusionRejectionCount}
       </text>
       ${cells.join('\n')}
+      ${details.join('\n')}
       <rect x="${plotX}" y="${plotY}" width="${PLOT_SIZE}" height="${PLOT_SIZE}"
         fill="none" stroke="#777365" stroke-width="1" />
       <line x1="${plotX}" y1="${plotY + (PLOT_SIZE / 2)}"
@@ -156,9 +187,10 @@ export function buildForestOwnerEnvironmentPreviewSvg({
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"
   viewBox="0 0 ${width} ${height}" role="img"
   aria-labelledby="preview-title preview-description">
-  <title id="preview-title">Activity Forest owner environment version 1</title>
+  <title id="preview-title">Activity Forest owner ground presentation version 2</title>
   <desc id="preview-description">
-    Signed-coordinate habitat patches and 600 environment-filtered trees for two owner-world seeds.
+    Signed-coordinate habitat patches, quiet ground landmarks, origin clearing, and 600
+    environment-filtered trees for two owner-world seeds.
   </desc>
   <style>
     text { font-family: "Be Vietnam Pro", Inter, system-ui, sans-serif; fill: #24372d; }
@@ -171,10 +203,10 @@ export function buildForestOwnerEnvironmentPreviewSvg({
   </style>
   <rect width="100%" height="100%" fill="#f1eee2" />
   <text x="${PAGE_PADDING}" y="48" class="page-title">
-    Owner environment v1 · signed-coordinate validation
+    Owner ground presentation v2 · signed-coordinate validation
   </text>
   <text x="${PAGE_PADDING}" y="77" class="page-subtitle">
-    Smooth seeded habitat patches; tree points include deterministic suitability filtering
+    Blended habitat patches, quiet landmarks, and a calmer origin; tree points retain v1 ecology
   </text>
   <g transform="translate(${PAGE_PADDING}, 105)">
     <rect x="0" y="-12" width="22" height="14" fill="rgb(170,188,126)" />

--- a/spec/forestOwnerEnvironmentPreviewSpec.js
+++ b/spec/forestOwnerEnvironmentPreviewSpec.js
@@ -9,7 +9,7 @@ describe('forest owner environment preview', () => {
     const second = buildForestOwnerEnvironmentPreviewSvg(options);
 
     expect(second).toBe(first);
-    expect(first).toContain('Owner environment v1');
+    expect(first).toContain('Owner ground presentation v2');
     expect(first).toContain('environment-preview-spec');
     expect(first).toContain('600 trees');
     expect(first).toContain('habitat exclusions');

--- a/spec/forestOwnerSceneBootstrapSpec.js
+++ b/spec/forestOwnerSceneBootstrapSpec.js
@@ -87,7 +87,7 @@ describe('forest owner scene bootstrap', () => {
       policyVersion: 1,
       schemaVersion: 1,
       worldGenerationVersion: 1,
-      groundPresentationVersion: 1,
+      groundPresentationVersion: 2,
       grammarId: 'owner-grove-patchwork-v1',
       seed: WORLD_SEED
     });

--- a/spec/ownerForestSceneSpec.js
+++ b/spec/ownerForestSceneSpec.js
@@ -1,4 +1,8 @@
-import { sampleOwnerForestEnvironment } from '../public/js/owner-forest-environment.js';
+import {
+  FOREST_OWNER_GROUND_PRESENTATION_CONFIG,
+  sampleOwnerForestEnvironment,
+  sampleOwnerForestGroundPresentation
+} from '../public/js/owner-forest-environment.js';
 import {
   decodeOwnerForestRaster,
   moveOwnerForestPlayer,
@@ -154,5 +158,50 @@ describe('owner forest browser scene policy', () => {
         treeAllowed: server.suitability.treeAllowed
       });
     }
+  });
+
+  it('derives stable quiet ground detail without changing environment identity', () => {
+    const worldSeed = 'owner-ground-presentation-spec';
+    const first = sampleOwnerForestGroundPresentation({
+      worldSeed, worldX: 24, worldY: 24
+    });
+    const second = sampleOwnerForestGroundPresentation({
+      worldSeed, worldX: 24, worldY: 24
+    });
+    const environment = sampleOwnerForestEnvironment({
+      worldSeed, worldX: 24, worldY: 24
+    });
+
+    expect(second).toEqual(first);
+    expect(first.presentationVersion).toBe(2);
+    expect(first.originClearingPermille).toBe(1000);
+    expect(first.rockinessPermille).toBeLessThanOrEqual(environment.rockinessPermille);
+    expect(Object.values(first.color).every(channel => (
+      Number.isSafeInteger(channel) && channel >= 0 && channel <= 255
+    ))).toBeTrue();
+    expect(FOREST_OWNER_GROUND_PRESENTATION_CONFIG.tileSize).toBe(48);
+  });
+
+  it('distributes bounded ground motifs across calm, transition, and rocky areas', () => {
+    const details = [];
+    for (let worldY = -2400; worldY <= 2400; worldY += 96) {
+      for (let worldX = -2400; worldX <= 2400; worldX += 96) {
+        const presentation = sampleOwnerForestGroundPresentation({
+          worldSeed: 'owner-ground-detail-distribution', worldX, worldY
+        });
+        if (presentation.detail) details.push(presentation.detail);
+      }
+    }
+
+    expect(details.length).toBeGreaterThan(300);
+    expect(new Set(details.map(detail => detail.kind))).toEqual(
+      new Set(['grass', 'moss', 'pebbles', 'stone'])
+    );
+    expect(details.every(detail => (
+      Math.abs(detail.offsetXPermille) <= 280
+      && Math.abs(detail.offsetYPermille) <= 280
+      && detail.scalePermille >= 720
+      && detail.scalePermille <= 1239
+    ))).toBeTrue();
   });
 });


### PR DESCRIPTION
## Summary

- advance the owner-forest ground presentation to version 2
- render finer deterministic terrain variation from the existing environment grammar
- add sparse grass, moss, pebble, and small-stone ground details
- give the signed origin a subtly calmer and more open appearance
- preserve the existing durable ecology, tree habitat, placement, and collision behavior
- update the fixed-seed environment preview for visual validation
- document the presentation boundary and intentionally deferred geography

## Scope

This is a presentation-only geography-legibility pass. Ground details are derived from the private world seed and signed coordinates, rendered beneath trees and the player, and have no persistent or interactive identity.

The change does not introduce rivers, bridges, collectible resources, interactive boulders, construction, inventory, durable player geography, or final biome simulation. Those remain later-milestone work.

## Verification

- complete test suite: 995 specs, 0 failures
- focused owner-scene and environment-preview tests: 19 specs, 0 failures
- changed-file ESLint: passed
- `git diff --check`: passed
- generated and reviewed the fixed-seed environment preview
- manually explored the production forest with the 600-tree pressure fixture
- confirmed terrain variation remains legible without competing with writing trees

## Visual review

The updated diagnostic can be generated with:

```bash
npm run forest:environment-preview
```

It writes SVG and PNG previews under `tmp/`.